### PR TITLE
fix(product-builds): handle rubin accelerator and fondue repo move

### DIFF
--- a/modules/product-builds/client/views/PreBuiltPackagesView.vue
+++ b/modules/product-builds/client/views/PreBuiltPackagesView.vue
@@ -4,8 +4,8 @@ import { useWheelOverrides } from '../composables/useWheelCollections'
 
 const wheelOverrides = useWheelOverrides()
 
-const BUILDER_REPO_URL = 'https://gitlab.com/redhat/rhel-ai/wheels/builder'
-const OVERRIDE_VARIANTS = ['cpu-ubi9', 'cuda-ubi9', 'gaudi-ubi9', 'neuron-ubi9', 'rocm-ubi9', 'spyre-ubi9', 'tpu-ubi9']
+const BUILDER_REPO_URL = 'https://gitlab.com/redhat/rhel-ai/wheels/fondue'
+const OVERRIDE_VARIANTS = ['cpu-ubi9', 'cuda-ubi9', 'gaudi-ubi9', 'neuron-ubi9', 'rocm-ubi9', 'rubin-ubi9', 'spyre-ubi9', 'tpu-ubi9']
 
 function getOverrideFileUrl(override) {
   if (!override.source_file) return null

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -162,7 +162,7 @@ watch(activeTab, (tab) => {
 // --- Artifacts tab ---
 const ITEMS_PER_PAGE = 10
 const AVAILABLE_ARCHS = ['aarch64', 'ppc64le', 's390x', 'x86_64']
-const AVAILABLE_ACCELS = ['cpu', 'cuda', 'gaudi', 'neuron', 'rocm', 'spyre', 'tpu']
+const AVAILABLE_ACCELS = ['cpu', 'cuda', 'gaudi', 'neuron', 'rocm', 'rubin', 'spyre', 'tpu']
 const DATE_RANGE_OPTIONS = [
   { value: '7d', label: 'Last 7 days' },
   { value: '30d', label: 'Last 30 days' },


### PR DESCRIPTION
Companion changes for two AIPCC Dashboard MRs.

**Rubin (dashboard MR #386):** the artifacts tab (`AVAILABLE_ACCELS`) and Pre-Built Packages (`OVERRIDE_VARIANTS`) hardcode accelerator filter lists that were missing `rubin`. The dashboard now returns Rubin artifacts, so the filter dropdowns had no way to reach them. Package rows and the search/wheel filters already read accelerators dynamically, so only these two dropdowns needed touching.

**Fondue (dashboard MR #385):** the builder repo moved into the `wheels/fondue` monorepo, and the collector now reports wheel-override `source_file` paths (under `builder/overrides/settings`) with fondue commit SHAs. Repointed `BUILDER_REPO_URL` to `wheels/fondue` so the source-file links resolve instead of 404ing against the old repo. Should land with #385.

Lint clean, product-builds unit tests pass (178/178).

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>