### PR TITLE
feat(product-builds): add Tests summary column to Artifacts tab

### DIFF
--- a/modules/product-builds/client/components/TestsSummary.vue
+++ b/modules/product-builds/client/components/TestsSummary.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { computed } from 'vue'
+import { CircleCheckIcon, CircleXIcon, Loader2Icon, ClockIcon, CircleHelpIcon } from 'lucide-vue-next'
+
+const props = defineProps({
+  tests: { type: Array, default: () => [] }
+})
+
+const counts = computed(() => {
+  let passed = 0, failed = 0, running = 0, pending = 0, unknown = 0
+  for (const t of props.tests) {
+    const s = t.status?.toLowerCase()
+    if (s === 'testpassed') passed++
+    else if (s === 'testfail') failed++
+    else if (s === 'pending') pending++
+    else if (s === 'inprogress') running++
+    else unknown++
+  }
+  return { passed, failed, running, pending, unknown }
+})
+</script>
+
+<template>
+  <span v-if="tests.length > 0" class="inline-flex items-center gap-2">
+    <span v-if="counts.passed > 0" class="inline-flex items-center gap-0.5 text-green-600 dark:text-green-400">
+      <CircleCheckIcon class="w-3.5 h-3.5" />
+      {{ counts.passed }}
+    </span>
+    <span v-if="counts.failed > 0" class="inline-flex items-center gap-0.5 text-red-600 dark:text-red-400">
+      <CircleXIcon class="w-3.5 h-3.5" />
+      {{ counts.failed }}
+    </span>
+    <span v-if="counts.running > 0" class="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400">
+      <Loader2Icon class="w-3.5 h-3.5 animate-spin" />
+      {{ counts.running }}
+    </span>
+    <span v-if="counts.pending > 0" class="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400">
+      <ClockIcon class="w-3.5 h-3.5" />
+      {{ counts.pending }}
+    </span>
+    <span v-if="counts.unknown > 0" class="inline-flex items-center gap-0.5 text-gray-500 dark:text-gray-400" title="Unrecognized test status">
+      <CircleHelpIcon class="w-3.5 h-3.5" />
+      {{ counts.unknown }}
+    </span>
+  </span>
+  <span v-else class="text-sm text-gray-400 dark:text-gray-500">—</span>
+</template>

--- a/modules/product-builds/client/views/ProductView.vue
+++ b/modules/product-builds/client/views/ProductView.vue
@@ -5,6 +5,7 @@ import { useProduct, useDrops, useSeries } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
+import TestsSummary from '../components/TestsSummary.vue'
 import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const PRODUCT_CONFIGS = {
@@ -294,6 +295,7 @@ const groupedDrops = computed(() => {
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Variant</th>
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Architectures</th>
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environments</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tests</th>
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">CHI</th>
                 </tr>
               </thead>
@@ -318,6 +320,9 @@ const groupedDrops = computed(() => {
                     </div>
                   </td>
                   <td class="px-4 py-3">
+                    <TestsSummary :tests="art.konflux_data?.tests || []" />
+                  </td>
+                  <td class="px-4 py-3">
                     <ChiBadge v-if="art.health_index" :health-index="art.health_index" />
                     <span v-else class="text-sm text-gray-400 dark:text-gray-500">—</span>
                   </td>
@@ -325,7 +330,7 @@ const groupedDrops = computed(() => {
               </tbody>
               <tfoot v-if="artifactsLoading">
                 <tr>
-                  <td colspan="5" class="px-4 py-3 text-center text-sm text-gray-500 dark:text-gray-400">
+                  <td colspan="6" class="px-4 py-3 text-center text-sm text-gray-500 dark:text-gray-400">
                     <span class="inline-flex items-center gap-2">
                       <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -10,6 +10,7 @@ const { setupErrorTracking, logCapturedErrors, mainContentIsVisible } = require(
  * - CHI column appears in artifacts table
  * - CHI badge renders in artifact detail view
  * - Artifacts without health_index don't show CHI
+ * - Tests column appears in artifacts table
  *
  * Tag: @product-builds
  * Usage: npx playwright test --grep @product-builds
@@ -63,6 +64,9 @@ test.describe('Product Builds Module @product-builds', () => {
 
       const chiHeader = page.locator('th').filter({ hasText: 'CHI' });
       await expect(chiHeader).toBeVisible();
+
+      const testsHeader = page.locator('th').filter({ hasText: 'Tests' });
+      await expect(testsHeader).toBeVisible();
     }
 
     const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));


### PR DESCRIPTION
Adding Konflux test summary column to Artifacts tab, similarly how it was implemented in AIPCC Dashboard

<img width="904" height="657" alt="org_pulse_test_results" src="https://github.com/user-attachments/assets/96d306bf-a2a0-417d-b353-109eb814bcdd" />
