### PR TITLE
feat(releases): add fix availability and summary metrics to CVE report

### DIFF
--- a/fixtures/releases/cve-sustaining/fix-availability.json
+++ b/fixtures/releases/cve-sustaining/fix-availability.json
@@ -1,0 +1,51 @@
+{
+  "releases": ["2.13.0", "2.16.0", "2.19.0", "2.22.0", "2.25.0", "3.0.0", "3.2.0", "3.3.0", "3.4.0"],
+  "selected": "3.4.0",
+  "perRelease": {
+    "2.13.0": {
+      "totalCves": 5934, "noFixCount": 1740, "pctNoFix": 29.3, "pctWithFix": 70.7,
+      "cvesWithFixAtRelease": 4194, "cvesWithFixVersion": 3797, "pctFixVersion": 90.5,
+      "uniqueCves": 256, "containersWithCves": 91, "avgCvesPerContainer": 65.2, "freshnessScore": 39.6
+    },
+    "2.16.0": {
+      "totalCves": 6241, "noFixCount": 1773, "pctNoFix": 28.4, "pctWithFix": 71.6,
+      "cvesWithFixAtRelease": 4468, "cvesWithFixVersion": 4093, "pctFixVersion": 91.6,
+      "uniqueCves": 295, "containersWithCves": 113, "avgCvesPerContainer": 55.2, "freshnessScore": 31
+    },
+    "2.19.0": {
+      "totalCves": 7119, "noFixCount": 2503, "pctNoFix": 35.2, "pctWithFix": 64.8,
+      "cvesWithFixAtRelease": 4616, "cvesWithFixVersion": 4247, "pctFixVersion": 92,
+      "uniqueCves": 311, "containersWithCves": 119, "avgCvesPerContainer": 59.8, "freshnessScore": 47.1
+    },
+    "2.22.0": {
+      "totalCves": 9827, "noFixCount": 3561, "pctNoFix": 36.2, "pctWithFix": 63.8,
+      "cvesWithFixAtRelease": 6266, "cvesWithFixVersion": 5958, "pctFixVersion": 95.1,
+      "uniqueCves": 342, "containersWithCves": 132, "avgCvesPerContainer": 74.4, "freshnessScore": 42.4
+    },
+    "2.25.0": {
+      "totalCves": 9159, "noFixCount": 1903, "pctNoFix": 20.8, "pctWithFix": 79.2,
+      "cvesWithFixAtRelease": 7256, "cvesWithFixVersion": 6954, "pctFixVersion": 95.8,
+      "uniqueCves": 371, "containersWithCves": 124, "avgCvesPerContainer": 73.9, "freshnessScore": 52.8
+    },
+    "3.0.0": {
+      "totalCves": 9178, "noFixCount": 1832, "pctNoFix": 20, "pctWithFix": 80,
+      "cvesWithFixAtRelease": 7346, "cvesWithFixVersion": 7047, "pctFixVersion": 95.9,
+      "uniqueCves": 372, "containersWithCves": 118, "avgCvesPerContainer": 77.8, "freshnessScore": 48.6
+    },
+    "3.2.0": {
+      "totalCves": 11418, "noFixCount": 4846, "pctNoFix": 42.4, "pctWithFix": 57.6,
+      "cvesWithFixAtRelease": 6572, "cvesWithFixVersion": 6354, "pctFixVersion": 96.7,
+      "uniqueCves": 331, "containersWithCves": 129, "avgCvesPerContainer": 88.5, "freshnessScore": 64.3
+    },
+    "3.3.0": {
+      "totalCves": 5920, "noFixCount": 3698, "pctNoFix": 62.5, "pctWithFix": 37.5,
+      "cvesWithFixAtRelease": 2222, "cvesWithFixVersion": 2061, "pctFixVersion": 92.8,
+      "uniqueCves": 198, "containersWithCves": 110, "avgCvesPerContainer": 53.8, "freshnessScore": 79.1
+    },
+    "3.4.0": {
+      "totalCves": 13111, "noFixCount": 6974, "pctNoFix": 53.2, "pctWithFix": 46.8,
+      "cvesWithFixAtRelease": 6137, "cvesWithFixVersion": 4265, "pctFixVersion": 69.5,
+      "uniqueCves": 308, "containersWithCves": 138, "avgCvesPerContainer": 95, "freshnessScore": 86.2
+    }
+  }
+}

--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const {
   normalizeIssue,
@@ -199,6 +199,10 @@ describe('jiraOffset', function () {
 })
 
 describe('lookbackCutoff', function () {
+  // Pin to noon UTC so offset shifts never cross a date boundary
+  beforeEach(function () { vi.useFakeTimers({ now: new Date('2026-08-13T12:00:00Z') }) })
+  afterEach(function () { vi.useRealTimers() })
+
   it('returns a YYYY-MM-DD dateStr and a numeric ms instant', function () {
     var c = lookbackCutoff(12, '+0000')
     expect(c.dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/)
@@ -261,6 +265,9 @@ describe('onOrAfter', function () {
 })
 
 describe('computeComponentPressure — timezone window boundary', function () {
+  beforeEach(function () { vi.useFakeTimers({ now: new Date('2026-08-13T12:00:00Z') }) })
+  afterEach(function () { vi.useRealTimers() })
+
   it('derives the account offset from data and counts by that offset boundary', function () {
     var offset = '-0400'
     var cutoff = lookbackCutoff(12, offset)

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -130,7 +130,7 @@
 
         <!--  Summary Metrics cards -->
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div v-for="card in summaryMetricCards" :key="card.label" class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div v-for="card in summaryMetricCards" :key="card.label" class="border-l-4 border-l-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <div class="flex items-center gap-1.5 mb-2">
               <span class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ card.label }}</span>
               <span class="relative group">
@@ -146,7 +146,7 @@
 
         <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mt-5 mb-3">Fix Availability at Release</h4>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="border-l-4 border-l-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <div class="flex items-center gap-1.5 mb-2">
               <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% CVEs with No Fix at Release</span>
               <span class="relative group">
@@ -162,7 +162,7 @@
               <div class="bg-red-400 flex-1"></div>
             </div>
           </div>
-          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="border-l-4 border-l-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <div class="flex items-center gap-1.5 mb-2">
               <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% CVEs with Fix at Release</span>
               <span class="relative group">
@@ -178,7 +178,7 @@
               <div class="bg-red-400 flex-1"></div>
             </div>
           </div>
-          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="border-l-4 border-l-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <div class="flex items-center gap-1.5 mb-2">
               <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% with RH Fix Version</span>
               <span class="relative group">

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -99,19 +99,106 @@
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
           <a v-for="(q, idx) in slaQuarters" :key="q.label"
             :href="q.total_jql" target="_blank" rel="noopener noreferrer"
-            class="rounded-lg border p-4 text-center hover:shadow-md transition-shadow cursor-pointer block"
+            class="rounded-lg border hover:shadow-md transition-shadow cursor-pointer flex overflow-hidden"
             :class="slaCardClasses(q.pct)"
             :title="`${q.label}: ${q.metSla} / ${q.total} CVEs met SLA — click to view in Jira`">
-            <p class="text-3xl font-extrabold">{{ q.pct }}%</p>
-            <div v-if="idx === slaQuarters.length - 1 && slaQuarters.length >= 2" class="mt-0.5">
-              <span class="text-[10px] font-semibold" :class="slaDeltaClass">
-                {{ slaDelta > 0 ? '+' : '' }}{{ slaDelta }}pp {{ slaDelta >= 0 ? '&#9650;' : '&#9660;' }}
-              </span>
+            <div class="flex items-center justify-center px-3 bg-black/5 dark:bg-white/5 border-r border-current/10 min-w-[60px]">
+              <p class="text-xs font-bold uppercase tracking-wide opacity-70 text-center leading-tight">{{ q.label }}</p>
             </div>
-            <p class="text-[10px] font-semibold uppercase tracking-wide mt-1 opacity-80">{{ q.label }}</p>
-            <p class="text-xs mt-1 opacity-60">{{ q.metSla }} / {{ q.total }} met SLA</p>
+            <div class="flex-1 p-4 text-center">
+              <p class="text-3xl font-extrabold">{{ q.pct }}%</p>
+              <div v-if="idx === slaQuarters.length - 1 && slaQuarters.length >= 2" class="mt-0.5">
+                <span class="text-[10px] font-semibold" :class="slaDeltaClass">
+                  {{ slaDelta > 0 ? '+' : '' }}{{ slaDelta }}pp {{ slaDelta >= 0 ? '&#9650;' : '&#9660;' }}
+                </span>
+              </div>
+              <p class="text-xs mt-1 opacity-60">{{ q.metSla }} / {{ q.total }} met SLA</p>
+            </div>
           </a>
         </div>
+      </section>
+
+      <!-- Fix Availability at Release -->
+      <section v-if="fixAvail.metrics" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Summary Metrics</h3>
+          <select v-if="fixAvail.releases?.length > 1" v-model="fixAvailRelease"
+            class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-primary-500">
+            <option v-for="r in fixAvail.releases" :key="r" :value="r">{{ r }}</option>
+          </select>
+        </div>
+
+        <!--  Summary Metrics cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div v-for="card in summaryMetricCards" :key="card.label" class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="flex items-center gap-1.5 mb-2">
+              <span class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ card.label }}</span>
+              <span class="relative group">
+                <HelpCircle :size="13" class="text-gray-400 dark:text-gray-500 cursor-help" />
+                <span class="absolute bottom-full left-0 mb-1.5 w-64 p-2 text-[10px] text-white bg-gray-900 dark:bg-gray-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20">
+                  {{ card.tooltip }}
+                </span>
+              </span>
+            </div>
+            <p class="text-3xl font-extrabold text-gray-900 dark:text-gray-100">{{ card.value }}</p>
+          </div>
+        </div>
+
+        <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mt-5 mb-3">Fix Availability at Release</h4>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="flex items-center gap-1.5 mb-2">
+              <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% CVEs with No Fix at Release</span>
+              <span class="relative group">
+                <HelpCircle :size="13" class="text-gray-400 dark:text-gray-500 cursor-help" />
+                <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-64 p-2 text-[10px] text-white bg-gray-900 dark:bg-gray-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20">
+                  Percentage of CVEs (discovered at or before release) where no fix existed at release date (FIX_DATE &gt; RELEASE_DATE, NO-RH-VEX, or NOT-FOUND in FIX_DATE field)
+                </span>
+              </span>
+            </div>
+            <p class="text-3xl font-extrabold text-gray-900 dark:text-gray-100">{{ fixAvail.metrics.pctNoFix }}%</p>
+            <div class="mt-2 h-1.5 rounded-full overflow-hidden flex bg-gray-200 dark:bg-gray-600">
+              <div class="bg-blue-500 rounded-full" :style="{ width: fixAvail.metrics.pctNoFix + '%' }"></div>
+              <div class="bg-red-400 flex-1"></div>
+            </div>
+          </div>
+          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="flex items-center gap-1.5 mb-2">
+              <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% CVEs with Fix at Release</span>
+              <span class="relative group">
+                <HelpCircle :size="13" class="text-gray-400 dark:text-gray-500 cursor-help" />
+                <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-64 p-2 text-[10px] text-white bg-gray-900 dark:bg-gray-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20">
+                  Percentage of CVEs (discovered at or before release) where a fix already existed at release date (FIX_DATE &le; RELEASE_DATE). A fix is available but may or may not be available through Red Hat.
+                </span>
+              </span>
+            </div>
+            <p class="text-3xl font-extrabold text-gray-900 dark:text-gray-100">{{ fixAvail.metrics.pctWithFix }}%</p>
+            <div class="mt-2 h-1.5 rounded-full overflow-hidden flex bg-gray-200 dark:bg-gray-600">
+              <div class="bg-blue-500 rounded-full" :style="{ width: fixAvail.metrics.pctWithFix + '%' }"></div>
+              <div class="bg-red-400 flex-1"></div>
+            </div>
+          </div>
+          <div class="border-l-4 border-red-500 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="flex items-center gap-1.5 mb-2">
+              <span class="text-xs font-medium text-gray-600 dark:text-gray-400">% with RH Fix Version</span>
+              <span class="relative group">
+                <HelpCircle :size="13" class="text-gray-400 dark:text-gray-500 cursor-help" />
+                <span class="absolute bottom-full right-0 mb-1.5 w-72 p-2 text-[10px] text-white bg-gray-900 dark:bg-gray-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20">
+                  Of CVEs with fix at release, this percentage has the fix-version field populated in VEX data, indicating Red Hat tracked a specific package version containing the fix.
+                </span>
+              </span>
+            </div>
+            <p class="text-3xl font-extrabold text-gray-900 dark:text-gray-100">{{ fixAvail.metrics.pctFixVersion }}%</p>
+            <div class="mt-2 h-1.5 rounded-full overflow-hidden flex bg-gray-200 dark:bg-gray-600">
+              <div class="bg-blue-500 rounded-full" :style="{ width: fixAvail.metrics.pctFixVersion + '%' }"></div>
+              <div class="bg-red-400 flex-1"></div>
+            </div>
+          </div>
+        </div>
+
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
+          {{ fixAvail.metrics.totalCves.toLocaleString() }} CVEs evaluated &middot; Release {{ fixAvail.selected }}
+        </p>
       </section>
 
       <!-- 2. CVEs by Due Date -->
@@ -323,8 +410,8 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, inject } from 'vue'
-import { ArrowLeft, RefreshCw, Shield } from 'lucide-vue-next'
+import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
+import { ArrowLeft, RefreshCw, Shield, HelpCircle } from 'lucide-vue-next'
 import { Bar, Pie, Doughnut, Line } from 'vue-chartjs'
 import {
   Chart as ChartJS,
@@ -474,6 +561,40 @@ async function handleRefresh() {
 
 onMounted(() => {
   loadData()
+  loadFixAvailability()
+})
+
+// ─── Fix Availability at Release ──────────────────────────────────────────────
+
+const fixAvail = ref({ releases: [], selected: null, metrics: null })
+const fixAvailRelease = ref(null)
+
+async function loadFixAvailability(release) {
+  try {
+    const qs = release ? `?release=${encodeURIComponent(release)}` : ''
+    const res = await fetch(`/api/modules/releases/cve-sustaining/fix-availability${qs}`)
+    if (!res.ok) return
+    const payload = await res.json()
+    fixAvail.value = payload
+    if (!fixAvailRelease.value && payload.selected) fixAvailRelease.value = payload.selected
+  } catch { /* no data available */ }
+}
+
+watch(fixAvailRelease, (newVal, oldVal) => {
+  if (newVal && oldVal && newVal !== oldVal) loadFixAvailability(newVal)
+})
+
+const summaryMetricCards = computed(() => {
+  const m = fixAvail.value?.metrics
+  if (!m) return []
+  return [
+    { label: 'Total CVEs at Release', value: (m.totalCves || 0).toLocaleString(), tooltip: 'Total CVE rows discovered at or before the release date, matching any active filters.' },
+    { label: 'CVEs with Fix Available at Release', value: (m.cvesWithFixAtRelease || 0).toLocaleString(), tooltip: 'CVEs where a fix already existed at release date (FIX_DATE ≤ RELEASE_DATE). Fix may be upstream or in other ecosystems.' },
+    { label: 'Unique CVEs', value: (m.uniqueCves || 0).toLocaleString(), tooltip: 'Distinct CVE IDs discovered at or before release. A single CVE can appear in multiple containers/packages.' },
+    { label: 'Number of Containers with CVEs', value: (m.containersWithCves || 0).toLocaleString(), tooltip: 'Unique containers (by SHA) that have at least one CVE discovered at or before release.' },
+    { label: 'Avg CVEs per Container', value: (m.avgCvesPerContainer || 0).toLocaleString(), tooltip: 'Average number of CVEs per container (total CVEs / unique containers).' },
+    { label: 'Container Freshness Score', value: (m.freshnessScore || 0) + '%', tooltip: 'Percentage of containers built within 30 days of the release date. Higher is better — indicates containers are up to date at release.' }
+  ]
 })
 
 function formatDate(iso) {

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -643,4 +643,249 @@ function getISOWeek(date) {
   return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
 }
 
-module.exports = registerCveSustainingRoutes;
+// ─── Fix Availability at Release ─────────────────────────────────────────────
+
+const fs = require('fs');
+const path = require('path');
+const rateLimit = require('express-rate-limit');
+
+const THERMOMETER_DIR = path.resolve(__dirname, '..', '..', '..', '..', 'data', 'releases', 'cve-sustaining', 'thermometer');
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', '..', '..', 'fixtures', 'releases', 'cve-sustaining');
+const FIX_AVAILABILITY_CACHE_FILE = `${STORAGE_PREFIX}/fix-availability-cache.json`;
+
+const fixAvailabilityCache = {};
+
+function getSummaryDir() {
+  const dataPath = path.join(THERMOMETER_DIR, 'summary');
+  if (fs.existsSync(dataPath)) return dataPath;
+  return null;
+}
+
+function parseReleaseFromFilename(filename) {
+  const match = filename.match(/rhoai-(\d+\.\d+\.\d+)-RELEASE\.tsv$/);
+  return match ? match[1] : null;
+}
+
+function listAvailableReleases() {
+  const dir = getSummaryDir();
+  if (!dir) return [];
+  try {
+    return fs.readdirSync(dir)
+      .filter(f => f.endsWith('.tsv'))
+      .map(f => ({ filename: f, release: parseReleaseFromFilename(f) }))
+      .filter(r => r.release)
+      .sort((a, b) => {
+        const [aMaj, aMin, aPatch] = a.release.split('.').map(Number);
+        const [bMaj, bMin, bPatch] = b.release.split('.').map(Number);
+        return (aMaj - bMaj) || (aMin - bMin) || (aPatch - bPatch);
+      });
+  } catch { return []; }
+}
+
+function parseTsv(filepath) {
+  const content = fs.readFileSync(filepath, 'utf-8');
+  const lines = content.split('\n').filter(l => l.trim());
+  if (lines.length < 2) return [];
+  const headers = lines[0].split('\t');
+  return lines.slice(1).map(line => {
+    const values = line.split('\t');
+    const row = {};
+    headers.forEach((h, i) => { row[h] = values[i] || ''; });
+    return row;
+  });
+}
+
+function isValidDate(str) {
+  if (!str || str === 'NO-RH-VEX' || str === 'NOT-FOUND') return false;
+  const d = new Date(str);
+  return !isNaN(d.getTime());
+}
+
+function computeFixAvailability(allRows) {
+  const filtered = allRows.filter(r => {
+    if (!isValidDate(r.DISCOVERY_DATE) || !isValidDate(r.RELEASE_DATE)) return false;
+    return new Date(r.DISCOVERY_DATE) <= new Date(r.RELEASE_DATE);
+  });
+
+  const totalCves = filtered.length;
+  if (totalCves === 0) {
+    return {
+      totalCves: 0, noFixCount: 0, pctNoFix: 0, pctWithFix: 0,
+      cvesWithFixAtRelease: 0, cvesWithFixVersion: 0, pctFixVersion: 0,
+      uniqueCves: 0, containersWithCves: 0, avgCvesPerContainer: 0, freshnessScore: 0
+    };
+  }
+
+  let noFixCount = 0;
+  let cvesWithFixAtRelease = 0;
+  let cvesWithFixVersion = 0;
+
+  for (const row of filtered) {
+    const fixDate = row.FIX_DATE;
+    const releaseDate = row.RELEASE_DATE;
+
+    if (fixDate === 'NO-RH-VEX' || fixDate === 'NOT-FOUND') {
+      noFixCount++;
+      continue;
+    }
+
+    if (isValidDate(fixDate) && isValidDate(releaseDate)) {
+      if (new Date(fixDate) > new Date(releaseDate)) {
+        noFixCount++;
+      } else {
+        cvesWithFixAtRelease++;
+        const fv = row['fix-version'];
+        if (fv && fv !== 'None' && fv !== 'NA' && fv.trim() !== '') {
+          cvesWithFixVersion++;
+        }
+      }
+    } else {
+      noFixCount++;
+    }
+  }
+
+  const pctNoFix = parseFloat(((noFixCount / totalCves) * 100).toFixed(1));
+  const pctWithFix = parseFloat((100 - pctNoFix).toFixed(1));
+  const withFixDenom = totalCves - noFixCount;
+  const pctFixVersion = withFixDenom > 0 ? parseFloat(((cvesWithFixVersion / withFixDenom) * 100).toFixed(1)) : 0;
+
+  const uniqueCves = new Set(filtered.map(r => r.id)).size;
+  const containersWithCves = new Set(filtered.map(r => r.SHA)).size;
+  const avgCvesPerContainer = containersWithCves > 0 ? parseFloat((totalCves / containersWithCves).toFixed(1)) : 0;
+
+  // Freshness: uses ALL rows, not just filtered
+  const freshnessScore = computeFreshnessScore(allRows);
+
+  return {
+    totalCves, noFixCount, pctNoFix, pctWithFix,
+    cvesWithFixAtRelease, cvesWithFixVersion, pctFixVersion,
+    uniqueCves, containersWithCves, avgCvesPerContainer, freshnessScore
+  };
+}
+
+function computeFreshnessScore(rows) {
+  const validRows = rows.filter(r =>
+    r['container-build-date'] && r['container-build-date'] !== 'W' &&
+    isValidDate(r['container-build-date']) && isValidDate(r.RELEASE_DATE)
+  );
+
+  const containerAge = {};
+  for (const row of validRows) {
+    if (containerAge[row.SHA] !== undefined) continue;
+    const releaseDate = new Date(row.RELEASE_DATE);
+    const buildDate = new Date(row['container-build-date']);
+    const ageDays = Math.max(0, Math.floor((releaseDate - buildDate) / (1000 * 60 * 60 * 24)));
+    containerAge[row.SHA] = ageDays;
+  }
+
+  const ages = Object.values(containerAge);
+  if (ages.length === 0) return 0;
+
+  const excellentCount = ages.filter(a => a <= 30).length;
+  return parseFloat(((excellentCount / ages.length) * 100).toFixed(1));
+}
+
+/**
+ * @openapi
+ * /api/modules/releases/cve-sustaining/fix-availability:
+ *   get:
+ *     tags: [Releases]
+ *     summary: Get fix availability at release metrics
+ *     description: >
+ *       Computes fix availability metrics from rhoai-thermometer TSV data.
+ *       Returns available releases and metrics for the selected release.
+ *     parameters:
+ *       - in: query
+ *         name: release
+ *         schema:
+ *           type: string
+ *         description: Release version to compute metrics for (defaults to latest)
+ *     responses:
+ *       200:
+ *         description: Fix availability metrics with release list
+ *       404:
+ *         description: No thermometer data available
+ */
+
+/**
+ * @openapi
+ * /api/modules/releases/cve-sustaining/fix-availability/refresh:
+ *   post:
+ *     tags: [Releases]
+ *     summary: Clear fix availability cache and recompute
+ *     responses:
+ *       200:
+ *         description: Cache cleared
+ */
+
+function registerFixAvailabilityRoutes(router, { storage, requireAuth, requireScope }) {
+  const fixAvailRateLimit = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => req.user?.email || req.ip
+  });
+
+  router.get('/fix-availability', fixAvailRateLimit, requireAuth, requireScope('releases:read'), async (req, res) => {
+    const releases = listAvailableReleases();
+
+    if (releases.length === 0) {
+      // No TSV files — serve from storage cache or pre-computed fixture
+      const cached = await storage.readFromStorage(FIX_AVAILABILITY_CACHE_FILE);
+      if (cached) return res.json(cached);
+
+      try {
+        const fixturePath = path.join(FIXTURE_DIR, 'fix-availability.json');
+        if (fs.existsSync(fixturePath)) {
+          const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+          if (fixture.perRelease) {
+            const selected = req.query.release || fixture.selected || fixture.releases[fixture.releases.length - 1];
+            const metrics = fixture.perRelease[selected];
+            if (metrics) return res.json({ releases: fixture.releases, selected, metrics });
+          }
+          return res.json(fixture);
+        }
+      } catch (err) {
+        console.error('[cve-sustaining] Failed to read fixture:', err.message);
+      }
+
+      return res.status(404).json({ error: 'No thermometer data available. Place TSV files in data/releases/cve-sustaining/thermometer/summary/' });
+    }
+
+    const selectedVersion = req.query.release || releases[releases.length - 1].release;
+    const releaseEntry = releases.find(r => r.release === selectedVersion);
+    if (!releaseEntry) {
+      return res.status(400).json({ error: `Release ${selectedVersion} not found`, available: releases.map(r => r.release) });
+    }
+
+    if (fixAvailabilityCache[selectedVersion]) {
+      return res.json({
+        releases: releases.map(r => r.release),
+        selected: selectedVersion,
+        metrics: fixAvailabilityCache[selectedVersion]
+      });
+    }
+
+    try {
+      const dir = getSummaryDir();
+      const rows = parseTsv(path.join(dir, releaseEntry.filename));
+      const metrics = computeFixAvailability(rows);
+      fixAvailabilityCache[selectedVersion] = metrics;
+
+      const payload = { releases: releases.map(r => r.release), selected: selectedVersion, metrics };
+      await storage.writeToStorage(FIX_AVAILABILITY_CACHE_FILE, payload);
+      res.json(payload);
+    } catch (err) {
+      console.error('[cve-sustaining] Fix availability computation failed:', err.message);
+      res.status(500).json({ error: `Computation failed: ${err.message}` });
+    }
+  });
+
+  router.post('/fix-availability/refresh', fixAvailRateLimit, requireAuth, requireScope('releases:write'), (req, res) => {
+    Object.keys(fixAvailabilityCache).forEach(k => delete fixAvailabilityCache[k]);
+    res.json({ status: 'ok', message: 'Fix availability cache cleared' });
+  });
+}
+
+module.exports = { registerCveSustainingRoutes, registerFixAvailabilityRoutes };

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -840,11 +840,11 @@ function registerFixAvailabilityRoutes(router, { storage, requireAuth, requireSc
         if (fs.existsSync(fixturePath)) {
           const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
           if (fixture.perRelease) {
-            const selected = req.query.release || fixture.selected || fixture.releases[fixture.releases.length - 1];
+            const requested = req.query.release || fixture.selected || fixture.releases[fixture.releases.length - 1];
+            const selected = fixture.perRelease[requested] ? requested : fixture.releases[fixture.releases.length - 1];
             const metrics = fixture.perRelease[selected];
             if (metrics) return res.json({ releases: fixture.releases, selected, metrics });
           }
-          return res.json(fixture);
         }
       } catch (err) {
         console.error('[cve-sustaining] Failed to read fixture:', err.message);

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -18,7 +18,7 @@ const registerFeaturePressureRoutes = require('./feature-pressure/routes');
 const registerPmHubRoutes = require('./pm-hub/routes');
 const registerDraftPlanRoutes = require('./draft-plans/routes');
 const registerReleaseReadinessRoutes = require('./release-readiness/routes');
-const registerCveSustainingRoutes = require('./cve-sustaining/routes');
+const { registerCveSustainingRoutes, registerFixAvailabilityRoutes } = require('./cve-sustaining/routes');
 const registerAiAdoptionRoutes = require('./ai-adoption/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
@@ -317,6 +317,11 @@ module.exports = async function registerRoutes(router, context) {
     requireAuth,
     requireScope,
     jira
+  });
+  registerFixAvailabilityRoutes(cveSustainingRouter, {
+    storage,
+    requireAuth,
+    requireScope
   });
   router.use('/cve-sustaining', cveSustainingRouter);
 


### PR DESCRIPTION
## Summary

- Add **Fix Availability at Release** section to the CVE Sustaining Report with a release dropdown (2.13.0–3.4.0), computing metrics from rhoai-thermometer TSV data
- Add **Summary Metrics** sub-section with 6 cards: Total CVEs at Release, CVEs with Fix Available, Unique CVEs, Containers with CVEs, Avg CVEs/Container, and Container Freshness Score
- Add **Fix Availability** sub-section with 3 percentage cards (No Fix at Release, Fix at Release, RH Fix Version) with progress bars and tooltips
- Pre-compute and cache all release metrics in fixture file for production use without TSV files on the PVC
- Improve SLA compliance cards with quarter/year sidebar labels for easier identification

## Changes

- `modules/releases/server/cve-sustaining/routes.js` — TSV parsing, fix availability computation endpoints (`GET /fix-availability`, `POST /fix-availability/refresh`), freshness score calculation, per-release fixture fallback
- `modules/releases/server/index.js` — register fix availability routes on CVE sustaining router
- `modules/releases/client/reports/CveSustainingReport.vue` — summary metrics cards, fix availability cards, release dropdown, SLA card sidebar layout
- `fixtures/releases/cve-sustaining/fix-availability.json` — pre-computed metrics for all 9 releases

## Test plan

- [ ] Verify summary metrics and fix availability cards render with correct data for each release in the dropdown
- [ ] Verify tooltip definitions appear on hover for all metric cards
- [ ] Verify fixture fallback works when no TSV files are present (demo mode / production without PVC data)
- [ ] Verify SLA compliance cards show quarter/year labels on the left sidebar
- [ ] Run `npm run validate:openapi` to confirm new route annotations pass


Made with [Cursor](https://cursor.com)