### PR TITLE
fix(releases): align PM Hub and Features List counts

### DIFF
--- a/deploy/openshift/overlays/ai-eng-preprod/api-route-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng-preprod/api-route-patch.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     shard: internal
     paas.redhat.com/appcode: AMBC-001
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
 spec:
   host: api-team-tracker.apps.int.spoke.preprod.us-west-2.aws.paas.redhat.com

--- a/deploy/openshift/overlays/ai-eng-preprod/route-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng-preprod/route-patch.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     shard: internal
     paas.redhat.com/appcode: AMBC-001
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
 spec:
   host: team-tracker.apps.int.spoke.preprod.us-west-2.aws.paas.redhat.com

--- a/deploy/openshift/overlays/ai-eng-prod/api-route-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng-prod/api-route-patch.yaml
@@ -5,5 +5,8 @@ metadata:
   labels:
     shard: internal
     paas.redhat.com/appcode: AMBC-001
+  annotations:
+    # PM Hub component-release-load does live multi-project Jira; default 30s → 504
+    haproxy.router.openshift.io/timeout: 120s
 spec:
   host: api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com

--- a/deploy/openshift/overlays/ai-eng-prod/route-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng-prod/route-patch.yaml
@@ -5,5 +5,8 @@ metadata:
   labels:
     shard: internal
     paas.redhat.com/appcode: AMBC-001
+  annotations:
+    # Frontend proxies /api; same live Jira paths as the API route
+    haproxy.router.openshift.io/timeout: 120s
 spec:
   host: team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1154,6 +1154,12 @@ async function loadData() {
     var response = await fetch(getApiBase() + API_BASE + '/component-release-load?' + params.toString())
     if (!response.ok) {
       var errData = await response.json().catch(function() { return {} })
+      if (response.status === 504) {
+        throw new Error(
+          'Request timed out (HTTP 504). Narrow the Release or Pillar filter and retry — ' +
+          'loading several releases with Pillar=All hits Jira too hard for the gateway limit.'
+        )
+      }
       throw new Error(errData.error || 'HTTP ' + response.status)
     }
     var data = await response.json()

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -297,7 +297,7 @@
       correlated. Use REQ/COM (and other) filter chips in the bar above to filter
       the table.
     -->
-    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-6 gap-3">
+    <div v-if="hasFetched && !loadingData" class="grid grid-cols-2 sm:grid-cols-6 gap-3">
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -156,6 +156,33 @@ describe('feature-query', function() {
       expect(result.targetVersions).toEqual(['rhoai-3.6'])
     })
 
+    it('keeps all Target Versions when Jira returns a multi-value field', function() {
+      var fields = {}
+      fields[CUSTOM_FIELDS.targetVersion] = [
+        { name: '3.6 GA RHOAI RELEASE' },
+        { name: '3.6 EA2 RHOAI RELEASE' },
+        { name: '3.6 EA2 RHOAI RELEASE' }
+      ]
+      var result = normalizeIssue({ key: 'RHAISTRAT-14m', fields: fields })
+      expect(result.targetVersions).toEqual([
+        '3.6 GA RHOAI RELEASE',
+        '3.6 EA2 RHOAI RELEASE'
+      ])
+    })
+
+    it('extracts Target Versions from value objects and plain strings', function() {
+      var fields = {}
+      fields[CUSTOM_FIELDS.targetVersion] = [
+        { value: '3.6 EA2 RHAII RELEASE' },
+        '3.6 EA1 RHOAI RELEASE'
+      ]
+      var result = normalizeIssue({ key: 'RHAISTRAT-14n', fields: fields })
+      expect(result.targetVersions).toEqual([
+        '3.6 EA2 RHAII RELEASE',
+        '3.6 EA1 RHOAI RELEASE'
+      ])
+    })
+
     it('returns empty targetVersions when custom field is null', function() {
       var result = normalizeIssue({ key: 'RHAISTRAT-15', fields: {} })
       expect(result.targetVersions).toEqual([])

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -22,6 +22,25 @@ var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status
 /** Bound live Jira so /feature-readiness stays under the gateway timeout. */
 var FETCH_FEATURES_TIMEOUT_MS = 12000
 
+function extractTargetVersions(field) {
+  if (field == null) return []
+  var arr = Array.isArray(field) ? field : [field]
+  var names = []
+  var seen = {}
+  for (var i = 0; i < arr.length; i++) {
+    var entry = arr[i]
+    if (entry == null) continue
+    var name
+    if (typeof entry === 'string') name = entry.trim()
+    else if (typeof entry === 'object') name = (entry.name || entry.value || '').toString().trim()
+    else name = String(entry).trim()
+    if (!name || seen[name]) continue
+    seen[name] = true
+    names.push(name)
+  }
+  return names
+}
+
 function normalizeIssue(issue) {
   var fields = issue.fields || {}
   var assignee = fields.assignee
@@ -34,8 +53,9 @@ function normalizeIssue(issue) {
     ? fields.fixVersions.map(function(v) { return v.name || String(v) }).filter(Boolean)
     : []
   var labels = Array.isArray(fields.labels) ? fields.labels : []
-  var targetVersionRaw = serializeField(fields[CUSTOM_FIELDS.targetVersion])
-  var targetVersions = targetVersionRaw ? [targetVersionRaw] : []
+  // Keep every Target Version — serializeField only returns the first and drops
+  // EA2 membership when GA is listed first (Features List under-count vs PM Hub).
+  var targetVersions = extractTargetVersions(fields[CUSTOM_FIELDS.targetVersion])
   var status = fields.status
     ? (typeof fields.status === 'object' ? fields.status.name || null : fields.status)
     : null
@@ -149,6 +169,7 @@ module.exports = {
   fetchFeatures: fetchFeatures,
   fetchFeaturesWithTimeout: fetchFeaturesWithTimeout,
   normalizeIssue: normalizeIssue,
+  extractTargetVersions: extractTargetVersions,
   enrichChildEpicCounts: enrichChildEpicCounts,
   JQL: JQL,
   QUERY_FIELDS: QUERY_FIELDS,

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -13,6 +13,7 @@ const { filterCommittedFixVersions, parseReleaseName, compareReleasesTemporally 
 const { parseDescriptionSignals } = require('../planning/health/description-scanner')
 const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
 const { loadIndex } = require('../planning/cache-reader')
+const { CLOSED_STATUSES } = require('../planning/constants')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
@@ -631,6 +632,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *     summary: Get component release load tracking data
    *     description: >
    *       Queries Jira for Features/Initiatives grouped by version then component.
+   *       Closed/Done/Resolved/Cancelled issues are excluded (same as Features List).
    *       F Requested = issues where Target Version (cf[10855]) matches a selected version.
    *       F Committed = issues where fixVersion matches a selected version AND a Target
    *       Version either matches that fixVersion or is later in the same release cycle
@@ -741,6 +743,10 @@ module.exports = async function registerPmHubRoutes(router, context) {
         'project IN (' + PM_HUB_PROJECTS.join(', ') + ')',
         'issuetype IN (' + DEFAULT_ISSUE_TYPES.join(', ') + ')'
       ]
+      // Requested/Committed exclude closed (same set as Features List). Velocity keeps Done.
+      var openParts = baseParts.concat([
+        'status NOT IN (' + CLOSED_STATUSES.join(', ') + ')'
+      ])
 
       var componentClause = ''
       if (componentNames.length > 0) {
@@ -756,35 +762,38 @@ module.exports = async function registerPmHubRoutes(router, context) {
 
       var fieldsWithTv = FIELDS_TO_FETCH + ',' + CUSTOM_FIELDS.targetVersion
 
-      // Query 1: F Requested — Target Version (cf[10855]) matches selected versions
-      var requestedIssues = []
+      // Parallelize live Jira + epic-index reads. Avoid expand=renderedFields —
+      // ADF in fields.description is enough for FPDoR description signals and
+      // rendered HTML roughly doubles payload (gateway ~30s timeout / 504).
+      var tvFetch = Promise.resolve([])
+      var fvFetch = Promise.resolve([])
       if (versionNames.length > 0) {
-        var tvJqlParts = baseParts.slice()
+        var tvJqlParts = openParts.slice()
         if (componentClause) tvJqlParts.push(componentClause)
         tvJqlParts.push('cf[10855] IN (' + escapedVer.join(', ') + ')')
-        var tvJql = tvJqlParts.join(' AND ')
-        requestedIssues = await jiraClient.fetchAllJqlResults(tvJql, fieldsWithTv, { expand: 'renderedFields' })
-      }
+        tvFetch = jiraClient.fetchAllJqlResults(tvJqlParts.join(' AND '), fieldsWithTv, {})
 
-      // Query 2: FV candidates — fixVersion matches selected versions.
-      // Committed bucketing applies a stricter TV/FV rule after fetch.
-      var committedIssues = []
-      if (versionNames.length > 0) {
-        var fvJqlParts = baseParts.slice()
+        var fvJqlParts = openParts.slice()
         if (componentClause) fvJqlParts.push(componentClause)
         fvJqlParts.push('fixVersion IN (' + escapedVer.join(', ') + ')')
-        var fvJql = fvJqlParts.join(' AND ')
-        committedIssues = await jiraClient.fetchAllJqlResults(fvJql, fieldsWithTv, { expand: 'renderedFields' })
+        // FV candidates; Committed bucketing applies a stricter TV/FV rule after fetch.
+        fvFetch = jiraClient.fetchAllJqlResults(fvJqlParts.join(' AND '), fieldsWithTv, {})
       } else if (componentNames.length > 0) {
-        var compOnlyParts = baseParts.slice()
+        var compOnlyParts = openParts.slice()
         compOnlyParts.push(componentClause)
-        var compJql = compOnlyParts.join(' AND ')
-        committedIssues = await jiraClient.fetchAllJqlResults(compJql, fieldsWithTv, { expand: 'renderedFields' })
+        fvFetch = jiraClient.fetchAllJqlResults(compOnlyParts.join(' AND '), fieldsWithTv, {})
       }
 
+      var parallel = await Promise.all([
+        tvFetch,
+        fvFetch,
+        loadEpicCountByKey(context.storage.readFromStorage)
+      ])
+      var requestedIssues = parallel[0]
+      var committedIssues = parallel[1]
+      var epicCountByKey = parallel[2]
+
       var versionGroups = {}
-      // Same Child epics source as Features List (jira-sync → execution index).
-      var epicCountByKey = await loadEpicCountByKey(context.storage.readFromStorage)
 
       function ensureGroup(vName, cName) {
         if (!versionGroups[vName]) {

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1042,7 +1042,7 @@ test.describe('Releases CVE Sustaining Report @releases', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    var card = page.locator('text=RHOAI Sustaining (CVEs)');
+    var card = page.locator('text=RHAI Sustaining (CVEs)');
     await expect(card.first()).toBeVisible();
 
     expect(page.errors).toHaveLength(0);
@@ -1054,7 +1054,7 @@ test.describe('Releases CVE Sustaining Report @releases', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Report heading
-    await expect(page.locator('text=RHOAI Sustaining (CVEs)').first()).toBeVisible();
+    await expect(page.locator('text=RHAI Sustaining (CVEs)').first()).toBeVisible();
 
     // Open CVEs banner
     await expect(page.locator('text=Open CVEs').first()).toBeVisible();
@@ -1064,7 +1064,7 @@ test.describe('Releases CVE Sustaining Report @releases', () => {
     await expect(page.locator('text=Due Date Passed').first()).toBeVisible();
 
     // Bar chart section
-    await expect(page.locator('text=RHOAI Open CVEs').first()).toBeVisible();
+    await expect(page.locator('text=RHAI Open CVEs').first()).toBeVisible();
 
     // Version matrix table
     await expect(page.locator('text=CVEs across all versions').first()).toBeVisible();

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1075,7 +1075,7 @@ test.describe('Releases CVE Sustaining Report @releases', () => {
     // Time series charts
     await expect(page.locator('text=Created vs Resolved').first()).toBeVisible();
     await expect(page.locator('text=Unresolved').first()).toBeVisible();
-    await expect(page.locator('text=RHOAI False Positives').first()).toBeVisible();
+    await expect(page.locator('text=RHAI False Positives').first()).toBeVisible();
 
     expect(page.errors).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- **Features List:** keep all Jira Target Versions when normalizing live issues (previously only the first TV was kept, so EA2 filters under-counted when GA was listed first — ~99 vs ~136 for 3.6 EA2).
- **PM Hub:** exclude Closed/Done/Resolved/Cancelled from Requested/Committed (same closed set as Features List); leave velocity Done query unchanged.
- **PM Hub 504:** parallelize TV/FV/epic-index fetches, drop `expand=renderedFields`, raise prod/preprod route timeout to 120s, and show a clearer client message on gateway timeout.

## Test plan
- [ ] Features List: Release 3.6 + Target Version = 3.6 EA2 RHOAI + RHAII → total near ~136 open RHAISTRAT (not ~99)
- [ ] PM Hub: Release 3.6 EA2 → Requested near open-only multi-project count (~140), no closed issues in tiles
- [ ] PM Hub: Pillar=All + multiple releases still loads (no 504) or shows the timeout guidance
- [ ] `npx vitest run modules/releases/server/planning/__tests__/feature-query.test.js modules/releases/__tests__/server/pm-hub`


Made with [Cursor](https://cursor.com)