### PR TITLE
(fix) - remove refresh functionality for e2e health dashboard

### DIFF
--- a/modules/system-health/client/composables/useOdhOperatorE2eHealth.js
+++ b/modules/system-health/client/composables/useOdhOperatorE2eHealth.js
@@ -61,28 +61,6 @@ async function loadRunHistory(options = {}) {
   }
 }
 
-async function refreshData() {
-  loading.value = true
-  error.value = null
-
-  try {
-    // Step 1: Trigger backend refresh to fetch fresh data from Prow CI
-    await apiRequest('/modules/system-health/odh-e2e-health/refresh', { method: 'POST' })
-
-    // Step 2: Load the fresh data that was just fetched
-    await Promise.all([
-      loadHealthData(true), // Force reload to bypass any caching
-      loadRunHistory({ page: 1, limit: 20 })
-    ])
-
-  } catch (e) {
-    error.value = e.message || 'Failed to refresh E2E health data'
-    console.error('Refresh failed:', e)
-  } finally {
-    loading.value = false
-  }
-}
-
 export function useOdhOperatorE2eHealth() {
   if (!hasFetched) {
     hasFetched = true
@@ -192,8 +170,7 @@ export function useOdhOperatorE2eHealth() {
 
     // Actions
     loadHealthData,
-    loadRunHistory,
-    refreshData
+    loadRunHistory
   }
 }
 

--- a/modules/system-health/client/views/OdhOperatorE2eHealthView.vue
+++ b/modules/system-health/client/views/OdhOperatorE2eHealthView.vue
@@ -23,7 +23,7 @@ import {
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Title)
 
 const nav = inject('moduleNav', null)
-const { healthData, runHistory, loading, error, loadHealthData, loadRunHistory, refreshData } = useOdhOperatorE2eHealth()
+const { healthData, runHistory, loading, error, loadHealthData, loadRunHistory } = useOdhOperatorE2eHealth()
 
 // Filters
 const suiteFilter = ref('all')
@@ -448,14 +448,7 @@ function formatPassRate(rate) {
 
 
 
-
-
 // Removed duplicate onMounted - now handled above with dark mode detection
-
-
-function handleRefresh() {
-  refreshData()
-}
 
 function handleRowClick(run) {
   // Navigate to internal test run detail view
@@ -493,14 +486,6 @@ function loadMoreRuns() {
           End-to-end test health monitoring for OpenDataHub and RHOAI
         </p>
       </div>
-      <button
-        @click="handleRefresh"
-        :disabled="loading"
-        class="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-      >
-        <RefreshCw :class="['w-4 h-4 -ml-1 mr-2', { 'animate-spin': loading }]" />
-        Refresh
-      </button>
     </div>
 
     <!-- Loading State -->

--- a/modules/system-health/server/odh-e2e-health/routes.js
+++ b/modules/system-health/server/odh-e2e-health/routes.js
@@ -85,7 +85,7 @@ function generateContextualFailingComponents(suites, componentStats = {}) {
  * @param {object} context
  */
 module.exports = function registerOpendatahubOperatorE2ERoutes(router, context) {
-  const { storage, requireAdmin, requireScope } = context;
+  const { storage } = context;
   const { readFromStorage } = storage;
 
   /**
@@ -360,63 +360,6 @@ module.exports = function registerOpendatahubOperatorE2ERoutes(router, context) 
     }
   });
 
-  /**
-   * @openapi
-   * /api/modules/system-health/odh-e2e-health/refresh:
-   *   post:
-   *     tags: [System Health]
-   *     summary: Trigger manual refresh of E2E health data
-   *     description: Manually refresh E2E test health data from Prow CI
-   *     responses:
-   *       200:
-   *         description: Refresh triggered successfully
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 status:
-   *                   type: string
-   *                 duration:
-   *                   type: number
-   *                 metrics:
-   *                   type: object
-   */
-  router.post('/refresh', requireAdmin, requireScope('system-health:write'), async (_req, res) => {
-    if (DEMO_MODE) {
-      return res.json({
-        success: true,
-        status: 'skipped',
-        message: 'Refresh disabled in demo mode',
-        trigger: 'manual'
-      });
-    }
-
-    try {
-      const { refreshE2EHealthData } = require('./scheduler');
-
-      console.log('Manual refresh triggered via API');
-
-      const result = await refreshE2EHealthData({
-        logger: console,
-        storage: context.storage
-      });
-
-      res.json({
-        success: true,
-        message: 'E2E health data refresh completed',
-        trigger: 'manual',
-        ...result
-      });
-
-    } catch (error) {
-      console.error('Error during manual refresh:', error);
-      res.status(500).json({
-        error: 'Failed to refresh E2E health data',
-        message: error.message
-      });
-    }
-  });
 
 
 };


### PR DESCRIPTION
The refresh functionality required admin permissions, so removing the manual refresh and relying on auto refresh for the e2e health dashboard.