### PR TITLE
fix(releases): PM Hub silent background refresh + auto-load on mount

### DIFF
--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1129,7 +1129,7 @@ async function loadData(opts) {
   var effectiveComponents = getEffectiveComponents()
   if (effectiveComponents.length === 0 && selectedVersions.value.length === 0) return
   if (!silent) loadingData.value = true
-  dataError.value = null
+  if (!silent) dataError.value = null
   hasFetched.value = true
 
   try {
@@ -1154,7 +1154,7 @@ async function loadData(opts) {
     groups.value = data.groups || []
     fetchedAt.value = data.fetchedAt || null
   } catch (err) {
-    dataError.value = err.message
+    if (!silent) dataError.value = err.message
     if (!silent) {
       groups.value = []
       velocity.value = null

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1120,14 +1120,15 @@ function startAutoRefresh() {
   autoRefreshTimer.value = setInterval(function() {
     if (!hasFetched.value || loadingData.value) return
     if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
-    loadData()
+    loadData({ silent: true })
   }, AUTO_REFRESH_MS)
 }
 
-async function loadData() {
+async function loadData(opts) {
+  var silent = opts && opts.silent
   var effectiveComponents = getEffectiveComponents()
   if (effectiveComponents.length === 0 && selectedVersions.value.length === 0) return
-  loadingData.value = true
+  if (!silent) loadingData.value = true
   dataError.value = null
   hasFetched.value = true
 
@@ -1154,10 +1155,13 @@ async function loadData() {
     fetchedAt.value = data.fetchedAt || null
   } catch (err) {
     dataError.value = err.message
-    groups.value = []
-    fetchedAt.value = null
+    if (!silent) {
+      groups.value = []
+      velocity.value = null
+      fetchedAt.value = null
+    }
   } finally {
-    loadingData.value = false
+    if (!silent) loadingData.value = false
     if (hasFetched.value && !autoRefreshTimer.value) startAutoRefresh()
   }
 }

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1157,7 +1157,6 @@ async function loadData(opts) {
     if (!silent) dataError.value = err.message
     if (!silent) {
       groups.value = []
-      velocity.value = null
       fetchedAt.value = null
     }
   } finally {

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1190,11 +1190,16 @@ watch(
   { deep: true }
 )
 
-onMounted(function() {
+onMounted(async function() {
   restoreFilters()
-  fetchPillarConfig()
-  fetchComponents()
+  await Promise.all([fetchPillarConfig(), fetchComponents()])
   document.addEventListener('mousedown', handleClickOutside)
+  if (!hasFetched.value) {
+    var effectiveComponents = getEffectiveComponents()
+    if (effectiveComponents.length > 0 || selectedVersions.value.length > 0) {
+      loadData()
+    }
+  }
 })
 
 onBeforeUnmount(function() {

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -308,6 +308,45 @@ test.describe('Releases PM Hub @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 
+  test('auto-loads data on mount when version filter is saved in localStorage', async ({ page }) => {
+    // Seed a version filter. Version labels map directly to PORTFOLIO_VERSIONS so the
+    // watcher fires as soon as selectedVersions is restored — no component list needed.
+    await page.addInitScript(`
+      localStorage.setItem('pm-hub-filters', JSON.stringify({
+        components: [],
+        pillars: [],
+        versions: ['3.5']
+      }));
+    `);
+
+    // Track whether the component-release-load API is called automatically on mount.
+    var loadRequests = [];
+    page.on('request', function(req) {
+      if (req.url().includes('/pm-hub/component-release-load')) loadRequests.push(req.url());
+    });
+
+    await page.goto('/#/releases/plan');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await page.locator('button', { hasText: 'PM Hub' }).click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var reportCard = page.locator('.cursor-pointer', { hasText: 'Component Release Load Tracking' });
+    await reportCard.first().click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // The API must have been called — savedVersions triggers loadData() automatically on mount.
+    expect(loadRequests.length).toBeGreaterThan(0);
+
+    // The "select filters" empty prompt must NOT be visible (hasFetched=true).
+    var emptyPrompt = page.locator('text=Select components and/or releases to view data.');
+    await expect(emptyPrompt).not.toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   test('pillar-config endpoint returns valid config', async ({ request }) => {
     const res = await request.get('/api/modules/releases/pm-hub/pillar-config');
     expect(res.ok()).toBe(true);


### PR DESCRIPTION
 ## Summary

- Auto-refresh now runs silently without toggling `loadingData`  instead of destroying and recreating the 'Component Release Load Tracking' table. This preserves open dropdowns and scroll position. Manual refresh still toggles `loadingData`.
- On initial page load, pillar/version filters restored from localStorage now correctly trigger a data fetch. Previously, the watch fired before `fetchPillarConfig` and `fetchComponents` resolved, causing `getEffectiveComponents` to return `[]` and bail out. `onMounted` now awaits both fetches before checking whether to call `loadData`, avoiding the need to manually trigger by removing/re-adding filters. 

## Test plan
  
- [x] Open PM Hub → Component Release Load Tracking with a pillar filter saved — data should load automatically without touching filters
- [x] Open a dropdown, wait 5 min (or temporarily set `AUTO_REFRESH_MS` lower) — dropdown should stay open after refresh fires, without losing place on the page
- [x] Manual Refresh button still shows spinner as before
- [x] `npm run lint` passes
- [x] `npm run build` passes