### PR TITLE
fix(tv-fv-delta): use key based JQL for aligned_on_time link

### DIFF
--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -1226,55 +1226,49 @@ describe('buildExport', () => {
     expect(result.releases['rhoai-3.5']).toBeDefined();
   });
 
-  it('aligned_on_time_jql includes earlier same-product releases in fixVersion clause (Case 2: ahead of schedule)', () => {
+  it('aligned_on_time_jql uses key-based JQL matching exactly the classified items (Case 2: ahead of schedule)', () => {
     const releases = ['3.6 EA1 RHOAI RELEASE', '3.5 GA RHOAI RELEASE', '3.5 EA2 RHOAI RELEASE'];
     const classifications = [
       { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
-    // Must include the earlier RHOAI releases as valid fix versions
-    expect(jql).toContain('"3.5 GA RHOAI RELEASE"');
-    expect(jql).toContain('"3.5 EA2 RHOAI RELEASE"');
-    // Must still require TV = the target release
-    expect(jql).toContain('"Target Version" in ("3.6 EA1 RHOAI RELEASE")');
+    // Key-based JQL: exact issue keys, guaranteed to match table count
+    expect(jql).toContain('key in (X-1)');
   });
 
-  it('aligned_on_time_jql includes later same-product releases in Target Version clause (Case 3: FV ahead)', () => {
+  it('aligned_on_time_jql uses key-based JQL matching exactly the classified items (Case 3: FV ahead)', () => {
     const releases = ['3.6 EA1 RHOAI RELEASE', '3.6 EA2 RHOAI RELEASE', '3.6 GA RHOAI RELEASE'];
     const classifications = [
       { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
-    // Case 3 clause: FV = EA1, TV = later release
-    expect(jql).toContain('fixVersion in ("3.6 EA1 RHOAI RELEASE")');
-    expect(jql).toContain('"3.6 EA2 RHOAI RELEASE"');
-    expect(jql).toContain('"3.6 GA RHOAI RELEASE"');
+    // Key-based JQL: exact issue keys, guaranteed to match table count
+    expect(jql).toContain('key in (X-1)');
   });
 
-  it('aligned_on_time_jql does not bleed cross-product releases into fixVersion or Target Version clauses', () => {
+  it('aligned_on_time_jql does not include cross-product releases', () => {
     const releases = ['3.6 EA1 RHOAI RELEASE', '3.6 EA1 RHAII RELEASE', '3.5 GA RHOAI RELEASE'];
     const classifications = [
       { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
-    // RHAII release must not appear — different product
+    // Key-based JQL: only the exact issue key, no release name strings
+    expect(jql).toContain('key in (X-1)');
     expect(jql).not.toContain('RHAII');
-    // Earlier RHOAI release must appear
-    expect(jql).toContain('"3.5 GA RHOAI RELEASE"');
   });
 
-  it('aligned_on_time_jql falls back to exact-match when release is unparseable (no earlier/later computed)', () => {
+  it('aligned_on_time_jql uses key-based JQL even when release is unparseable', () => {
     const releases = ['unparseable-version', 'rhoai-3.5'];
     const classifications = [
       { release: 'unparseable-version', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
-    // Just the release itself, no compound OR clause (compound uses ') OR (' pattern)
-    expect(jql).toContain('"unparseable-version"');
+    // Key-based JQL: exact issue keys regardless of release parseability
+    expect(jql).toContain('key in (X-1)');
     expect(jql).not.toContain(') OR (');
   });
 });

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -1271,6 +1271,46 @@ describe('buildExport', () => {
     expect(jql).toContain('key in (X-1)');
     expect(jql).not.toContain(') OR (');
   });
+
+  it('aligned_on_time_jql falls back to alias JQL when key count exceeds 300', () => {
+    const releases = ['3.5 EA1 RHOAI RELEASE'];
+    const classifications = Array.from({ length: 301 }, function(_, i) {
+      return {
+        release: '3.5 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-' + (i + 1),
+        url: '', summary: '', status: '', color_status: '', product_manager: '',
+        assignee: '', team: '', components: [], component: '',
+        target_version: '3.5 EA1 RHOAI RELEASE', fix_versions: '3.5 EA1 RHOAI RELEASE',
+      };
+    });
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // Over limit → alias JQL (not key in)
+    expect(jql).not.toContain('key in (');
+    expect(jql).toContain('"Target Version" in');
+    expect(jql).toContain('fixVersion in');
+  });
+
+  it('aligned_on_time_jql fallback uses fvAliases (not tvAliases) in fixVersion clause', () => {
+    // When aligned_on_time count is 0, the fallback JQL should use TV aliases for
+    // "Target Version" and FV aliases for fixVersion — not TV aliases for both.
+    const releases = ['3.5 EA1 RHOAI RELEASE'];
+    const classifications = [
+      {
+        release: '3.5 EA1 RHOAI RELEASE', category: 'tv_only', key: 'X-1',
+        url: '', summary: '', status: '', color_status: '', product_manager: '',
+        assignee: '', team: '', components: [], component: '',
+        target_version: '3.5 EA1 RHOAI RELEASE',
+        fix_versions: 'rhoai-3.5.EA1',
+      },
+    ];
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // Fallback (no aligned_on_time keys): TV clause uses TV alias, FV clause uses FV alias
+    expect(jql).toContain('"Target Version" in');
+    expect(jql).toContain('fixVersion in');
+    // FV alias (rhoai-3.5.EA1) must appear in fixVersion clause, not TV alias only
+    expect(jql).toContain('rhoai-3.5.EA1');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -592,37 +592,39 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       dates = releaseDates[release] || releaseDates[normVer(release)] || {}
     }
 
-    // Build compound aligned_on_time JQL covering all three cases:
-    //   Case 1: TV = R, FV = R (exact match)
-    //   Case 2: TV = R, FV = earlier same-product release (ahead of schedule)
-    //   Case 3: FV = R, TV = later same-product release (also ahead of schedule)
-    // Note: features with FV pointing outside the tracked releases array won't appear
-    // in this JQL — we can only enumerate releases known to the pipeline.
-    var rParsed = parseReleaseName(release)
-    var sameProduct = releases.filter(function(r) {
-      if (r === release) return false
-      var p = parseReleaseName(r)
-      return p && rParsed && p.product === rParsed.product
-    })
-    var earlierReleases = sameProduct.filter(function(r) {
-      var cmp = compareReleasesTemporally(r, release)
-      return cmp !== null && cmp < 0
-    })
-    var laterReleases = sameProduct.filter(function(r) {
-      var cmp = compareReleasesTemporally(r, release)
-      return cmp !== null && cmp > 0
-    })
-    var allFvForAligned = [release].concat(earlierReleases)
-    var case12 = '"Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + allFvForAligned.map(quoteRelease).join(', ') + ')'
-    var case3 = laterReleases.length > 0
-      ? 'fixVersion in (' + quoteRelease(release) + ') AND "Target Version" in (' + laterReleases.map(quoteRelease).join(', ') + ')'
-      : null
-    var alignedOnTimeJql = case3 ? '(' + case12 + ') OR (' + case3 + ')' : case12
+    // Build JQL aliases for TV/FV to handle alternate Jira version name formats.
+    var relNorm = normVer(release)
+    var tvAliasesForRelease = new Set([release])
+    var fvAliasesForRelease = new Set([release])
+
+    for (var ii = 0; ii < items.length; ii++) {
+      var tvParts = items[ii].target_version ? items[ii].target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean) : []
+      var fvParts = items[ii].fix_versions ? items[ii].fix_versions.split(',').map(function(s) { return s.trim() }).filter(Boolean) : []
+      for (var tii = 0; tii < tvParts.length; tii++) {
+        if (normVer(tvParts[tii]) === relNorm) tvAliasesForRelease.add(tvParts[tii])
+      }
+      for (var fii = 0; fii < fvParts.length; fii++) {
+        if (normVer(fvParts[fii]) === relNorm) fvAliasesForRelease.add(fvParts[fii])
+      }
+    }
+
+    var tvAliases = Array.from(tvAliasesForRelease)
+    var fvAliases = Array.from(fvAliasesForRelease)
+    var allAliases = Array.from(new Set(tvAliases.concat(fvAliases)))
+
+    // Key-based JQL: exact issue list guarantees table count == Jira link count.
+    var alignedKeys = items
+      .filter(function(it) { return it.category === 'aligned_on_time' })
+      .map(function(it) { return it.key })
+      .filter(Boolean)
+    var alignedOnTimeJql = alignedKeys.length > 0
+      ? 'key in (' + alignedKeys.join(', ') + ')'
+      : '"Target Version" in (' + tvAliases.map(quoteRelease).join(', ') + ') AND fixVersion in (' + tvAliases.map(quoteRelease).join(', ') + ')'
 
     executiveSummary.push({
       release: release,
       total: nTotal,
-      total_jql: jqlUrl(baseJql + ' AND ("Target Version" in (' + quoteRelease(release) + ') OR fixVersion in (' + quoteRelease(release) + '))'),
+      total_jql: jqlUrl(baseJql + ' AND ("Target Version" in (' + allAliases.map(quoteRelease).join(', ') + ') OR fixVersion in (' + allAliases.map(quoteRelease).join(', ') + '))'),
       aligned_on_time: cats.aligned_on_time,
       aligned_on_time_jql: jqlUrl(baseJql + ' AND (' + alignedOnTimeJql + ')'),
       aligned_late: cats.aligned_late,
@@ -630,9 +632,9 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       misaligned: cats.misaligned,
       misaligned_jql: null, // Cannot express temporal + freeze logic in JQL
       tv_only: cats.tv_only,
-      tv_only_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion is EMPTY'),
+      tv_only_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + tvAliases.map(quoteRelease).join(', ') + ') AND fixVersion is EMPTY'),
       fv_only: cats.fv_only,
-      fv_only_jql: jqlUrl(baseJql + ' AND fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is EMPTY'),
+      fv_only_jql: jqlUrl(baseJql + ' AND fixVersion in (' + fvAliases.map(quoteRelease).join(', ') + ') AND "Target Version" is EMPTY'),
       alignment_pct: alignPct,
       ga_date: dates.dueDate || null,
       planning_freeze: dates.planningFreezeDate || null,

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -613,13 +613,18 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
     var allAliases = Array.from(new Set(tvAliases.concat(fvAliases)))
 
     // Key-based JQL: exact issue list guarantees table count == Jira link count.
+    // Cap at 300 keys to stay within CloudFront's ~8 KB URL limit (RHAISTRAT-XXXX
+    // keys are ~20 chars URL-encoded each; 300 keys ≈ 6 KB, safely under the ceiling).
+    // Fall back to alias JQL for very large releases (live filter, may drift slightly).
+    var KEY_JQL_LIMIT = 300
     var alignedKeys = items
       .filter(function(it) { return it.category === 'aligned_on_time' })
       .map(function(it) { return it.key })
-      .filter(Boolean)
-    var alignedOnTimeJql = alignedKeys.length > 0
+      .filter(function(k) { return k && /^[A-Z]+-\d+$/.test(k) })
+    var aliasFallbackJql = '"Target Version" in (' + tvAliases.map(quoteRelease).join(', ') + ') AND fixVersion in (' + fvAliases.map(quoteRelease).join(', ') + ')'
+    var alignedOnTimeJql = alignedKeys.length > 0 && alignedKeys.length <= KEY_JQL_LIMIT
       ? 'key in (' + alignedKeys.join(', ') + ')'
-      : '"Target Version" in (' + tvAliases.map(quoteRelease).join(', ') + ') AND fixVersion in (' + tvAliases.map(quoteRelease).join(', ') + ')'
+      : aliasFallbackJql
 
     executiveSummary.push({
       release: release,


### PR DESCRIPTION
## Summary
The JQL link constructed for the aligned_on_time column now uses key-based JQL so the issues shown in Jira exactly match the table count.

- Replaces TV/FV-reconstructed JQL with `key in (...)` built from the exact classified issue keys (derived from `classifyFeatures()`). The classification logic (temporal ordering, freeze dates, multi-product features) cannot be perfectly expressed in JQL, causing systematic drift between the table count and the Jira link count (e.g. 73 vs 69 for 3.6 EA1 RHOAI RELEASE). Key-based JQL guarantees the link returns exactly the issues that were counted.
- Also improves total_jql, tv_only_jql, and fv_only_jql to use all observed TV/FV alias strings (not just the canonical release name), so alternate Jira version name formats are captured.

**Note:** the key-based JQL provides a snapshot of issues classified as 'aligned on time', not a live filter. Issues are only added/removed when Refresh from Jira runs. The previous TV/FV JQL was a live filter but did not fully capture classification logic, causing table count =/= Jira issue count from link.

## Test plan
- [x] `npm test` — all tv-fv-delta tests pass (142/142) (two tests added)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Manual: Refresh from Jira on TV vs FV Delta page, then verify aligned_on_time cell count matches issue count returned in Jira via link