### PR TITLE
feat(releases): shared Features pipeline Phase 3 — PM Hub TV/FV alignment + Features List sort

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -55,7 +55,6 @@ function mountTable(props) {
         makeFeature({ key: 'X-2', priority: 'Major', assignee: 'Bob' })
       ]),
       componentLeads: {},
-      velocity: null,
       initialSort: { column: null, direction: 'asc' }
     }, props || {})
   })

--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -7,6 +7,11 @@
  * inlined from the component source.
  */
 import { describe, it, expect } from 'vitest'
+import {
+  isAlignedCategory,
+  worseAlignmentCategory,
+  ALIGNMENT_CATEGORY_PRIORITY
+} from '../../../client/plan/utils/tv-fv-alignment-display.js'
 
 // ---------------------------------------------------------------------------
 // Inline the pure functions from ComponentReleaseLoadTable.vue so we can
@@ -113,7 +118,10 @@ function buildComponentGroups(groups) {
             releaseType: feat.releaseType,
             priority: feat.priority,
             isBlocked: feat.isBlocked,
-            pmDoAligned: !!feat.pmDoAligned,
+            alignmentCategory: feat.alignmentCategory || null,
+            pmDoAligned: feat.alignmentCategory
+              ? isAlignedCategory(feat.alignmentCategory)
+              : !!feat.pmDoAligned,
             fpdor: feat.fpdor || null,
             confidence: feat.confidence || null,
             isAiFirst: !!feat.isAiFirst,
@@ -129,6 +137,13 @@ function buildComponentGroups(groups) {
         }
 
         var entry = cg.features[feat.key]
+        entry.alignmentCategory = worseAlignmentCategory(
+          entry.alignmentCategory,
+          feat.alignmentCategory || null
+        )
+        entry.pmDoAligned = entry.alignmentCategory
+          ? isAlignedCategory(entry.alignmentCategory)
+          : !!entry.pmDoAligned
         var product = extractProduct(version)
         if (entry.products.indexOf(product) === -1) {
           entry.products.push(product)
@@ -189,6 +204,7 @@ function makeFeature(overrides) {
     targetVersions: ['rhoai-3.5'],
     assignee: 'Alice',
     pmOwner: 'Bob',
+    alignmentCategory: 'aligned_on_time',
     pmDoAligned: true
   }, overrides)
 }
@@ -563,15 +579,46 @@ describe('buildComponentGroups', function () {
     var result = buildComponentGroups(groups)
     expect(result[0].features[0].fixVersions).toHaveLength(3)
   })
+
+  it('derives pmDoAligned from alignmentCategory (on-time and late count as aligned)', function () {
+    var feats = [
+      makeFeature({ key: 'A-1', alignmentCategory: 'aligned_on_time' }),
+      makeFeature({ key: 'A-2', alignmentCategory: 'aligned_late' }),
+      makeFeature({ key: 'A-3', alignmentCategory: 'tv_only' }),
+      makeFeature({ key: 'A-4', alignmentCategory: 'misaligned' })
+    ]
+    var result = buildComponentGroups([makeGroup('rhoai-3.5', 'Dash', feats)])
+    expect(result[0].notAlignedCount).toBe(2)
+    var byKey = {}
+    result[0].features.forEach(function(f) { byKey[f.key] = f })
+    expect(byKey['A-1'].pmDoAligned).toBe(true)
+    expect(byKey['A-2'].pmDoAligned).toBe(true)
+    expect(byKey['A-3'].pmDoAligned).toBe(false)
+    expect(byKey['A-4'].pmDoAligned).toBe(false)
+  })
+
+  it('keeps worst alignmentCategory when the same feature merges across groups', function () {
+    var early = makeFeature({ key: 'X-1', alignmentCategory: 'aligned_on_time' })
+    var worse = makeFeature({ key: 'X-1', alignmentCategory: 'misaligned' })
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dash', [early]),
+      makeGroup('rhoai-3.6', 'Dash', [worse])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].alignmentCategory).toBe('misaligned')
+    expect(result[0].features[0].pmDoAligned).toBe(false)
+    expect(result[0].notAlignedCount).toBe(1)
+  })
 })
 
 // ---------------------------------------------------------------------------
 // Sort logic — inlined from ComponentReleaseLoadTable.vue
 // ---------------------------------------------------------------------------
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'alignmentCategory', 'readiness', 'assignee', 'pmOwner', 'docs']
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
+var ALIGNMENT_SORT_ORDER = ALIGNMENT_CATEGORY_PRIORITY
 
 function getSortValue(feature, column) {
   if (column === 'key') return feature.key || ''
@@ -593,7 +640,10 @@ function getSortValue(feature, column) {
     return feature.targetVersions && feature.targetVersions.length > 0 ? feature.targetVersions[0] : ''
   }
   if (column === 'blocked') return feature.isBlocked ? 1 : 0
-  if (column === 'pmDoAligned') return feature.pmDoAligned ? 0 : 1
+  if (column === 'alignmentCategory') {
+    var ao = ALIGNMENT_SORT_ORDER[feature.alignmentCategory]
+    return ao !== undefined ? ao : 99
+  }
   if (column === 'readiness') {
     if (!feature.fpdor) return 99
     if (feature.fpdor.allApplicablePassed) return 0
@@ -936,7 +986,7 @@ describe('toggleSort', function () {
   })
 
   it('works for all valid sort columns', function () {
-    var columns = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
+    var columns = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'alignmentCategory', 'readiness', 'assignee', 'pmOwner', 'docs']
     for (var i = 0; i < columns.length; i++) {
       var result = toggleSort({ column: null, direction: 'asc' }, columns[i])
       expect(result.column).toBe(columns[i])

--- a/modules/releases/__tests__/client/plan/feature-readiness-drawer-model.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-drawer-model.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { toDrawerFeature } from '../../../client/plan/utils/feature-readiness-drawer-model.js'
+
+describe('toDrawerFeature', function() {
+  it('returns null for empty input', function() {
+    expect(toDrawerFeature(null)).toBeNull()
+    expect(toDrawerFeature(undefined)).toBeNull()
+  })
+
+  it('maps PM Hub summary/assignee/linkedRfe into drawer fields', function() {
+    var row = toDrawerFeature({
+      key: 'RHAISTRAT-1',
+      summary: 'From PM Hub',
+      assignee: 'Alice',
+      linkedRfeKey: 'RHOAIENG-9',
+      fixVersions: ['rhoai-3.6'],
+      alignmentCategory: 'tv_only',
+      fpdor: { items: [] }
+    })
+    expect(row.title).toBe('From PM Hub')
+    expect(row.deliveryOwner).toBe('Alice')
+    expect(row.sourceRfe).toBe('RHOAIENG-9')
+    expect(row.fixVersion).toBe('rhoai-3.6')
+    expect(row.alignmentCategory).toBe('tv_only')
+    expect(row.dataSource).toBe('jira')
+  })
+
+  it('preserves Features List title and dataSource', function() {
+    var row = toDrawerFeature({
+      key: 'RHAISTRAT-2',
+      title: 'Canonical title',
+      summary: 'ignored when title set',
+      deliveryOwner: 'Bob',
+      dataSource: 'health-pipeline',
+      alignmentCategory: 'aligned_on_time'
+    })
+    expect(row.title).toBe('Canonical title')
+    expect(row.deliveryOwner).toBe('Bob')
+    expect(row.dataSource).toBe('health-pipeline')
+    expect(row.alignmentCategory).toBe('aligned_on_time')
+  })
+})

--- a/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
@@ -81,7 +81,7 @@ describe('feature-readiness-export helpers', function() {
     it('applies readiness when enabled', function() {
       var filters = {
         outcome: [], targetVersion: [], fixVersion: [], component: [],
-        priority: [], team: [], product: [], fpdorItems: [], readiness: 'not-ready'
+        priority: [], team: [], product: [], fpdorItems: [], alignment: [], readiness: 'not-ready'
       }
       expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(false)
       expect(featureMatchesSharedFilters(
@@ -95,7 +95,7 @@ describe('feature-readiness-export helpers', function() {
     it('skips readiness when disabled for counts', function() {
       var filters = {
         outcome: [], targetVersion: [], fixVersion: [], component: [],
-        priority: [], team: [], product: [], fpdorItems: [], readiness: 'not-ready'
+        priority: [], team: [], product: [], fpdorItems: [], alignment: [], readiness: 'not-ready'
       }
       expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: false })).toBe(true)
     })
@@ -103,11 +103,38 @@ describe('feature-readiness-export helpers', function() {
     it('applies product and fpdor filters', function() {
       var filters = {
         outcome: [], targetVersion: [], fixVersion: [], component: [],
-        priority: [], team: [], product: ['RHOAI'], fpdorItems: ['Acceptance Criteria'], readiness: null
+        priority: [], team: [], product: ['RHOAI'], fpdorItems: ['Acceptance Criteria'],
+        alignment: [], readiness: null
       }
       expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(true)
       filters.product = ['RHAIIS']
       expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(false)
+    })
+
+    it('applies alignment filter', function() {
+      var filters = {
+        outcome: [], targetVersion: [], fixVersion: [], component: [],
+        priority: [], team: [], product: [], fpdorItems: [],
+        alignment: ['misaligned'], readiness: null
+      }
+      expect(featureMatchesSharedFilters(
+        Object.assign({}, base, { alignmentCategory: 'misaligned' }),
+        filters,
+        '',
+        { applyReadiness: true }
+      )).toBe(true)
+      expect(featureMatchesSharedFilters(
+        Object.assign({}, base, { alignmentCategory: 'aligned_on_time' }),
+        filters,
+        '',
+        { applyReadiness: true }
+      )).toBe(false)
+      expect(featureMatchesSharedFilters(
+        Object.assign({}, base, { alignmentCategory: null }),
+        filters,
+        '',
+        { applyReadiness: true }
+      )).toBe(false)
     })
   })
 })

--- a/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
@@ -21,6 +21,7 @@ function defaultModelValue() {
     team: [],
     product: [],
     fpdorItems: [],
+    alignment: [],
     readiness: null
   }
 }
@@ -258,6 +259,7 @@ describe('FeatureReadinessFilterBar', function() {
     expect(cleared.fixVersion).toEqual([])
     expect(cleared.component).toEqual([])
     expect(cleared.team).toEqual([])
+    expect(cleared.alignment).toEqual([])
   })
 
   // ─── Readiness single-select ───
@@ -366,6 +368,25 @@ describe('FeatureReadinessFilterBar', function() {
     })
     expect(wrapper.text()).toContain('All products')
     expect(wrapper.text()).toContain('Any failed item')
+    expect(wrapper.text()).toContain('All alignments')
+  })
+
+  it('emits alignment selection', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var alignBtn = findButtonByText(wrapper, 'All alignments')
+    expect(alignBtn.length).toBe(1)
+    await alignBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('On time')
+    expect(wrapper.text()).toContain('Misaligned')
+    var labels = wrapper.findAll('label').filter(function(l) { return l.text().includes('Misaligned') })
+    expect(labels.length).toBeGreaterThan(0)
+    await labels[0].find('input').setValue(true)
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted[emitted.length - 1][0].alignment).toContain('misaligned')
+    wrapper.unmount()
   })
 
   it('emits product selection', async function() {

--- a/modules/releases/__tests__/client/plan/feature-readiness-row.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-row.test.js
@@ -126,4 +126,15 @@ describe('FeatureReadinessRow fail chips', function() {
     expect(legacy.text()).toContain('Legacy')
     expect(legacy.text()).not.toContain('AI First')
   })
+
+  it('renders TV/FV Align chip from alignmentCategory', function() {
+    var wrapper = mountRow({
+      key: 'RHAISTRAT-7',
+      title: 'Aligned feature',
+      alignmentCategory: 'aligned_on_time',
+      fpdor: { passedCount: 17, applicableCount: 17, items: [] }
+    })
+    expect(wrapper.text()).toContain('On time')
+    expect(wrapper.find('[title*="Fix Version matches Target Version"]').exists()).toBe(true)
+  })
 })

--- a/modules/releases/__tests__/client/plan/feature-readiness-sort.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-sort.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for Features List column sorting helpers.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  getSortValue,
+  compareByDefaultScore,
+  sortFeatures,
+  nextSortState,
+  SORTABLE_COLUMNS
+} from '../../../client/plan/utils/feature-readiness-sort.js'
+
+function feature(overrides) {
+  return Object.assign({
+    key: 'RHAISTRAT-1',
+    title: 'Alpha',
+    bigRock: 'Outcome A',
+    targetVersions: ['3.6'],
+    fixVersion: 'rhoai-3.6',
+    components: ['Dashboard'],
+    team: 'Platform',
+    status: 'In Progress',
+    priority: 'Major',
+    recommendation: 'revise',
+    effectivePriorityScore: 50,
+    rubricTotal: 10,
+    rank: 5,
+    needsAttention: false,
+    fpdor: { items: [] },
+    confidence: 'ready'
+  }, overrides)
+}
+
+describe('feature-readiness-sort', function() {
+  it('lists expected sortable columns', function() {
+    expect(SORTABLE_COLUMNS).toContain('score')
+    expect(SORTABLE_COLUMNS).toContain('key')
+    expect(SORTABLE_COLUMNS).toContain('readiness')
+  })
+
+  it('getSortValue returns numeric score and priority order', function() {
+    expect(getSortValue(feature({ effectivePriorityScore: 72 }), 'score')).toBe(72)
+    expect(getSortValue(feature({ priority: 'Blocker' }), 'priority')).toBe(0)
+    expect(getSortValue(feature({ priority: 'Normal' }), 'priority')).toBe(3)
+  })
+
+  it('getSortValue ranks readiness by fail severity (ready = 0)', function() {
+    expect(getSortValue(feature({ fpdor: { items: [{ name: 'UXD', pass: true }] } }), 'readiness')).toBe(0)
+    expect(getSortValue(feature({
+      fpdor: { items: [{ name: 'Components', pass: false }] }
+    }), 'readiness')).toBe(4)
+  })
+
+  it('compareByDefaultScore prefers higher score then higher rubric', function() {
+    var a = feature({ effectivePriorityScore: 40, rubricTotal: 20, key: 'A' })
+    var b = feature({ effectivePriorityScore: 80, rubricTotal: 5, key: 'B' })
+    expect(compareByDefaultScore(a, b)).toBeGreaterThan(0)
+    var c = feature({ effectivePriorityScore: 50, rubricTotal: 1, key: 'C' })
+    var d = feature({ effectivePriorityScore: 50, rubricTotal: 9, key: 'D' })
+    expect(compareByDefaultScore(c, d)).toBeGreaterThan(0)
+  })
+
+  it('sortFeatures uses default score order when column is null', function() {
+    var sorted = sortFeatures([
+      feature({ key: 'Low', effectivePriorityScore: 10 }),
+      feature({ key: 'High', effectivePriorityScore: 90 }),
+      feature({ key: 'Mid', effectivePriorityScore: 40 })
+    ], { column: null, direction: 'asc' })
+    expect(sorted.map(function(f) { return f.key })).toEqual(['High', 'Mid', 'Low'])
+  })
+
+  it('sortFeatures sorts by key ascending', function() {
+    var sorted = sortFeatures([
+      feature({ key: 'C-3' }),
+      feature({ key: 'A-1' }),
+      feature({ key: 'B-2' })
+    ], { column: 'key', direction: 'asc' })
+    expect(sorted.map(function(f) { return f.key })).toEqual(['A-1', 'B-2', 'C-3'])
+  })
+
+  it('sortFeatures sorts by score descending', function() {
+    var sorted = sortFeatures([
+      feature({ key: 'Low', effectivePriorityScore: 10 }),
+      feature({ key: 'High', effectivePriorityScore: 90 })
+    ], { column: 'score', direction: 'desc' })
+    expect(sorted[0].key).toBe('High')
+  })
+
+  it('nextSortState uses desc-first for score then asc then clear', function() {
+    var s1 = nextSortState({ column: null, direction: 'asc' }, 'score')
+    expect(s1).toEqual({ column: 'score', direction: 'desc' })
+    var s2 = nextSortState(s1, 'score')
+    expect(s2).toEqual({ column: 'score', direction: 'asc' })
+    var s3 = nextSortState(s2, 'score')
+    expect(s3).toEqual({ column: null, direction: 'asc' })
+  })
+
+  it('nextSortState uses asc-first for title', function() {
+    var s1 = nextSortState({ column: null, direction: 'asc' }, 'title')
+    expect(s1).toEqual({ column: 'title', direction: 'asc' })
+    var s2 = nextSortState(s1, 'title')
+    expect(s2).toEqual({ column: 'title', direction: 'desc' })
+    var s3 = nextSortState(s2, 'title')
+    expect(s3).toEqual({ column: null, direction: 'asc' })
+  })
+})

--- a/modules/releases/__tests__/client/plan/feature-readiness-sort.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-sort.test.js
@@ -36,12 +36,19 @@ describe('feature-readiness-sort', function() {
     expect(SORTABLE_COLUMNS).toContain('score')
     expect(SORTABLE_COLUMNS).toContain('key')
     expect(SORTABLE_COLUMNS).toContain('readiness')
+    expect(SORTABLE_COLUMNS).toContain('alignment')
   })
 
   it('getSortValue returns numeric score and priority order', function() {
     expect(getSortValue(feature({ effectivePriorityScore: 72 }), 'score')).toBe(72)
     expect(getSortValue(feature({ priority: 'Blocker' }), 'priority')).toBe(0)
     expect(getSortValue(feature({ priority: 'Normal' }), 'priority')).toBe(3)
+  })
+
+  it('getSortValue ranks alignment categories best-to-worst', function() {
+    expect(getSortValue(feature({ alignmentCategory: 'aligned_on_time' }), 'alignment')).toBe(0)
+    expect(getSortValue(feature({ alignmentCategory: 'misaligned' }), 'alignment')).toBe(4)
+    expect(getSortValue(feature({ alignmentCategory: null }), 'alignment')).toBe(99)
   })
 
   it('getSortValue ranks readiness by fail severity (ready = 0)', function() {
@@ -84,6 +91,15 @@ describe('feature-readiness-sort', function() {
       feature({ key: 'High', effectivePriorityScore: 90 })
     ], { column: 'score', direction: 'desc' })
     expect(sorted[0].key).toBe('High')
+  })
+
+  it('sortFeatures sorts by alignment ascending (best first)', function() {
+    var sorted = sortFeatures([
+      feature({ key: 'Bad', alignmentCategory: 'misaligned' }),
+      feature({ key: 'Good', alignmentCategory: 'aligned_on_time' }),
+      feature({ key: 'Late', alignmentCategory: 'aligned_late' })
+    ], { column: 'alignment', direction: 'asc' })
+    expect(sorted.map(function(f) { return f.key })).toEqual(['Good', 'Late', 'Bad'])
   })
 
   it('nextSortState uses desc-first for score then asc then clear', function() {

--- a/modules/releases/__tests__/client/plan/features-list-filter-storage.test.js
+++ b/modules/releases/__tests__/client/plan/features-list-filter-storage.test.js
@@ -41,6 +41,24 @@ describe('features-list-filter-storage', function() {
     expect(restored.filters.fpdorItems).toEqual(['Child epics'])
     expect(restored.filters.readiness).toBe('not-ready')
     expect(restored.filters.fixVersion).toEqual([])
+    expect(restored.filters.alignment).toEqual([])
+  })
+
+  it('round-trips alignment filter', function() {
+    saveFeaturesListFilters({
+      outcome: [],
+      targetVersion: [],
+      fixVersion: [],
+      component: [],
+      priority: [],
+      team: [],
+      product: [],
+      fpdorItems: [],
+      alignment: ['misaligned', 'tv_only'],
+      readiness: null
+    }, '')
+    var restored = restoreFeaturesListFilters()
+    expect(restored.filters.alignment).toEqual(['misaligned', 'tv_only'])
   })
 
   it('ignores non-array filter values', function() {

--- a/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
@@ -76,6 +76,7 @@ describe('PM Hub feature slide tray', function() {
     var drawerFeature = Object.assign({}, feature, {
       fixVersion: null,
       deliveryOwner: feature.assignee,
+      alignmentCategory: 'tv_only',
       dataSource: 'pm-hub'
     })
 
@@ -96,6 +97,8 @@ describe('PM Hub feature slide tray', function() {
     expect(wrapper.text()).toContain('FPDoR Readiness')
     expect(wrapper.text()).toContain('Target Version')
     expect(wrapper.text()).toContain('RICE')
+    expect(wrapper.text()).toContain('TV only')
+    expect(wrapper.text()).toContain('TV/FV Align')
     // No empty AI review chrome for PM Hub rows without review meta
     expect(wrapper.text()).not.toContain('Awaiting Sign-off')
     expect(wrapper.text()).toContain('Jira')

--- a/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
+++ b/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
@@ -1,0 +1,29 @@
+/**
+ * Client display helpers for TV/FV alignment categories.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  worseAlignmentCategory,
+  isAlignedCategory,
+  alignmentCategoryLabel,
+  alignmentCategoryChipClass
+} from '../../../client/plan/utils/tv-fv-alignment-display.js'
+
+describe('tv-fv-alignment-display', function() {
+  it('picks worst category across merges', function() {
+    expect(worseAlignmentCategory('aligned_on_time', 'misaligned')).toBe('misaligned')
+    expect(worseAlignmentCategory('tv_only', 'aligned_late')).toBe('tv_only')
+  })
+
+  it('treats on-time and late as aligned', function() {
+    expect(isAlignedCategory('aligned_on_time')).toBe(true)
+    expect(isAlignedCategory('aligned_late')).toBe(true)
+    expect(isAlignedCategory('misaligned')).toBe(false)
+  })
+
+  it('labels and chip classes are defined for all categories', function() {
+    expect(alignmentCategoryLabel('fv_only')).toBe('FV only')
+    expect(alignmentCategoryChipClass('aligned_on_time')).toContain('emerald')
+    expect(alignmentCategoryChipClass('misaligned')).toContain('red')
+  })
+})

--- a/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
+++ b/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
@@ -6,7 +6,10 @@ import {
   worseAlignmentCategory,
   isAlignedCategory,
   alignmentCategoryLabel,
-  alignmentCategoryChipClass
+  alignmentCategoryHelp,
+  alignmentCategoryChipClass,
+  ALIGNMENT_CATEGORY_LABELS,
+  ALIGNMENT_CATEGORY_HELP
 } from '../../../client/plan/utils/tv-fv-alignment-display.js'
 
 describe('tv-fv-alignment-display', function() {
@@ -15,15 +18,41 @@ describe('tv-fv-alignment-display', function() {
     expect(worseAlignmentCategory('tv_only', 'aligned_late')).toBe('tv_only')
   })
 
-  it('treats on-time and late as aligned', function() {
+  it('treats on-time and late as aligned (Not Aligned KPI excludes both)', function() {
     expect(isAlignedCategory('aligned_on_time')).toBe(true)
     expect(isAlignedCategory('aligned_late')).toBe(true)
     expect(isAlignedCategory('misaligned')).toBe(false)
+    expect(isAlignedCategory('tv_only')).toBe(false)
+    expect(isAlignedCategory('fv_only')).toBe(false)
   })
 
-  it('labels and chip classes are defined for all categories', function() {
+  it('labels match Delta language (On time, not Yes/No)', function() {
+    expect(alignmentCategoryLabel('aligned_on_time')).toBe('On time')
+    expect(alignmentCategoryLabel('aligned_late')).toBe('Late')
+    expect(alignmentCategoryLabel('misaligned')).toBe('Misaligned')
+    expect(alignmentCategoryLabel('tv_only')).toBe('TV only')
     expect(alignmentCategoryLabel('fv_only')).toBe('FV only')
+    expect(Object.keys(ALIGNMENT_CATEGORY_LABELS).sort()).toEqual([
+      'aligned_late',
+      'aligned_on_time',
+      'fv_only',
+      'misaligned',
+      'tv_only'
+    ].sort())
+  })
+
+  it('help text is defined for every category', function() {
+    Object.keys(ALIGNMENT_CATEGORY_HELP).forEach(function(cat) {
+      expect(alignmentCategoryHelp(cat).length).toBeGreaterThan(10)
+    })
+    expect(alignmentCategoryHelp('aligned_on_time')).toMatch(/Fix Version matches Target Version|ships earlier/i)
+  })
+
+  it('chip classes are defined for all categories', function() {
     expect(alignmentCategoryChipClass('aligned_on_time')).toContain('emerald')
+    expect(alignmentCategoryChipClass('aligned_late')).toContain('amber')
     expect(alignmentCategoryChipClass('misaligned')).toContain('red')
+    expect(alignmentCategoryChipClass('tv_only')).toContain('blue')
+    expect(alignmentCategoryChipClass('fv_only')).toContain('violet')
   })
 })

--- a/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
+++ b/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
@@ -207,3 +207,25 @@ describe('extractTargetVersions', function () {
     expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
   })
 })
+
+describe('attachAlignment', function () {
+  var attachAlignment = require('../../../server/pm-hub/routes').attachAlignment
+
+  it('marks early delivery as aligned_on_time for the TV release', function () {
+    var base = buildFeatureObj({
+      key: 'X-1',
+      fixVersions: ['rhoai-3.5'],
+      summary: 'Early'
+    }, ['rhoai-3.6'])
+    var row = attachAlignment(Object.assign({}, base), 'rhoai-3.6', {})
+    expect(row.alignmentCategory).toBe('aligned_on_time')
+    expect(row.pmDoAligned).toBe(true)
+  })
+
+  it('marks TV-only as not aligned', function () {
+    var base = buildFeatureObj({ key: 'X-2', fixVersions: [], summary: 'TV' }, ['rhoai-3.6'])
+    var row = attachAlignment(Object.assign({}, base), 'rhoai-3.6', {})
+    expect(row.alignmentCategory).toBe('tv_only')
+    expect(row.pmDoAligned).toBe(false)
+  })
+})

--- a/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
+++ b/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for PM Hub canonical Component Release Load grouping.
+ */
+import { describe, it, expect } from 'vitest'
+
+const {
+  canonicalToLoadRow,
+  buildComponentReleaseLoadGroups,
+  featureMatchesComponents
+} = require('../../../server/pm-hub/canonical-load')
+
+function feature(overrides) {
+  return Object.assign({
+    key: 'RHAISTRAT-1',
+    title: 'Test',
+    status: 'In Progress',
+    components: ['Dashboard'],
+    targetVersions: ['rhoai-3.6'],
+    fixVersions: ['rhoai-3.6'],
+    fixVersion: 'rhoai-3.6',
+    fpdor: { items: [], allApplicablePassed: true },
+    isAiFirst: false,
+    confidence: 'ready',
+    isBlocked: false,
+    blockedBy: [],
+    labels: []
+  }, overrides)
+}
+
+describe('canonical-load', function() {
+  it('maps canonical feature to load row', function() {
+    var row = canonicalToLoadRow(feature({
+      deliveryOwner: 'Alice',
+      pmOwner: 'Bob',
+      colorStatus: 'Green'
+    }))
+    expect(row.key).toBe('RHAISTRAT-1')
+    expect(row.summary).toBe('Test')
+    expect(row.assignee).toBe('Alice')
+    expect(row.pmOwner).toBe('Bob')
+    expect(row.colorStatus).toBe('Green')
+    expect(row.fixVersions).toEqual(['rhoai-3.6'])
+    expect(row.fpdor).toBeTruthy()
+  })
+
+  it('filters by component', function() {
+    expect(featureMatchesComponents(feature(), ['Dashboard'])).toBe(true)
+    expect(featureMatchesComponents(feature(), ['Other'])).toBe(false)
+  })
+
+  it('groups requested and committed under matching version', function() {
+    var built = buildComponentReleaseLoadGroups([
+      feature({ key: 'A-1' }),
+      feature({
+        key: 'A-2',
+        targetVersions: ['rhoai-3.6'],
+        fixVersions: [],
+        fixVersion: null
+      })
+    ], {
+      components: ['Dashboard'],
+      versions: ['rhoai-3.6'],
+      releaseDates: {}
+    })
+    expect(built.groups.length).toBe(1)
+    expect(built.groups[0].version).toBe('rhoai-3.6')
+    var comp = built.groups[0].components[0]
+    expect(comp.requestedCount).toBe(2)
+    expect(comp.committedCount).toBe(1)
+    expect(comp.committedFeatures[0].alignmentCategory).toBe('aligned_on_time')
+    expect(comp.requestedFeatures.find(function(f) { return f.key === 'A-2' }).alignmentCategory).toBe('tv_only')
+  })
+
+  it('marks early delivery committed as aligned_on_time for TV release', function() {
+    var built = buildComponentReleaseLoadGroups([
+      feature({
+        key: 'EARLY-1',
+        targetVersions: ['rhoai-3.6'],
+        fixVersions: ['rhoai-3.5'],
+        fixVersion: 'rhoai-3.5'
+      })
+    ], {
+      components: ['Dashboard'],
+      versions: ['rhoai-3.6', 'rhoai-3.5'],
+      releaseDates: {}
+    })
+    var tvGroup = built.groups.find(function(g) { return g.version === 'rhoai-3.6' })
+    expect(tvGroup).toBeTruthy()
+    var row = tvGroup.components[0].requestedFeatures[0]
+    expect(row.alignmentCategory).toBe('aligned_on_time')
+    expect(row.pmDoAligned).toBe(true)
+  })
+})

--- a/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
+++ b/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
@@ -32,7 +32,11 @@ describe('canonical-load', function() {
     var row = canonicalToLoadRow(feature({
       deliveryOwner: 'Alice',
       pmOwner: 'Bob',
-      colorStatus: 'Green'
+      colorStatus: 'Green',
+      bigRock: 'Outcome A',
+      team: 'Platform',
+      effectivePriorityScore: 72,
+      priorityScoreBreakdown: { rice: 10 }
     }))
     expect(row.key).toBe('RHAISTRAT-1')
     expect(row.summary).toBe('Test')
@@ -41,6 +45,10 @@ describe('canonical-load', function() {
     expect(row.colorStatus).toBe('Green')
     expect(row.fixVersions).toEqual(['rhoai-3.6'])
     expect(row.fpdor).toBeTruthy()
+    expect(row.bigRock).toBe('Outcome A')
+    expect(row.team).toBe('Platform')
+    expect(row.effectivePriorityScore).toBe(72)
+    expect(row.priorityScoreBreakdown).toEqual({ rice: 10 })
   })
 
   it('filters by component', function() {

--- a/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
+++ b/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
@@ -79,7 +79,7 @@ describe('canonical-load', function() {
     expect(comp.requestedFeatures.find(function(f) { return f.key === 'A-2' }).alignmentCategory).toBe('tv_only')
   })
 
-  it('marks early delivery committed as aligned_on_time for TV release', function() {
+  it('marks early delivery as aligned_on_time for TV release', function() {
     var built = buildComponentReleaseLoadGroups([
       feature({
         key: 'EARLY-1',
@@ -97,5 +97,24 @@ describe('canonical-load', function() {
     var row = tvGroup.components[0].requestedFeatures[0]
     expect(row.alignmentCategory).toBe('aligned_on_time')
     expect(row.pmDoAligned).toBe(true)
+  })
+
+  it('counts FV-only (no TV) as committed when Fix Version is in scope', function() {
+    var built = buildComponentReleaseLoadGroups([
+      feature({
+        key: 'FV-ONLY-1',
+        targetVersions: [],
+        fixVersions: ['rhoai-3.6'],
+        fixVersion: 'rhoai-3.6'
+      })
+    ], {
+      components: ['Dashboard'],
+      versions: ['rhoai-3.6'],
+      releaseDates: {}
+    })
+    var comp = built.groups[0].components[0]
+    expect(comp.requestedCount).toBe(0)
+    expect(comp.committedCount).toBe(1)
+    expect(comp.committedFeatures[0].key).toBe('FV-ONLY-1')
   })
 })

--- a/modules/releases/__tests__/server/pm-hub/committed-definition.test.js
+++ b/modules/releases/__tests__/server/pm-hub/committed-definition.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 
 const {
   sameReleaseCycle,
-  tvSupportsCommittedFixVersion,
   filterCommittedFixVersions
 } = require('../../../server/pm-hub/committed-definition')
 
@@ -19,93 +18,39 @@ describe('sameReleaseCycle', function () {
   })
 })
 
-describe('tvSupportsCommittedFixVersion / filterCommittedFixVersions', function () {
-  it('exact TV=FV match → committed', function () {
-    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.6.EA1'])).toBe(true)
-    expect(filterCommittedFixVersions(['rhoai-3.6.EA1'], ['rhoai-3.6.EA1'])).toEqual(['rhoai-3.6.EA1'])
-  })
-
-  it('semantic TV=FV match across naming styles → committed', function () {
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['3.6 EA1 RHOAI RELEASE'])
-    ).toBe(true)
-  })
-
-  it('early delivery (FV EA1, TV EA2 same cycle) → committed', function () {
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.6.EA2'])
-    ).toBe(true)
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['3.6 EA2 RHOAI RELEASE'])
-    ).toBe(true)
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA2', ['rhoai-3.6'])
-    ).toBe(true)
-  })
-
-  it('FV-only (no TV) → not committed', function () {
-    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', [])).toBe(false)
-    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', null)).toBe(false)
-    expect(filterCommittedFixVersions(['rhoai-3.6.EA1'], [])).toEqual([])
-  })
-
-  it('late (FV EA2, TV EA1 same cycle) → not committed', function () {
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA2', ['rhoai-3.6.EA1'])
-    ).toBe(false)
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6', ['rhoai-3.6.EA1'])
-    ).toBe(false)
-  })
-
-  it('cross-cycle / cross-product → not committed', function () {
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.5.EA2'])
-    ).toBe(false)
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhelai-3.6.EA2'])
-    ).toBe(false)
-  })
-
-  it('unparseable TV that cannot establish same-cycle → not committed', function () {
-    expect(
-      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['Totally Unknown Version'])
-    ).toBe(false)
-  })
-
-  it('identical unparseable TV and FV strings → committed (exact match)', function () {
-    expect(
-      tvSupportsCommittedFixVersion('Custom Label X', ['Custom Label X'])
-    ).toBe(true)
-  })
-
-  it('filters matching FVs to only those supported by TV', function () {
-    var matchingFv = ['rhoai-3.6.EA1', 'rhoai-3.6.EA2']
-    // TV EA1 supports EA1 match, but not EA2 (late)
-    expect(filterCommittedFixVersions(matchingFv, ['rhoai-3.6.EA1'])).toEqual([
-      'rhoai-3.6.EA1'
+describe('filterCommittedFixVersions (FV-in-scope only)', function () {
+  it('returns Fix Versions in scope regardless of Target Version', function () {
+    expect(filterCommittedFixVersions(['rhoai-3.6.EA2'], ['rhoai-3.6.EA2'])).toEqual([
+      'rhoai-3.6.EA2'
     ])
-    // TV EA2 supports EA1 (early) and EA2 (match)
-    expect(filterCommittedFixVersions(matchingFv, ['rhoai-3.6.EA2'])).toEqual([
+    expect(filterCommittedFixVersions(['rhoai-3.6.EA2'], [])).toEqual(['rhoai-3.6.EA2'])
+    expect(filterCommittedFixVersions(['rhoai-3.6.EA2'], null)).toEqual(['rhoai-3.6.EA2'])
+  })
+
+  it('keeps FV-only (no TV) as committed', function () {
+    expect(filterCommittedFixVersions(['3.6 EA2 RHOAI RELEASE'], [])).toEqual([
+      '3.6 EA2 RHOAI RELEASE'
+    ])
+  })
+
+  it('keeps late / cross-cycle FV when it is in the selected matching set', function () {
+    // Caller already restricted matchingFv to selected scope; we do not re-filter by TV.
+    expect(
+      filterCommittedFixVersions(['rhoai-3.6.EA2'], ['rhoai-3.6.EA1'])
+    ).toEqual(['rhoai-3.6.EA2'])
+  })
+
+  it('returns empty when no matching Fix Versions', function () {
+    expect(filterCommittedFixVersions([], ['rhoai-3.6.EA1'])).toEqual([])
+    expect(filterCommittedFixVersions(null, ['rhoai-3.6.EA1'])).toEqual([])
+  })
+
+  it('returns a copy of all matching FVs', function () {
+    var matchingFv = ['rhoai-3.6.EA1', 'rhoai-3.6.EA2']
+    expect(filterCommittedFixVersions(matchingFv, [])).toEqual([
       'rhoai-3.6.EA1',
       'rhoai-3.6.EA2'
     ])
-  })
-})
-
-describe('Requested unchanged (caller contract)', function () {
-  // Requested is TV ∩ selected scope — not altered by committed helpers.
-  // Document the independence: FV-only helpers never consume matchingTv.
-  it('committed helpers ignore selected-scope TV list; use all issue TVs', function () {
-    // Selected scope is EA1 only; TV is EA2 (not in scope) but still qualifies early delivery
-    var matchingFv = ['rhoai-3.6.EA1']
-    var allTvOnIssue = ['rhoai-3.6.EA2']
-    expect(filterCommittedFixVersions(matchingFv, allTvOnIssue)).toEqual([
-      'rhoai-3.6.EA1'
-    ])
-  })
-
-  it('TV-only (no matching FV) yields empty committed list', function () {
-    expect(filterCommittedFixVersions([], ['rhoai-3.6.EA1'])).toEqual([])
+    expect(filterCommittedFixVersions(matchingFv, [])).not.toBe(matchingFv)
   })
 })

--- a/modules/releases/__tests__/server/tv-fv-delta/alignment.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/alignment.test.js
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for shared TV/FV alignment helpers used by PM Hub.
+ */
+import { describe, it, expect } from 'vitest'
+
+const {
+  classifyForRelease,
+  isAlignedCategory,
+  categoryLabel,
+  worstCategory
+} = require('../../../server/tv-fv-delta/alignment')
+
+describe('tv-fv-delta/alignment (PM Hub shared)', function() {
+  it('classifies exact TV/FV match as aligned_on_time', function() {
+    var cat = classifyForRelease(['rhoai-3.6'], ['rhoai-3.6'], 'rhoai-3.6', {})
+    expect(cat).toBe('aligned_on_time')
+    expect(isAlignedCategory(cat)).toBe(true)
+  })
+
+  it('classifies early delivery (FV before TV) as aligned_on_time for the TV release', function() {
+    var cat = classifyForRelease(['rhoai-3.6'], ['rhoai-3.5'], 'rhoai-3.6', {})
+    expect(cat).toBe('aligned_on_time')
+    expect(isAlignedCategory(cat)).toBe(true)
+  })
+
+  it('classifies TV-only as tv_only', function() {
+    var cat = classifyForRelease(['rhoai-3.6'], [], 'rhoai-3.6', {})
+    expect(cat).toBe('tv_only')
+    expect(isAlignedCategory(cat)).toBe(false)
+  })
+
+  it('classifies FV-only as fv_only', function() {
+    var cat = classifyForRelease([], ['rhoai-3.6'], 'rhoai-3.6', {})
+    expect(cat).toBe('fv_only')
+    expect(isAlignedCategory(cat)).toBe(false)
+  })
+
+  it('classifies unfrozen slip as misaligned', function() {
+    var cat = classifyForRelease(['rhoai-3.5'], ['rhoai-3.6'], 'rhoai-3.5', {})
+    expect(cat).toBe('misaligned')
+  })
+
+  it('classifies frozen slip as aligned_late', function() {
+    var releaseDates = {
+      'rhoai 3 5': { planningFreezeDate: '2020-01-01', dueDate: '2020-02-01' }
+    }
+    var cat = classifyForRelease(['rhoai-3.5'], ['rhoai-3.6'], 'rhoai-3.5', releaseDates)
+    expect(cat).toBe('aligned_late')
+    expect(isAlignedCategory(cat)).toBe(true)
+  })
+
+  it('returns null when release is not on TV or FV', function() {
+    expect(classifyForRelease(['rhoai-3.5'], ['rhoai-3.5'], 'rhoai-3.6', {})).toBeNull()
+  })
+
+  it('labels and worstCategory helpers work', function() {
+    expect(categoryLabel('aligned_on_time')).toBe('On time')
+    expect(worstCategory(['aligned_on_time', 'misaligned', 'tv_only'])).toBe('misaligned')
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -21,20 +21,10 @@ import {
 const props = defineProps({
   groups: { type: Array, default: () => [] },
   componentLeads: { type: Object, default: () => ({}) },
-  velocity: { type: Object, default: null },
   initialSort: { type: Object, default: () => ({ column: null, direction: 'asc' }) }
 })
 
 var emit = defineEmits(['sort-changed', 'select'])
-
-function getComponentVelocity(componentName) {
-  if (!props.velocity || !props.velocity.components) return null
-  var comps = props.velocity.components
-  for (var i = 0; i < comps.length; i++) {
-    if (comps[i].component === componentName) return comps[i]
-  }
-  return null
-}
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
 var MAX_VISIBLE_FAIL_CHIPS = 2
@@ -375,11 +365,6 @@ defineExpose({ expandAll, collapseAll })
                     ? 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300'
                     : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
                 >{{ comp.notAlignedCount }} not aligned</span>
-                <span
-                  v-if="getComponentVelocity(comp.component)"
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
-                  :title="getComponentVelocity(comp.component).isPartialYear ? 'Less than a year of data' : ''"
-                >{{ getComponentVelocity(comp.component).avgPerRelease }} avg/rel<span v-if="getComponentVelocity(comp.component).isPartialYear" class="ml-0.5 text-gray-400 dark:text-gray-500">*</span></span>
               </div>
               <div v-if="getLeads(comp.component)" class="flex items-center gap-5 mt-2 ml-[38px]">
                 <div v-if="getLeads(comp.component).pmLead" class="flex items-center gap-1.5">

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -17,6 +17,13 @@ import {
   docsRequiredTitle,
   docsRequiredChipClass
 } from '../utils/docs-required-display.js'
+import {
+  alignmentCategoryLabel,
+  alignmentCategoryHelp,
+  alignmentCategoryChipClass,
+  worseAlignmentCategory,
+  isAlignedCategory
+} from '../utils/tv-fv-alignment-display.js'
 
 const props = defineProps({
   groups: { type: Array, default: () => [] },
@@ -38,10 +45,17 @@ var expandedComponents = reactive({})
 
 // ═══ SORT STATE ═══
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'alignmentCategory', 'readiness', 'assignee', 'pmOwner', 'docs']
 
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
+var ALIGNMENT_SORT_ORDER = {
+  aligned_on_time: 0,
+  aligned_late: 1,
+  fv_only: 2,
+  tv_only: 3,
+  misaligned: 4
+}
 
 var sortState = reactive({
   column: SORT_COLUMNS.indexOf(props.initialSort.column) !== -1 ? props.initialSort.column : null,
@@ -84,7 +98,10 @@ function getSortValue(feature, column) {
     return feature.targetVersions && feature.targetVersions.length > 0 ? feature.targetVersions[0] : ''
   }
   if (column === 'blocked') return feature.isBlocked ? 1 : 0
-  if (column === 'pmDoAligned') return feature.pmDoAligned ? 0 : 1
+  if (column === 'alignmentCategory') {
+    var ao = ALIGNMENT_SORT_ORDER[feature.alignmentCategory]
+    return ao !== undefined ? ao : 99
+  }
   if (column === 'readiness') {
     if (!feature.fpdor) return 99
     if (feature.fpdor.allApplicablePassed) return 0
@@ -235,7 +252,10 @@ var componentGroups = computed(function() {
             priority: feat.priority,
             isBlocked: feat.isBlocked,
             blockedBy: feat.blockedBy || [],
-            pmDoAligned: !!feat.pmDoAligned,
+            alignmentCategory: feat.alignmentCategory || null,
+            pmDoAligned: feat.alignmentCategory
+              ? isAlignedCategory(feat.alignmentCategory)
+              : !!feat.pmDoAligned,
             fpdor: feat.fpdor || null,
             confidence: feat.confidence || null,
             isAiFirst: !!feat.isAiFirst,
@@ -256,6 +276,13 @@ var componentGroups = computed(function() {
         }
 
         var entry = cg.features[feat.key]
+        entry.alignmentCategory = worseAlignmentCategory(
+          entry.alignmentCategory,
+          feat.alignmentCategory || null
+        )
+        entry.pmDoAligned = entry.alignmentCategory
+          ? isAlignedCategory(entry.alignmentCategory)
+          : !!entry.pmDoAligned
         var product = extractProduct(version)
         if (entry.products.indexOf(product) === -1) {
           entry.products.push(product)
@@ -421,8 +448,8 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('blocked')">
               <span class="inline-flex items-center gap-1 justify-center">Blocked<SortArrow :direction="sortIcon('blocked')" /></span>
             </th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('pmDoAligned')" title="Yes when Target Version and Fix Version match">
-              <span class="inline-flex items-center gap-1 justify-center">PM/DO Aligned<SortArrow :direction="sortIcon('pmDoAligned')" /></span>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('alignmentCategory')" title="TV vs FV Delta category for this release (same rules as Reports → TV vs FV Delta)">
+              <span class="inline-flex items-center gap-1 justify-center">TV/FV Align<SortArrow :direction="sortIcon('alignmentCategory')" /></span>
             </th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-[10rem] cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('readiness')">
               <span class="inline-flex items-center gap-1">Readiness<SortArrow :direction="sortIcon('readiness')" /></span>
@@ -539,13 +566,9 @@ defineExpose({ expandAll, collapseAll })
               <td class="px-3 py-2.5 text-center">
                 <span
                   class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                  :class="feature.pmDoAligned
-                    ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
-                    : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'"
-                  :title="feature.pmDoAligned
-                    ? 'Target Version and Fix Version match'
-                    : 'Target Version and Fix Version missing or do not match'"
-                >{{ feature.pmDoAligned ? 'Yes' : 'No' }}</span>
+                  :class="alignmentCategoryChipClass(feature.alignmentCategory)"
+                  :title="alignmentCategoryHelp(feature.alignmentCategory)"
+                >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
               </td>
               <td class="px-3 py-2.5">
                 <div v-if="feature.fpdor" class="flex flex-wrap items-center gap-1 max-w-[14rem]">

--- a/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
@@ -8,6 +8,11 @@ import {
   pathChipClass,
   pathChipTitle
 } from '../utils/fpdor-severity.js'
+import {
+  alignmentCategoryLabel,
+  alignmentCategoryHelp,
+  alignmentCategoryChipClass
+} from '../utils/tv-fv-alignment-display.js'
 
 const props = defineProps({
   feature: { type: Object, default: null },
@@ -48,7 +53,7 @@ const fixVersionDisplay = computed(function() {
 const dataSourceLabel = computed(function() {
   var src = props.feature && props.feature.dataSource
   if (src === 'health-pipeline') return 'Health Pipeline'
-  if (src === 'pm-hub' || src === 'jira') return 'Jira'
+  if (src === 'pm-hub' || src === 'jira' || src === 'canonical') return 'Jira'
   return 'Strategy Creator'
 })
 
@@ -323,6 +328,12 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               :class="pathChipClass(feature)"
               :title="pathChipTitle(feature)"
             >{{ pathLabel(feature) }}</span>
+            <span
+              v-if="feature.alignmentCategory"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
+              :class="alignmentCategoryChipClass(feature.alignmentCategory)"
+              :title="alignmentCategoryHelp(feature.alignmentCategory)"
+            >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
 
             <!-- Health pipeline badges -->
             <template v-if="isHealthPipeline">
@@ -606,6 +617,17 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
 
               <dt class="text-gray-400 dark:text-gray-500">Fix Version</dt>
               <dd class="font-mono text-gray-700 dark:text-gray-300">{{ fixVersionDisplay || '—' }}</dd>
+
+              <dt class="text-gray-400 dark:text-gray-500">TV/FV Align</dt>
+              <dd>
+                <span
+                  v-if="feature.alignmentCategory"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                  :class="alignmentCategoryChipClass(feature.alignmentCategory)"
+                  :title="alignmentCategoryHelp(feature.alignmentCategory)"
+                >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
+                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+              </dd>
 
               <dt class="text-gray-400 dark:text-gray-500 self-start">Components</dt>
               <dd>

--- a/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
@@ -1,6 +1,10 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { FPDOR_ITEM_NAMES, KNOWN_PRODUCTS } from '../utils/feature-readiness-export.js'
+import {
+  ALIGNMENT_CATEGORY_LABELS,
+  alignmentCategoryLabel
+} from '../utils/tv-fv-alignment-display.js'
 
 const props = defineProps({
   filterMeta: {
@@ -18,6 +22,7 @@ const props = defineProps({
       team: [],
       product: [],
       fpdorItems: [],
+      alignment: [],
       readiness: null
     })
   }
@@ -33,6 +38,7 @@ const teamOpen = ref(false)
 const priorityOpen = ref(false)
 const productOpen = ref(false)
 const fpdorItemsOpen = ref(false)
+const alignmentOpen = ref(false)
 
 const outcomeRef = ref(null)
 const targetVersionRef = ref(null)
@@ -42,6 +48,7 @@ const teamRef = ref(null)
 const priorityRef = ref(null)
 const productRef = ref(null)
 const fpdorItemsRef = ref(null)
+const alignmentRef = ref(null)
 
 function closeAll() {
   outcomeOpen.value = false
@@ -52,6 +59,7 @@ function closeAll() {
   priorityOpen.value = false
   productOpen.value = false
   fpdorItemsOpen.value = false
+  alignmentOpen.value = false
 }
 
 function toggleDropdown(name) {
@@ -63,7 +71,8 @@ function toggleDropdown(name) {
     team: teamOpen,
     priority: priorityOpen,
     product: productOpen,
-    fpdorItems: fpdorItemsOpen
+    fpdorItems: fpdorItemsOpen,
+    alignment: alignmentOpen
   }
   var wasOpen = map[name].value
   closeAll()
@@ -71,7 +80,7 @@ function toggleDropdown(name) {
 }
 
 function handleClickOutside(event) {
-  var refs = [outcomeRef, targetVersionRef, fixVersionRef, componentRef, teamRef, priorityRef, productRef, fpdorItemsRef]
+  var refs = [outcomeRef, targetVersionRef, fixVersionRef, componentRef, teamRef, priorityRef, productRef, fpdorItemsRef, alignmentRef]
   for (var i = 0; i < refs.length; i++) {
     if (refs[i].value && refs[i].value.contains(event.target)) return
   }
@@ -103,6 +112,7 @@ function clearFilters() {
     team: [],
     product: [],
     fpdorItems: [],
+    alignment: [],
     readiness: null
   })
 }
@@ -118,6 +128,7 @@ const hasActiveFilters = computed(() => {
     (f.team && f.team.length) ||
     (f.product && f.product.length) ||
     (f.fpdorItems && f.fpdorItems.length) ||
+    (f.alignment && f.alignment.length) ||
     f.readiness
   )
 })
@@ -125,6 +136,12 @@ const hasActiveFilters = computed(() => {
 function multiLabel(selected, allLabel) {
   if (!selected || selected.length === 0) return allLabel
   if (selected.length === 1) return selected[0]
+  return selected.length + ' selected'
+}
+
+function alignmentMultiLabel(selected) {
+  if (!selected || selected.length === 0) return 'All alignments'
+  if (selected.length === 1) return alignmentCategoryLabel(selected[0])
   return selected.length + ' selected'
 }
 
@@ -136,6 +153,7 @@ const priorities = computed(() => props.filterMeta.priorities || [])
 const teams = computed(() => props.filterMeta.teams || [])
 const products = KNOWN_PRODUCTS
 const fpdorItems = FPDOR_ITEM_NAMES
+const alignmentOptions = Object.keys(ALIGNMENT_CATEGORY_LABELS)
 
 const btnClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
 const btnActiveClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-primary-400 dark:border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
@@ -206,6 +224,23 @@ const optionClass = 'flex items-center gap-2 px-3 py-1.5 text-xs text-gray-900 d
           <label v-for="fv in fixVersions" :key="fv" :class="optionClass">
             <input type="checkbox" :checked="(modelValue.fixVersion || []).includes(fv)" @change="toggleValue('fixVersion', fv)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
             <span class="truncate">{{ fv }}</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <!-- TV/FV Align -->
+    <div class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">TV/FV Align</label>
+      <div ref="alignmentRef" class="relative">
+        <button type="button" @click="toggleDropdown('alignment')" @keydown.escape="alignmentOpen = false" :aria-expanded="alignmentOpen" aria-haspopup="listbox" :class="(modelValue.alignment || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ alignmentMultiLabel(modelValue.alignment) }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="alignmentOpen" role="group" :class="dropdownClass" @keydown.escape="alignmentOpen = false">
+          <label v-for="cat in alignmentOptions" :key="cat" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.alignment || []).includes(cat)" @change="toggleValue('alignment', cat)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ alignmentCategoryLabel(cat) }}</span>
           </label>
         </div>
       </div>

--- a/modules/releases/client/plan/components/FeatureReadinessRow.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessRow.vue
@@ -12,6 +12,11 @@ import {
   pathChipClass,
   pathChipTitle
 } from '../utils/fpdor-severity.js'
+import {
+  alignmentCategoryLabel,
+  alignmentCategoryHelp,
+  alignmentCategoryChipClass
+} from '../utils/tv-fv-alignment-display.js'
 
 var MAX_VISIBLE_FAIL_CHIPS = 3
 
@@ -217,6 +222,15 @@ var scoreBreakdown = computed(function() {
     <!-- Fix Version -->
     <td class="px-3 py-2.5 whitespace-nowrap">
       <span class="font-mono text-xs text-gray-700 dark:text-gray-300">{{ feature.fixVersion || '—' }}</span>
+    </td>
+
+    <!-- TV/FV Align -->
+    <td class="px-3 py-2.5 text-center whitespace-nowrap">
+      <span
+        class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
+        :class="alignmentCategoryChipClass(feature.alignmentCategory)"
+        :title="alignmentCategoryHelp(feature.alignmentCategory)"
+      >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
     </td>
 
     <!-- Components -->

--- a/modules/releases/client/plan/utils/feature-readiness-drawer-model.js
+++ b/modules/releases/client/plan/utils/feature-readiness-drawer-model.js
@@ -1,0 +1,19 @@
+/**
+ * Normalize Features List / PM Hub row shapes for FeatureReadinessDrawer.
+ */
+
+/**
+ * @param {object|null|undefined} feature
+ * @returns {object|null}
+ */
+export function toDrawerFeature(feature) {
+  if (!feature) return null
+  var fixVersions = Array.isArray(feature.fixVersions) ? feature.fixVersions : []
+  return Object.assign({}, feature, {
+    title: feature.title || feature.summary || '',
+    fixVersion: feature.fixVersion || (fixVersions.length ? fixVersions[0] : null),
+    deliveryOwner: feature.deliveryOwner || feature.assignee || null,
+    sourceRfe: feature.sourceRfe || feature.linkedRfeKey || null,
+    dataSource: feature.dataSource || 'jira'
+  })
+}

--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -1,5 +1,6 @@
 import { escapeCsv, triggerDownload } from './health-export.js'
 import { pathLabel } from './fpdor-severity.js'
+import { alignmentCategoryLabel } from './tv-fv-alignment-display.js'
 
 var FPDOR_CONFLUENCE_URL = 'https://redhat.atlassian.net/wiki/spaces/RHAI/pages/442958832/Planning+Phase+-+Definition+of+Ready+Definition+of+Done'
 
@@ -81,6 +82,7 @@ function exportFeatureReadinessCsv(features) {
       getter: function(f) { return (f.targetVersions || []).join('; ') }
     },
     { label: 'Fix Version', getter: function(f) { return f.fixVersion || '' } },
+    { label: 'TV/FV Align', getter: function(f) { return alignmentCategoryLabel(f.alignmentCategory) } },
     { label: 'Release Type', getter: function(f) { return f.releaseType || '' } },
     {
       label: 'Components',
@@ -125,6 +127,10 @@ function featureMatchesSharedFilters(feature, filterState, selectedVersion, opti
   if (f.team && f.team.length && f.team.indexOf(feature.team) === -1) return false
   if (f.product && f.product.length && !featureMatchesProduct(feature, f.product)) return false
   if (f.fpdorItems && f.fpdorItems.length && !featureFailsSelectedFpdorItems(feature, f.fpdorItems)) return false
+  if (f.alignment && f.alignment.length) {
+    var cat = feature.alignmentCategory || null
+    if (!cat || f.alignment.indexOf(cat) === -1) return false
+  }
   if (applyReadiness) {
     if (f.readiness === 'ready' && feature.confidence === 'not-ready') return false
     if (f.readiness === 'not-ready' && feature.confidence !== 'not-ready') return false

--- a/modules/releases/client/plan/utils/feature-readiness-sort.js
+++ b/modules/releases/client/plan/utils/feature-readiness-sort.js
@@ -27,6 +27,7 @@ export var SORTABLE_COLUMNS = [
   'outcome',
   'targetVersion',
   'fixVersion',
+  'alignment',
   'components',
   'team',
   'rubric',
@@ -64,6 +65,18 @@ export function getSortValue(feature, column) {
     return tvs.length > 0 ? String(tvs[0]).toLowerCase() : ''
   }
   if (column === 'fixVersion') return (feature.fixVersion || '').toLowerCase()
+  if (column === 'alignment') {
+    // Keep in sync with ALIGNMENT_CATEGORY_PRIORITY (best → worst for asc).
+    var order = {
+      aligned_on_time: 0,
+      aligned_late: 1,
+      fv_only: 2,
+      tv_only: 3,
+      misaligned: 4
+    }
+    var ao = order[feature.alignmentCategory]
+    return ao !== undefined ? ao : 99
+  }
   if (column === 'components') {
     var comps = feature.components || []
     return comps.length > 0 ? String(comps[0]).toLowerCase() : ''

--- a/modules/releases/client/plan/utils/feature-readiness-sort.js
+++ b/modules/releases/client/plan/utils/feature-readiness-sort.js
@@ -1,0 +1,157 @@
+/**
+ * Client-side column sorting for Features List (FeatureReadinessView).
+ */
+
+import { worstFailedSeverity, SEVERITY_RANK } from './fpdor-severity.js'
+
+var PRIORITY_ORDER = {
+  Blocker: 0,
+  Critical: 1,
+  Major: 2,
+  Normal: 3,
+  Minor: 4
+}
+
+var RECOMMENDATION_ORDER = {
+  approve: 0,
+  revise: 1,
+  reject: 2
+}
+
+export var SORTABLE_COLUMNS = [
+  'rank',
+  'score',
+  'readiness',
+  'key',
+  'title',
+  'outcome',
+  'targetVersion',
+  'fixVersion',
+  'components',
+  'team',
+  'rubric',
+  'recommendation',
+  'status',
+  'priority',
+  'attention'
+]
+
+/**
+ * @param {object} feature
+ * @param {string} column
+ * @returns {string|number}
+ */
+export function getSortValue(feature, column) {
+  if (!feature) return ''
+  if (column === 'rank') {
+    return feature.rank != null ? feature.rank : Number.POSITIVE_INFINITY
+  }
+  if (column === 'score') {
+    return feature.effectivePriorityScore != null
+      ? feature.effectivePriorityScore
+      : Number.NEGATIVE_INFINITY
+  }
+  if (column === 'readiness') {
+    var sev = worstFailedSeverity(feature)
+    if (!sev) return 0
+    return SEVERITY_RANK[sev] || 99
+  }
+  if (column === 'key') return feature.key || ''
+  if (column === 'title') return (feature.title || '').toLowerCase()
+  if (column === 'outcome') return (feature.bigRock || '').toLowerCase()
+  if (column === 'targetVersion') {
+    var tvs = feature.targetVersions || []
+    return tvs.length > 0 ? String(tvs[0]).toLowerCase() : ''
+  }
+  if (column === 'fixVersion') return (feature.fixVersion || '').toLowerCase()
+  if (column === 'components') {
+    var comps = feature.components || []
+    return comps.length > 0 ? String(comps[0]).toLowerCase() : ''
+  }
+  if (column === 'team') return (feature.team || '').toLowerCase()
+  if (column === 'rubric') {
+    return feature.rubricTotal != null ? feature.rubricTotal : Number.NEGATIVE_INFINITY
+  }
+  if (column === 'recommendation') {
+    var rec = (feature.recommendation || '').toLowerCase()
+    return RECOMMENDATION_ORDER[rec] !== undefined ? RECOMMENDATION_ORDER[rec] : 99
+  }
+  if (column === 'status') return (feature.status || '').toLowerCase()
+  if (column === 'priority') {
+    var po = PRIORITY_ORDER[feature.priority]
+    return po !== undefined ? po : 99
+  }
+  if (column === 'attention') return feature.needsAttention ? 1 : 0
+  return ''
+}
+
+/**
+ * Default Features List order: score desc, then rubric desc.
+ * @param {object} a
+ * @param {object} b
+ * @returns {number}
+ */
+export function compareByDefaultScore(a, b) {
+  var sa = a.effectivePriorityScore != null ? a.effectivePriorityScore : Number.NEGATIVE_INFINITY
+  var sb = b.effectivePriorityScore != null ? b.effectivePriorityScore : Number.NEGATIVE_INFINITY
+  if (sb !== sa) return sb - sa
+  var ra = a.rubricTotal != null ? a.rubricTotal : Number.NEGATIVE_INFINITY
+  var rb = b.rubricTotal != null ? b.rubricTotal : Number.NEGATIVE_INFINITY
+  return rb - ra
+}
+
+/**
+ * @param {object[]} features
+ * @param {{ column: string|null, direction: string }} sortState
+ * @returns {object[]}
+ */
+export function sortFeatures(features, sortState) {
+  var list = features.slice()
+  if (!sortState || !sortState.column || SORTABLE_COLUMNS.indexOf(sortState.column) === -1) {
+    return list.sort(compareByDefaultScore)
+  }
+  var col = sortState.column
+  var dir = sortState.direction === 'asc' ? 1 : -1
+  list.sort(function(a, b) {
+    var va = getSortValue(a, col)
+    var vb = getSortValue(b, col)
+    if (va < vb) return -1 * dir
+    if (va > vb) return 1 * dir
+    return compareByDefaultScore(a, b)
+  })
+  return list
+}
+
+/**
+ * Preferred first click direction per column.
+ * Score/rubric/# default high-first; most others A→Z / ready-first.
+ * @param {string} column
+ * @returns {'asc'|'desc'}
+ */
+export function firstDirectionForColumn(column) {
+  if (column === 'score' || column === 'rubric' || column === 'rank' || column === 'attention') {
+    return 'desc'
+  }
+  return 'asc'
+}
+
+/**
+ * Three-state toggle: unset → firstDir → opposite → unset (default score order).
+ * @param {{ column: string|null, direction: string }} sortState
+ * @param {string} column
+ * @returns {{ column: string|null, direction: string }}
+ */
+export function nextSortState(sortState, column) {
+  if (SORTABLE_COLUMNS.indexOf(column) === -1) {
+    return { column: sortState.column, direction: sortState.direction }
+  }
+  if (sortState.column !== column) {
+    return { column: column, direction: firstDirectionForColumn(column) }
+  }
+  var first = firstDirectionForColumn(column)
+  var second = first === 'asc' ? 'desc' : 'asc'
+  if (sortState.direction === first) {
+    return { column: column, direction: second }
+  }
+  return { column: null, direction: 'asc' }
+}

--- a/modules/releases/client/plan/utils/features-list-filter-storage.js
+++ b/modules/releases/client/plan/utils/features-list-filter-storage.js
@@ -14,6 +14,7 @@ export var DEFAULT_FILTERS = {
   team: [],
   product: [],
   fpdorItems: [],
+  alignment: [],
   readiness: null
 }
 
@@ -40,6 +41,7 @@ export function saveFeaturesListFilters(filters, selectedVersion) {
         team: asStringArray(filters && filters.team),
         product: asStringArray(filters && filters.product),
         fpdorItems: asStringArray(filters && filters.fpdorItems),
+        alignment: asStringArray(filters && filters.alignment),
         readiness: filters && filters.readiness != null ? String(filters.readiness) : null
       },
       selectedVersion: typeof selectedVersion === 'string' ? selectedVersion : ''
@@ -70,6 +72,7 @@ export function restoreFeaturesListFilters() {
         team: asStringArray(saved.team),
         product: asStringArray(saved.product),
         fpdorItems: asStringArray(saved.fpdorItems),
+        alignment: asStringArray(saved.alignment),
         readiness: saved.readiness != null && saved.readiness !== '' ? String(saved.readiness) : null
       },
       selectedVersion: typeof state.selectedVersion === 'string' ? state.selectedVersion : ''

--- a/modules/releases/client/plan/utils/tv-fv-alignment-display.js
+++ b/modules/releases/client/plan/utils/tv-fv-alignment-display.js
@@ -1,0 +1,69 @@
+/**
+ * Client helpers for TV/FV Delta alignment categories (PM Hub).
+ * Keep labels/help in sync with server tv-fv-delta/alignment.js and TvFvDeltaView COLUMN_HELP.
+ */
+
+export var ALIGNMENT_CATEGORY_PRIORITY = {
+  misaligned: 4,
+  tv_only: 3,
+  fv_only: 2,
+  aligned_late: 1,
+  aligned_on_time: 0
+}
+
+export var ALIGNMENT_CATEGORY_LABELS = {
+  aligned_on_time: 'On time',
+  aligned_late: 'Late',
+  misaligned: 'Misaligned',
+  tv_only: 'TV only',
+  fv_only: 'FV only'
+}
+
+export var ALIGNMENT_CATEGORY_HELP = {
+  aligned_on_time: 'Fix Version matches Target Version, or ships earlier than planned.',
+  aligned_late: 'Fix Version is later than Target Version, but planning freeze for that Target Version has already passed — accepted slip.',
+  misaligned: 'Fix Version slips past Target Version before planning freeze, or TV/FV point at different products (for example RHOAI vs RHAII).',
+  tv_only: 'Target Version is set for this release, but Fix Version is empty.',
+  fv_only: 'Fix Version is set for this release, but Target Version is empty.'
+}
+
+export function isAlignedCategory(category) {
+  return category === 'aligned_on_time' || category === 'aligned_late'
+}
+
+export function alignmentCategoryLabel(category) {
+  if (!category) return '—'
+  return ALIGNMENT_CATEGORY_LABELS[category] || category
+}
+
+export function alignmentCategoryHelp(category) {
+  if (!category) return 'No Target Version or Fix Version in this release scope.'
+  return ALIGNMENT_CATEGORY_HELP[category] || ''
+}
+
+export function worseAlignmentCategory(a, b) {
+  if (!a) return b || null
+  if (!b) return a
+  var ra = ALIGNMENT_CATEGORY_PRIORITY[a]
+  var rb = ALIGNMENT_CATEGORY_PRIORITY[b]
+  if (ra === undefined) return b
+  if (rb === undefined) return a
+  return ra >= rb ? a : b
+}
+
+export function alignmentCategoryChipClass(category) {
+  switch (category) {
+    case 'aligned_on_time':
+      return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+    case 'aligned_late':
+      return 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200'
+    case 'misaligned':
+      return 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+    case 'tv_only':
+      return 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+    case 'fv_only':
+      return 'bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300'
+    default:
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+  }
+}

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -297,7 +297,7 @@
       correlated. Use REQ/COM (and other) filter chips in the bar above to filter
       the table.
     -->
-    <div v-if="hasFetched && !loadingData" class="grid grid-cols-2 sm:grid-cols-6 gap-3">
+    <div v-if="hasFetched && !loadingData" class="grid grid-cols-2 sm:grid-cols-5 gap-3">
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
@@ -337,16 +337,6 @@
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Not Aligned</span>
         </div>
         <div class="text-2xl font-bold ml-7" :class="totalNotAligned > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'" title="PM/DO Aligned = No (TV and FV missing or mismatch)">{{ totalNotAligned }}</div>
-      </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-violet-500 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-violet-100 dark:bg-violet-900/40">
-            <svg class="w-3 h-3 text-violet-600 dark:text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Avg Features Delivered</span>
-        </div>
-        <div class="text-2xl font-bold text-violet-600 dark:text-violet-400 ml-7">{{ velocity ? velocity.avgPerRelease : '—' }}<span v-if="velocity && velocity.hasPartialYear" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-0.5" title="Includes components with less than a year of data">*</span></div>
       </div>
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
@@ -390,7 +380,6 @@
       ref="tableRef"
       :groups="clientFilteredGroups"
       :componentLeads="componentLeads"
-      :velocity="velocity"
       :initialSort="savedSort"
       @sort-changed="onSortChanged"
       @select="selectedFeature = $event"
@@ -1013,8 +1002,6 @@ var totalNotAligned = computed(function() {
   return count
 })
 
-var velocity = ref(null)
-
 var formattedFetchedAt = computed(function() {
   if (!fetchedAt.value) return null
   try {
@@ -1164,12 +1151,10 @@ async function loadData() {
     }
     var data = await response.json()
     groups.value = data.groups || []
-    velocity.value = data.velocity || null
     fetchedAt.value = data.fetchedAt || null
   } catch (err) {
     dataError.value = err.message
     groups.value = []
-    velocity.value = null
     fetchedAt.value = null
   } finally {
     loadingData.value = false

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -293,7 +293,7 @@
     <!--
       Summary cards are display-only KPIs. Click-to-filter was removed because
       toggling Requested/Committed via tiles made independent Requested (TV in
-      scope) and Committed (FV in scope + TV match/early delivery) counts appear
+      scope) and Committed (Fix Version in selected release scope) counts appear
       correlated. Use REQ/COM (and other) filter chips in the bar above to filter
       the table.
     -->
@@ -677,7 +677,7 @@ var filteredPmOwners = computed(function() {
  * Apply client-side filters to groups.
  * @param {boolean} includeTypeFilter - when true, apply REQ/COM (filterType) for the table.
  *   KPI summary tiles intentionally omit type filter so Requested (TV in scope)
- *   and Committed (FV in scope + TV match/early delivery) remain independent
+ *   and Committed (Fix Version in selected release scope) remain independent
  *   headline counts.
  */
 function filterGroups(includeTypeFilter) {

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -409,6 +409,7 @@ import { buildComponentLeadsMap } from '../../composables/componentLeads'
 import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
 import PillarConfigPanel from '../components/PillarConfigPanel.vue'
 import FeatureReadinessDrawer from '../components/FeatureReadinessDrawer.vue'
+import { toDrawerFeature } from '../utils/feature-readiness-drawer-model.js'
 
 const nav = inject('moduleNav', null)
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -417,19 +418,6 @@ function navigateToFeature(key) {
   if (nav && typeof nav.navigateTo === 'function') {
     nav.navigateTo('feature-detail', { key, from: 'plan-pm-hub' })
   }
-}
-
-/** Normalize PM Hub row shape for FeatureReadinessDrawer. */
-function toDrawerFeature(feature) {
-  if (!feature) return null
-  var fixVersions = feature.fixVersions || []
-  return Object.assign({}, feature, {
-    title: feature.title || feature.summary || '',
-    fixVersion: feature.fixVersion || (fixVersions.length ? fixVersions[0] : null),
-    deliveryOwner: feature.deliveryOwner || feature.assignee || null,
-    sourceRfe: feature.sourceRfe || feature.linkedRfeKey || null,
-    dataSource: feature.dataSource || 'pm-hub'
-  })
 }
 
 const API_BASE = '/modules/releases/pm-hub'

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -336,7 +336,7 @@
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Not Aligned</span>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="totalNotAligned > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'" title="PM/DO Aligned = No (TV and FV missing or mismatch)">{{ totalNotAligned }}</div>
+        <div class="text-2xl font-bold ml-7" :class="totalNotAligned > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'" title="Not aligned = TV only, FV only, or misaligned (same categories as TV vs FV Delta). On time and Late count as aligned.">{{ totalNotAligned }}</div>
       </div>
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, inject, watch } from 'vue'
+import { ref, reactive, computed, onMounted, inject, watch, h } from 'vue'
 import { useFeatureReadiness } from '../composables/useFeatureReadiness'
 import { useReleases } from '../composables/useReleasePlanning'
 import { useRefreshPolling } from '../composables/useRefreshPolling'
@@ -16,6 +16,10 @@ import {
   saveFeaturesListFilters,
   restoreFeaturesListFilters
 } from '../utils/features-list-filter-storage.js'
+import {
+  sortFeatures,
+  nextSortState
+} from '../utils/feature-readiness-sort.js'
 
 const nav = inject('moduleNav')
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -103,14 +107,49 @@ function matchesFilters(feature) {
   return featureMatchesSharedFilters(feature, filters.value, selectedVersion.value, { applyReadiness: true })
 }
 
-const filteredFeatures = computed(() => {
-  var all = pendingReview.value.concat(ready.value)
-  return all.filter(matchesFilters).sort(function(a, b) {
-    if (b.effectivePriorityScore !== a.effectivePriorityScore) {
-      return b.effectivePriorityScore - a.effectivePriorityScore
+/** Default matches prior score-desc order; arrow visible so columns look sortable. */
+var sortState = reactive({ column: 'score', direction: 'desc' })
+
+function toggleSort(column) {
+  var next = nextSortState(sortState, column)
+  sortState.column = next.column
+  sortState.direction = next.direction
+}
+
+function sortIcon(column) {
+  if (sortState.column !== column) return 'none'
+  return sortState.direction
+}
+
+var SortArrow = {
+  props: { direction: { type: String, default: 'none' } },
+  setup: function(props) {
+    return function() {
+      if (props.direction === 'none') return null
+      return h('svg', {
+        class: [
+          'w-3 h-3 inline-block transition-transform shrink-0',
+          props.direction === 'desc' ? 'rotate-180' : ''
+        ],
+        fill: 'none',
+        viewBox: '0 0 24 24',
+        stroke: 'currentColor',
+        'stroke-width': '2.5',
+        'aria-hidden': 'true'
+      }, [
+        h('path', {
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+          d: 'M5 15l7-7 7 7'
+        })
+      ])
     }
-    return b.rubricTotal - a.rubricTotal
-  })
+  }
+}
+
+const filteredFeatures = computed(function() {
+  var all = pendingReview.value.concat(ready.value).filter(matchesFilters)
+  return sortFeatures(all, sortState)
 })
 
 const readyCounts = computed(() => {
@@ -139,21 +178,21 @@ function exportCsv() {
 }
 
 const headers = [
-  { id: 'h-num',        label: '#',               scope: 'col' },
-  { id: 'h-score',      label: 'Score',           scope: 'col', hasScoreTooltip: true },
-  { id: 'h-readiness',  label: 'Readiness',       scope: 'col', hasTooltip: true },
-  { id: 'h-key',        label: 'Key',             scope: 'col' },
-  { id: 'h-title',      label: 'Title',           scope: 'col' },
-  { id: 'h-outcome',    label: 'Outcome',         scope: 'col' },
-  { id: 'h-target',     label: 'Target Version',  scope: 'col', info: 'The release version that PM is targeting for this feature to be delivered in.' },
-  { id: 'h-fixver',     label: 'Fix Version',     scope: 'col', info: 'The release version that engineering has committed to delivering this feature in.' },
-  { id: 'h-comp',       label: 'Components',      scope: 'col' },
-  { id: 'h-team',       label: 'Team',            scope: 'col' },
-  { id: 'h-rubric',     label: 'Rubric',          scope: 'col' },
-  { id: 'h-rec',        label: 'AI First Recommends',  scope: 'col', info: 'AI review verdict from the strat-creator (AI First) pipeline.' },
-  { id: 'h-status',     label: 'Status',          scope: 'col' },
-  { id: 'h-priority',   label: 'Priority',        scope: 'col' },
-  { id: 'h-attention',  label: '',                scope: 'col' },
+  { id: 'h-num',        label: '#',               scope: 'col', sortKey: 'rank' },
+  { id: 'h-score',      label: 'Score',           scope: 'col', sortKey: 'score', hasScoreTooltip: true },
+  { id: 'h-readiness',  label: 'Readiness',       scope: 'col', sortKey: 'readiness', hasTooltip: true },
+  { id: 'h-key',        label: 'Key',             scope: 'col', sortKey: 'key' },
+  { id: 'h-title',      label: 'Title',           scope: 'col', sortKey: 'title' },
+  { id: 'h-outcome',    label: 'Outcome',         scope: 'col', sortKey: 'outcome' },
+  { id: 'h-target',     label: 'Target Version',  scope: 'col', sortKey: 'targetVersion', info: 'The release version that PM is targeting for this feature to be delivered in.' },
+  { id: 'h-fixver',     label: 'Fix Version',     scope: 'col', sortKey: 'fixVersion', info: 'The release version that engineering has committed to delivering this feature in.' },
+  { id: 'h-comp',       label: 'Components',      scope: 'col', sortKey: 'components' },
+  { id: 'h-team',       label: 'Team',            scope: 'col', sortKey: 'team' },
+  { id: 'h-rubric',     label: 'Rubric',          scope: 'col', sortKey: 'rubric' },
+  { id: 'h-rec',        label: 'AI First Recommends',  scope: 'col', sortKey: 'recommendation', info: 'AI review verdict from the strat-creator (AI First) pipeline.' },
+  { id: 'h-status',     label: 'Status',          scope: 'col', sortKey: 'status' },
+  { id: 'h-priority',   label: 'Priority',        scope: 'col', sortKey: 'priority' },
+  { id: 'h-attention',  label: '',                scope: 'col', sortKey: 'attention', ariaLabel: 'Needs attention' },
 ]
 
 function formatSyncDate(dateStr) {
@@ -228,15 +267,24 @@ function formatSyncDate(dateStr) {
               :key="header.id"
               role="columnheader"
               :scope="header.scope"
+              :aria-sort="header.sortKey && sortState.column === header.sortKey
+                ? (sortState.direction === 'asc' ? 'ascending' : 'descending')
+                : (header.sortKey ? 'none' : undefined)"
+              :aria-label="header.ariaLabel || undefined"
               class="px-3 py-2.5 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide leading-tight"
+              :class="header.sortKey ? 'cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200' : ''"
+              @click="header.sortKey && toggleSort(header.sortKey)"
             >
               <span v-if="header.hasTooltip" class="inline-flex items-center gap-1 group relative">
                 {{ header.label }}
+                <SortArrow :direction="sortIcon(header.sortKey)" />
                 <span
                   class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                  @click.stop
                 >i</span>
                 <div
                   class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block"
+                  @click.stop
                 >
                   <p class="font-semibold text-gray-700 dark:text-gray-200 mb-1.5">Readiness color</p>
                   <div class="space-y-1">
@@ -277,11 +325,14 @@ function formatSyncDate(dateStr) {
               </span>
               <span v-else-if="header.hasScoreTooltip" class="inline-flex items-center gap-1 group relative">
                 {{ header.label }}
+                <SortArrow :direction="sortIcon(header.sortKey)" />
                 <span
                   class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                  @click.stop
                 >i</span>
                 <div
                   class="absolute z-50 top-full mt-1 left-0 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block"
+                  @click.stop
                 >
                   <p class="font-semibold text-gray-700 dark:text-gray-200 mb-2">Score Rubric</p>
                   <div class="space-y-2 text-gray-600 dark:text-gray-300">
@@ -298,14 +349,22 @@ function formatSyncDate(dateStr) {
               </span>
               <span v-else-if="header.info" class="inline-flex items-center gap-1 group relative">
                 {{ header.label }}
+                <SortArrow :direction="sortIcon(header.sortKey)" />
                 <span
                   class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                  @click.stop
                 >i</span>
-                <span class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block">
+                <span
+                  class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block"
+                  @click.stop
+                >
                   {{ header.info }}
                 </span>
               </span>
-              <span v-else>{{ header.label }}</span>
+              <span v-else class="inline-flex items-center gap-1">
+                {{ header.label }}
+                <SortArrow v-if="header.sortKey" :direction="sortIcon(header.sortKey)" />
+              </span>
             </th>
           </tr>
         </thead>

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -20,6 +20,7 @@ import {
   sortFeatures,
   nextSortState
 } from '../utils/feature-readiness-sort.js'
+import { toDrawerFeature } from '../utils/feature-readiness-drawer-model.js'
 
 const nav = inject('moduleNav')
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -60,6 +61,9 @@ useRefreshPolling(refreshing, checkRefreshStatus, function() {
 })
 
 const selectedFeature = ref(null)
+const drawerFeature = computed(function() {
+  return toDrawerFeature(selectedFeature.value)
+})
 const selectedVersion = ref('')
 
 const filters = ref(Object.assign({}, DEFAULT_FILTERS, {
@@ -414,7 +418,7 @@ function formatSyncDate(dateStr) {
   </div>
 
   <FeatureReadinessDrawer
-    :feature="selectedFeature"
+    :feature="drawerFeature"
     :jiraBaseUrl="jiraBaseUrl"
     @close="selectedFeature = null"
     @navigate="navigateToFeature"

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -70,7 +70,8 @@ const filters = ref(Object.assign({}, DEFAULT_FILTERS, {
   priority: [],
   team: [],
   product: [],
-  fpdorItems: []
+  fpdorItems: [],
+  alignment: []
 }))
 
 function restorePersistedFilters() {
@@ -84,7 +85,8 @@ function restorePersistedFilters() {
     priority: saved.filters.priority.slice(),
     team: saved.filters.team.slice(),
     product: saved.filters.product.slice(),
-    fpdorItems: saved.filters.fpdorItems.slice()
+    fpdorItems: saved.filters.fpdorItems.slice(),
+    alignment: (saved.filters.alignment || []).slice()
   })
   selectedVersion.value = saved.selectedVersion
 }
@@ -186,6 +188,7 @@ const headers = [
   { id: 'h-outcome',    label: 'Outcome',         scope: 'col', sortKey: 'outcome' },
   { id: 'h-target',     label: 'Target Version',  scope: 'col', sortKey: 'targetVersion', info: 'The release version that PM is targeting for this feature to be delivered in.' },
   { id: 'h-fixver',     label: 'Fix Version',     scope: 'col', sortKey: 'fixVersion', info: 'The release version that engineering has committed to delivering this feature in.' },
+  { id: 'h-align',      label: 'TV/FV Align',     scope: 'col', sortKey: 'alignment', info: 'Same categories as Reports → TV vs FV Delta (worst across Target/Fix Versions on the issue). On time and Late count as aligned.' },
   { id: 'h-comp',       label: 'Components',      scope: 'col', sortKey: 'components' },
   { id: 'h-team',       label: 'Team',            scope: 'col', sortKey: 'team' },
   { id: 'h-rubric',     label: 'Rubric',          scope: 'col', sortKey: 'rubric' },

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -25,24 +25,16 @@ function mockJiraClient(featureIssues, childIssues) {
 describe('feature-query', function() {
 
   describe('JQL', function() {
-    it('queries shared pipeline projects for Features and Initiatives', function() {
-      expect(JQL).toContain('project IN (')
-      expect(JQL).toContain('RHAIENG')
-      expect(JQL).toContain('RHOAIENG')
-      expect(JQL).toContain('INFERENG')
-      expect(JQL).toContain('AIPCC')
-      expect(JQL).toContain('RHAISTRAT')
-      expect(JQL).toContain('RHAIRFE')
-      expect(JQL).toContain('RHELAI')
-      expect(JQL).toContain('RHAI')
+    it('queries RHAISTRAT and AIPCC for Features and Initiatives', function() {
+      expect(JQL).toContain('project IN (RHAISTRAT, AIPCC)')
       expect(JQL).toContain('issuetype IN (Feature, Initiative)')
+      expect(JQL).not.toContain('RHAIENG')
+      expect(JQL).not.toContain('INFERENG')
+      expect(JQL).not.toContain('RHAIRFE')
     })
 
-    it('excludes Cancelled only at fetch (Closed/Done/Resolved stay for PM Hub / shared set)', function() {
-      expect(JQL).toContain('status NOT IN (Cancelled)')
-      expect(JQL).not.toContain('Closed')
-      expect(JQL).not.toContain('Done')
-      expect(JQL).not.toContain('Resolved')
+    it('excludes Closed, Done, Resolved, and Cancelled at live fetch (open only)', function() {
+      expect(JQL).toContain('status NOT IN (Closed, Done, Resolved, Cancelled)')
     })
 
     it('does not include a created date filter', function() {

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -3,12 +3,14 @@ import { describe, it, expect } from 'vitest'
 const {
   computeReadiness,
   buildFeatureReadiness,
+  buildCanonicalFeatures,
   computeBlockers,
   hasBlockingViolations,
   computeHygieneStatus,
   computeConfidence,
   collectFilterMeta,
   isHiddenFromFeaturesList,
+  shouldIncludeInCanonical,
   buildCanonicalKeySet,
   mergeFeatureData
 } = require('../feature-readiness')
@@ -2122,6 +2124,27 @@ describe('buildFeatureReadiness', function() {
     })
   })
 
+  describe('shouldIncludeInCanonical', function() {
+    it('never includes Cancelled', function() {
+      expect(shouldIncludeInCanonical('Cancelled', false)).toBe(false)
+      expect(shouldIncludeInCanonical('Cancelled', true)).toBe(false)
+    })
+
+    it('excludes Closed/Done/Resolved when includeClosed is false', function() {
+      expect(shouldIncludeInCanonical('Closed', false)).toBe(false)
+      expect(shouldIncludeInCanonical('Done', false)).toBe(false)
+      expect(shouldIncludeInCanonical('Resolved', false)).toBe(false)
+      expect(shouldIncludeInCanonical('In Progress', false)).toBe(true)
+    })
+
+    it('keeps Closed/Done/Resolved when includeClosed is true', function() {
+      expect(shouldIncludeInCanonical('Closed', true)).toBe(true)
+      expect(shouldIncludeInCanonical('Done', true)).toBe(true)
+      expect(shouldIncludeInCanonical('Resolved', true)).toBe(true)
+      expect(shouldIncludeInCanonical('In Progress', true)).toBe(true)
+    })
+  })
+
 })
 
 // ---------------------------------------------------------------------------
@@ -3537,5 +3560,120 @@ describe('buildFeatureReadiness — single-pass merging', function() {
     expect(allKeys).toContain('RHAISTRAT-AI')
     expect(allKeys).toContain('RHAISTRAT-JIRA')
     expect(allKeys).toContain('RHAISTRAT-HEALTH')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCanonicalFeatures (shared pipeline builder)
+// ---------------------------------------------------------------------------
+
+describe('buildCanonicalFeatures', function() {
+  function makeJiraMap(features) {
+    var map = new Map()
+    for (var i = 0; i < features.length; i++) {
+      map.set(features[i].key, features[i])
+    }
+    return map
+  }
+
+  function makeJiraFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      project: key.split('-')[0],
+      summary: 'Jira Feature ' + key,
+      status: 'In Progress',
+      issueType: 'Feature',
+      assignee: 'Alice',
+      team: 'Platform',
+      components: ['Dashboard'],
+      labels: [],
+      fixVersions: [],
+      targetVersions: ['rhoai-3.6'],
+      priority: 'Major',
+      riceScore: null
+    }, overrides)
+  }
+
+  it('includes RHAISTRAT and eng-project features with FPDoR fields', async function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-100'),
+      makeJiraFeature('RHAIENG-200', { project: 'RHAIENG', summary: 'Eng Initiative' }),
+      makeJiraFeature('RHELAI-300', { project: 'RHELAI' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      ...convertToUnifiedFormat(makeFeaturesStore({})),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': { features: [], fetchedAt: null, schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = await buildCanonicalFeatures({
+      readFromStorage: readFromStorage,
+      jiraFeatures: jiraFeatures,
+      includeClosed: false
+    })
+
+    var keys = result.features.map(function(f) { return f.key }).sort()
+    expect(keys).toEqual(['RHAIENG-200', 'RHAISTRAT-100', 'RHELAI-300'])
+    result.features.forEach(function(f) {
+      expect(f.fpdor).toBeTruthy()
+      expect(f).toHaveProperty('confidence')
+      expect(f).toHaveProperty('isAiFirst')
+      expect(f).toHaveProperty('isReady')
+      expect(f.project).toBeTruthy()
+    })
+  })
+
+  it('excludes Closed by default but keeps them when includeClosed is true', async function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAI-1', { project: 'RHAI', status: 'In Progress' }),
+      makeJiraFeature('RHAI-2', { project: 'RHAI', status: 'Closed' }),
+      makeJiraFeature('RHAI-3', { project: 'RHAI', status: 'Done' }),
+      makeJiraFeature('RHAI-4', { project: 'RHAI', status: 'Cancelled' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      ...convertToUnifiedFormat(makeFeaturesStore({})),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': { features: [], fetchedAt: null, schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var openOnly = await buildCanonicalFeatures({
+      readFromStorage: readFromStorage,
+      jiraFeatures: jiraFeatures,
+      includeClosed: false
+    })
+    expect(openOnly.features.map(function(f) { return f.key })).toEqual(['RHAI-1'])
+
+    var withClosed = await buildCanonicalFeatures({
+      readFromStorage: readFromStorage,
+      jiraFeatures: jiraFeatures,
+      includeClosed: true
+    })
+    var withClosedKeys = withClosed.features.map(function(f) { return f.key }).sort()
+    expect(withClosedKeys).toEqual(['RHAI-1', 'RHAI-2', 'RHAI-3'])
+    expect(withClosedKeys).not.toContain('RHAI-4')
+  })
+
+  it('Features List path strips isReady and matches open-only canonical set', async function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('INFERENG-9', { project: 'INFERENG' }),
+      makeJiraFeature('INFERENG-10', { project: 'INFERENG', status: 'Resolved' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      ...convertToUnifiedFormat(makeFeaturesStore({})),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': { features: [], fetchedAt: null, schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var canonical = await buildCanonicalFeatures({
+      readFromStorage: readFromStorage,
+      jiraFeatures: jiraFeatures,
+      includeClosed: false
+    })
+    var list = await buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var listKeys = list.pendingReview.concat(list.ready).map(function(f) { return f.key })
+
+    expect(canonical.features.map(function(f) { return f.key })).toEqual(['INFERENG-9'])
+    expect(listKeys).toEqual(['INFERENG-9'])
+    expect(list.pendingReview.concat(list.ready)[0].isReady).toBeUndefined()
   })
 })

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1614,15 +1614,75 @@ describe('buildFeatureReadiness', function() {
       expect(docsItem.pass).toBe(false)
     })
 
-    it('docs impact passes via rp-qg1-pass without fields', function() {
+    it('docs impact ignores unverified rp-qg1-pass without fields', function() {
       var result = computeReadiness(readyFeature({
         components: ['Platform', 'Serving', 'UXD'],
         docsRequired: null,
         labels: ['rp-qg1-pass']
       }))
       var docsItem = result.fpdor.items.find(function(i) { return i.name === 'Docs impact' })
+      expect(docsItem.pass).toBe(false)
+    })
+
+    it('docs impact passes via bot-verified rp-qg1-pass without fields', function() {
+      var result = computeReadiness(readyFeature({
+        components: ['Platform', 'Serving', 'UXD'],
+        docsRequired: null,
+        labels: ['rp-qg1-pass'],
+        qg1PassVerified: true
+      }))
+      var docsItem = result.fpdor.items.find(function(i) { return i.name === 'Docs impact' })
       expect(docsItem.pass).toBe(true)
       expect(docsItem.detail).toContain('rp-qg1-pass')
+    })
+
+    it('mandatory shortcuts ignore hand-applied rp-qg1-pass', function() {
+      var result = computeReadiness(readyFeature({
+        targetVersions: [],
+        releaseType: null,
+        priority: null,
+        riceScore: null,
+        docsRequired: null,
+        labels: ['rp-qg1-pass']
+      }))
+      expect(result.isReady).toBe(false)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'Target Version' }).pass).toBe(false)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'RICE' }).pass).toBe(false)
+    })
+
+    it('mandatory shortcuts accept bot-verified rp-qg1-pass', function() {
+      var result = computeReadiness(readyFeature({
+        targetVersions: [],
+        releaseType: null,
+        priority: null,
+        riceScore: null,
+        docsRequired: null,
+        labels: ['rp-qg1-pass'],
+        qg1PassVerified: true
+      }))
+      expect(result.fpdor.items.find(function(i) { return i.name === 'Target Version' }).pass).toBe(true)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'Release Type' }).pass).toBe(true)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'Priority' }).pass).toBe(true)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'RICE' }).pass).toBe(true)
+      expect(result.fpdor.items.find(function(i) { return i.name === 'Docs impact' }).pass).toBe(true)
+    })
+
+    it('AI First sign-off ignores unverified rp-qg1-pass', function() {
+      var result = computeReadiness(readyFeature({
+        labels: ['strat-creator-auto-created', 'rp-qg1-pass']
+      }))
+      var signOff = result.fpdor.items.find(function(i) { return i.name === 'Feature human sign-off' })
+      expect(signOff.pass).toBe(false)
+    })
+
+    it('AI First sign-off passes via bot-verified rp-qg1-pass', function() {
+      var result = computeReadiness(readyFeature({
+        labels: ['strat-creator-auto-created', 'rp-qg1-pass'],
+        qg1PassVerified: true
+      }))
+      var signOff = result.fpdor.items.find(function(i) { return i.name === 'Feature human sign-off' })
+      expect(signOff.pass).toBe(true)
+      expect(signOff.detail).toContain('rp-qg1-pass')
     })
 
     it('UXD is not-checked without UXD component or N/A note', function() {

--- a/modules/releases/server/planning/constants.js
+++ b/modules/releases/server/planning/constants.js
@@ -4,9 +4,8 @@ const CLOSED_STATUSES = ['Closed', 'Done', 'Resolved', 'Cancelled']
 const TERMINAL_STATUSES = ['Review', 'Pending Release']
 
 /**
- * Shared Features pipeline population (Features List + PM Hub).
- * Canonical Jira fetch: Feature/Initiative in these projects, status ≠ Cancelled.
- * Features List additionally hides Closed/Done/Resolved at the API/view layer.
+ * Shared Features pipeline population (Features List + PM Hub target set).
+ * PM Hub metadata / future canonical cache use this full project list.
  */
 const FEATURE_PIPELINE_PROJECTS = [
   'RHAIENG',
@@ -19,7 +18,13 @@ const FEATURE_PIPELINE_PROJECTS = [
   'RHAI'
 ]
 
-/** Statuses Features List hides after the shared fetch (Cancelled already excluded upstream). */
+/**
+ * Features List live Jira fetch — narrowed for gateway timeout budget.
+ * Open Features/Initiatives only in RHAISTRAT + AIPCC.
+ */
+const FEATURES_LIST_PROJECTS = ['RHAISTRAT', 'AIPCC']
+
+/** Statuses Features List hides after merge (and excludes at live fetch). */
 const FEATURES_LIST_HIDDEN_STATUSES = ['Closed', 'Done', 'Resolved']
 
 const PRIORITY_ORDER = { Blocker: 0, Critical: 1, Major: 2, Normal: 3, Minor: 4 }
@@ -111,6 +116,7 @@ module.exports = {
   JIRA_BROWSE_URL,
   CLOSED_STATUSES,
   FEATURE_PIPELINE_PROJECTS,
+  FEATURES_LIST_PROJECTS,
   FEATURES_LIST_HIDDEN_STATUSES,
   TERMINAL_STATUSES,
   PRIORITY_ORDER,

--- a/modules/releases/server/planning/constants.js
+++ b/modules/releases/server/planning/constants.js
@@ -4,25 +4,15 @@ const CLOSED_STATUSES = ['Closed', 'Done', 'Resolved', 'Cancelled']
 const TERMINAL_STATUSES = ['Review', 'Pending Release']
 
 /**
- * Shared Features pipeline population (Features List + PM Hub target set).
- * PM Hub metadata / future canonical cache use this full project list.
+ * Canonical Features/Initiatives population (Features List + PM Hub).
+ * Planning Features live in RHAISTRAT + AIPCC only — eng-project Features
+ * (RHAIENG, RHOAIENG, …) are out of scope. Child epics FPDoR uses quality-gate /
+ * epic-creator labels, not a multi-project Feature scrape.
  */
-const FEATURE_PIPELINE_PROJECTS = [
-  'RHAIENG',
-  'RHOAIENG',
-  'INFERENG',
-  'AIPCC',
-  'RHAISTRAT',
-  'RHAIRFE',
-  'RHELAI',
-  'RHAI'
-]
+const FEATURE_PIPELINE_PROJECTS = ['RHAISTRAT', 'AIPCC']
 
-/**
- * Features List live Jira fetch — narrowed for gateway timeout budget.
- * Open Features/Initiatives only in RHAISTRAT + AIPCC.
- */
-const FEATURES_LIST_PROJECTS = ['RHAISTRAT', 'AIPCC']
+/** Live Features List / PM Hub fetch — same population as FEATURE_PIPELINE_PROJECTS. */
+const FEATURES_LIST_PROJECTS = FEATURE_PIPELINE_PROJECTS
 
 /** Statuses Features List hides after merge (and excludes at live fetch). */
 const FEATURES_LIST_HIDDEN_STATUSES = ['Closed', 'Done', 'Resolved']

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -6,6 +6,7 @@ var { FEATURES_LIST_PROJECTS, CLOSED_STATUSES } = require('./constants')
 var QUERY_FIELDS = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions',
   'components', 'labels', 'priority', 'created', 'updated', 'project',
+  'issuelinks',
   CUSTOM_FIELDS.team,
   CUSTOM_FIELDS.targetVersion,
   CUSTOM_FIELDS.riceScore,
@@ -65,6 +66,28 @@ function extractProject(issue, fields) {
   return null
 }
 
+function extractBlockedBy(issueLinks) {
+  var blockedBy = []
+  if (!Array.isArray(issueLinks)) return blockedBy
+  for (var i = 0; i < issueLinks.length; i++) {
+    var link = issueLinks[i]
+    if (!link || !link.inwardIssue) continue
+    var type = link.type || {}
+    if (type.name !== 'Blocks' && type.inward !== 'is blocked by') continue
+    var linkedFields = link.inwardIssue.fields || {}
+    var linkedStatus = linkedFields.status || {}
+    var linkedStatusCat = linkedStatus.statusCategory && linkedStatus.statusCategory.name
+    var linkedStatusName = linkedStatus.name || ''
+    if (linkedStatusCat === 'Done') continue
+    blockedBy.push({
+      key: link.inwardIssue.key,
+      summary: linkedFields.summary || '',
+      status: linkedStatusName
+    })
+  }
+  return blockedBy
+}
+
 function normalizeIssue(issue) {
   var fields = issue.fields || {}
   var assignee = fields.assignee
@@ -83,6 +106,9 @@ function normalizeIssue(issue) {
   var status = fields.status
     ? (typeof fields.status === 'object' ? fields.status.name || null : fields.status)
     : null
+  var statusCategory = fields.status && typeof fields.status === 'object' && fields.status.statusCategory
+    ? fields.status.statusCategory.name || null
+    : null
   var priority = fields.priority
     ? (typeof fields.priority === 'object' ? fields.priority.name || null : fields.priority)
     : null
@@ -95,11 +121,14 @@ function normalizeIssue(issue) {
     ? (typeof pmOwnerField === 'object' ? pmOwnerField.displayName || null : pmOwnerField)
     : null
 
+  var blockedBy = extractBlockedBy(fields.issuelinks)
+
   return {
     key: issue.key,
     project: extractProject(issue, fields),
     summary: fields.summary || '',
     status: status,
+    statusCategory: statusCategory,
     issueType: issueType,
     assignee: assignee,
     team: serializeField(fields[CUSTOM_FIELDS.team]),
@@ -116,6 +145,8 @@ function normalizeIssue(issue) {
     targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd]),
     pmOwner: pmOwner,
     effort: numericField(fields[CUSTOM_FIELDS.effort]),
+    isBlocked: blockedBy.length > 0,
+    blockedBy: blockedBy,
     // null when description was not fetched — lets health/cache signals win in merge
     descriptionSignals: fields.description ? parseDescriptionSignals(fields.description) : null
     // Do not set epicCount here — live fetch does not discover child Epics.
@@ -196,6 +227,7 @@ module.exports = {
   normalizeIssue: normalizeIssue,
   extractTargetVersions: extractTargetVersions,
   extractProject: extractProject,
+  extractBlockedBy: extractBlockedBy,
   enrichChildEpicCounts: enrichChildEpicCounts,
   JQL: JQL,
   QUERY_FIELDS: QUERY_FIELDS,

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -1,7 +1,7 @@
 var { CUSTOM_FIELDS, serializeField, numericField } = require('../hygiene/jira-fetch')
 var { parseDescriptionSignals } = require('./health/description-scanner')
 var { fetchEpicsForFeatures } = require('../execution/jira-enrich')
-var { FEATURE_PIPELINE_PROJECTS } = require('./constants')
+var { FEATURES_LIST_PROJECTS, CLOSED_STATUSES } = require('./constants')
 
 var QUERY_FIELDS = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions',
@@ -19,13 +19,15 @@ var QUERY_FIELDS = [
 ].join(',')
 
 /**
- * Canonical shared-pipeline JQL: all FEATURE_PIPELINE_PROJECTS Features/Initiatives,
- * excluding Cancelled only. Features List strips Closed/Done/Resolved after merge.
+ * Features List live JQL: RHAISTRAT + AIPCC Features/Initiatives, open only.
+ * Closed/Done/Resolved/Cancelled are excluded here so the request stays under
+ * the gateway timeout. Wider Cancelled-only multi-project fetch belongs in a
+ * background canonical cache (PM Hub), not this path.
  */
 var JQL = [
-  'project IN (' + FEATURE_PIPELINE_PROJECTS.join(', ') + ')',
+  'project IN (' + FEATURES_LIST_PROJECTS.join(', ') + ')',
   'issuetype IN (Feature, Initiative)',
-  'status NOT IN (Cancelled)'
+  'status NOT IN (' + CLOSED_STATUSES.join(', ') + ')'
 ].join(' AND ')
 
 /** Bound live Jira so /feature-readiness stays under the gateway timeout. */

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -19,10 +19,9 @@ var QUERY_FIELDS = [
 ].join(',')
 
 /**
- * Features List live JQL: RHAISTRAT + AIPCC Features/Initiatives, open only.
- * Closed/Done/Resolved/Cancelled are excluded here so the request stays under
- * the gateway timeout. Wider Cancelled-only multi-project fetch belongs in a
- * background canonical cache (PM Hub), not this path.
+ * Features List / PM Hub live JQL: RHAISTRAT + AIPCC Features/Initiatives, open only.
+ * Closed/Done/Resolved/Cancelled are excluded so the request stays under the
+ * gateway timeout. Scoped closed history (if needed) is a separate, version-bounded query.
  */
 var JQL = [
   'project IN (' + FEATURES_LIST_PROJECTS.join(', ') + ')',

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -480,6 +480,19 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
   var effort = (jira && jira.effort) || (exec && exec.effort) || null
   var tshirtSize = (health && health.tshirtSize) || (aiReview && aiReview.size) || null
   var descriptionSignals = (jira && jira.descriptionSignals) || (health && health.descriptionSignals) || null
+  var colorStatus = (jira && jira.colorStatus) || (health && health.colorStatus) || (exec && exec.colorStatus) || null
+  var statusSummary = (jira && jira.statusSummary) || (health && health.statusSummary) || (exec && exec.statusSummary) || null
+  var statusCategory = (jira && jira.statusCategory) || null
+  var isBlocked = !!(jira && jira.isBlocked)
+  var blockedBy = (jira && Array.isArray(jira.blockedBy)) ? jira.blockedBy : []
+  var fixVersions
+  if (jira && Array.isArray(jira.fixVersions) && jira.fixVersions.length > 0) {
+    fixVersions = jira.fixVersions.slice()
+  } else if (fixVersion) {
+    fixVersions = [fixVersion]
+  } else {
+    fixVersions = []
+  }
 
   if (!pmOwner && pm) pmOwner = pm
   if (!sourceRfe && exec && exec.linkedRfeKey) sourceRfe = exec.linkedRfeKey
@@ -492,6 +505,7 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
     sourceRfe: sourceRfe,
     priority: priority,
     status: status,
+    statusCategory: statusCategory,
     size: size,
     recommendation: recommendation,
     needsAttention: needsAttention,
@@ -512,6 +526,7 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
     rockPriority: rockPriority,
     targetVersions: targetVersions,
     fixVersion: fixVersion,
+    fixVersions: fixVersions,
     labels: labels,
     violations: violations,
     hygieneStatus: hygieneStatus,
@@ -526,6 +541,10 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
     effort: effort,
     tshirtSize: tshirtSize,
     descriptionSignals: descriptionSignals,
+    colorStatus: colorStatus,
+    statusSummary: statusSummary,
+    isBlocked: isBlocked,
+    blockedBy: blockedBy,
     phase: releaseType
   }
 }
@@ -625,6 +644,7 @@ async function buildCanonicalFeatures(options) {
       rockPriority: merged.rockPriority,
       targetVersions: merged.targetVersions,
       fixVersion: merged.fixVersion,
+      fixVersions: merged.fixVersions || (merged.fixVersion ? [merged.fixVersion] : []),
       priorityScore: effectivePriorityScore,
       priorityScoreBreakdown: priorityBreakdown,
       effectivePriorityScore: effectivePriorityScore,
@@ -639,6 +659,13 @@ async function buildCanonicalFeatures(options) {
       fpdor: readinessResult.fpdor,
       violations: merged.violations,
       hygieneStatus: merged.hygieneStatus,
+      releaseType: merged.releaseType || null,
+      docsRequired: merged.docsRequired || null,
+      colorStatus: merged.colorStatus || null,
+      statusSummary: merged.statusSummary || null,
+      statusCategory: merged.statusCategory || null,
+      isBlocked: !!merged.isBlocked,
+      blockedBy: merged.blockedBy || [],
       isReady: isReady
     })
   }

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -4,6 +4,7 @@ var { EARLY_STATUSES, FEATURES_LIST_HIDDEN_STATUSES } = require('./constants')
 var { deriveHumanReviewStatus: sharedDeriveStatus } = require('../execution/ai-review-fields')
 var { computeFPDoRReadiness, isAiFirstFeature } = require('./fpdor')
 var { computePriorityScores } = require('./health/priority-scorer')
+var { classifyOverall, loadReleaseDatesMap } = require('../tv-fv-delta/alignment')
 
 var BLOCKING_HYGIENE_RULES = []
 
@@ -557,6 +558,7 @@ async function buildCanonicalFeatures(options) {
 
   var execData = await loadExecutionData(readFromStorage)
   var cacheData = await loadCacheIndexes(readFromStorage, listStorageFiles)
+  var releaseDates = await loadReleaseDatesMap({ readFromStorage: readFromStorage })
 
   var execMap = new Map()
   for (var emi = 0; emi < execData.execFeatures.length; emi++) {
@@ -616,6 +618,12 @@ async function buildCanonicalFeatures(options) {
     var readinessResult = computeReadiness(merged)
     var isReady = readinessResult.isReady
     var confidence = computeConfidence(isReady, merged.fixVersion)
+    var fixVersions = merged.fixVersions || (merged.fixVersion ? [merged.fixVersion] : [])
+    var alignmentCategory = classifyOverall(
+      merged.targetVersions || [],
+      fixVersions,
+      releaseDates
+    )
 
     features.push({
       key: merged.key,
@@ -644,7 +652,8 @@ async function buildCanonicalFeatures(options) {
       rockPriority: merged.rockPriority,
       targetVersions: merged.targetVersions,
       fixVersion: merged.fixVersion,
-      fixVersions: merged.fixVersions || (merged.fixVersion ? [merged.fixVersion] : []),
+      fixVersions: fixVersions,
+      alignmentCategory: alignmentCategory,
       priorityScore: effectivePriorityScore,
       priorityScoreBreakdown: priorityBreakdown,
       effectivePriorityScore: effectivePriorityScore,

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -108,6 +108,17 @@ function isHiddenFromFeaturesList(status) {
   return FEATURES_LIST_HIDDEN_STATUSES.indexOf(status) !== -1 || status === 'Cancelled'
 }
 
+/**
+ * Whether a status belongs in the canonical feature set.
+ * Cancelled is never included. Closed/Done/Resolved only when includeClosed is true
+ * (PM Hub release-load history); Features List uses includeClosed=false.
+ */
+function shouldIncludeInCanonical(status, includeClosed) {
+  if (status === 'Cancelled') return false
+  if (!includeClosed && FEATURES_LIST_HIDDEN_STATUSES.indexOf(status) !== -1) return false
+  return true
+}
+
 function deriveHumanReviewStatusFromLabels(labels) {
   return sharedDeriveStatus(labels)
 }
@@ -519,7 +530,12 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
   }
 }
 
-async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) {
+async function buildCanonicalFeatures(options) {
+  var readFromStorage = options.readFromStorage
+  var jiraFeatures = options.jiraFeatures
+  var listStorageFiles = options.listStorageFiles
+  var includeClosed = !!options.includeClosed
+
   var execData = await loadExecutionData(readFromStorage)
   var cacheData = await loadCacheIndexes(readFromStorage, listStorageFiles)
 
@@ -528,17 +544,12 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
     if (execData.execFeatures[emi].key) execMap.set(execData.execFeatures[emi].key, execData.execFeatures[emi])
   }
 
-  var canonicalKeys = buildCanonicalKeySet(jiraFeatures, execData.aiReviewMap, execData.execFeatures, cacheData.healthIndex)
-
-  var pendingReview = []
-  var ready = []
-  var allComponents = []
-  var allPriorities = new Set()
-  var allBigRocks = new Set()
-  var allTargetVersions = new Set()
-  var allFixVersions = new Set()
-  var allTeams = new Set()
-  var allProjects = new Set()
+  var canonicalKeys = buildCanonicalKeySet(
+    jiraFeatures,
+    execData.aiReviewMap,
+    execData.execFeatures,
+    cacheData.healthIndex
+  )
 
   var bigRockPriorityMap = new Map()
   for (var bvi = 0; bvi < cacheData.configuredVersions.length; bvi++) {
@@ -556,8 +567,17 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
 
   var allMerged = []
   canonicalKeys.forEach(function(key) {
-    var merged = mergeFeatureData(key, jiraFeatures, execData.aiReviewMap, cacheData.candidateIndex, cacheData.healthIndex, cacheData.hygieneIndex, cacheData.teamIndex, execMap)
-    if (isHiddenFromFeaturesList(merged.status)) return
+    var merged = mergeFeatureData(
+      key,
+      jiraFeatures,
+      execData.aiReviewMap,
+      cacheData.candidateIndex,
+      cacheData.healthIndex,
+      cacheData.hygieneIndex,
+      cacheData.teamIndex,
+      execMap
+    )
+    if (!shouldIncludeInCanonical(merged.status, includeClosed)) return
     allMerged.push(merged)
   })
 
@@ -566,6 +586,7 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
     configuredVersions: cacheData.configuredVersions
   })
 
+  var features = []
   for (var mi = 0; mi < allMerged.length; mi++) {
     var merged = allMerged[mi]
     var scored = batchScores.get(merged.key)
@@ -573,12 +594,11 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
     var priorityBreakdown = scored ? scored.breakdown : null
 
     var blockerResult = computeBlockers(merged, merged.dataSource)
-
     var readinessResult = computeReadiness(merged)
     var isReady = readinessResult.isReady
     var confidence = computeConfidence(isReady, merged.fixVersion)
 
-    var feature = {
+    features.push({
       key: merged.key,
       project: merged.project,
       title: merged.title,
@@ -618,16 +638,60 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
       readinessGates: readinessResult.gates,
       fpdor: readinessResult.fpdor,
       violations: merged.violations,
-      hygieneStatus: merged.hygieneStatus
-    }
+      hygieneStatus: merged.hygieneStatus,
+      isReady: isReady
+    })
+  }
+
+  return {
+    features: features,
+    execData: execData,
+    cacheData: cacheData,
+    includeClosed: includeClosed
+  }
+}
+
+async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) {
+  var canonical = await buildCanonicalFeatures({
+    readFromStorage: readFromStorage,
+    jiraFeatures: jiraFeatures,
+    listStorageFiles: listStorageFiles,
+    includeClosed: false
+  })
+
+  var pendingReview = []
+  var ready = []
+  var allComponents = []
+  var allPriorities = new Set()
+  var allBigRocks = new Set()
+  var allTargetVersions = new Set()
+  var allFixVersions = new Set()
+  var allTeams = new Set()
+  var allProjects = new Set()
+
+  for (var i = 0; i < canonical.features.length; i++) {
+    var feature = canonical.features[i]
+    // Drop builder-only flag from the Features List payload.
+    var isReady = feature.isReady
+    var listFeature = Object.assign({}, feature)
+    delete listFeature.isReady
 
     if (isReady) {
-      ready.push(feature)
+      ready.push(listFeature)
     } else {
-      pendingReview.push(feature)
+      pendingReview.push(listFeature)
     }
 
-    collectFilterMeta(feature, allComponents, allPriorities, allBigRocks, allTargetVersions, allFixVersions, allTeams, allProjects)
+    collectFilterMeta(
+      listFeature,
+      allComponents,
+      allPriorities,
+      allBigRocks,
+      allTargetVersions,
+      allFixVersions,
+      allTeams,
+      allProjects
+    )
   }
 
   function sortFeatures(a, b) {
@@ -661,8 +725,8 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
     total: pendingReview.length + ready.length,
     pendingReviewCount: pendingReview.length,
     readyCount: ready.length,
-    versions: cacheData.configuredVersions,
-    lastSyncedAt: execData.lastSyncedAt || null,
+    versions: canonical.cacheData.configuredVersions,
+    lastSyncedAt: canonical.execData.lastSyncedAt || null,
     jiraAvailable: jiraFeatures != null
   }
 
@@ -671,6 +735,7 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
 
 module.exports = {
   buildFeatureReadiness: buildFeatureReadiness,
+  buildCanonicalFeatures: buildCanonicalFeatures,
   computeBlockers: computeBlockers,
   computeReadiness: computeReadiness,
   hasBlockingViolations: hasBlockingViolations,
@@ -678,6 +743,7 @@ module.exports = {
   computeConfidence: computeConfidence,
   collectFilterMeta: collectFilterMeta,
   isHiddenFromFeaturesList: isHiddenFromFeaturesList,
+  shouldIncludeInCanonical: shouldIncludeInCanonical,
   deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels,
   buildCanonicalKeySet: buildCanonicalKeySet,
   mergeFeatureData: mergeFeatureData,

--- a/modules/releases/server/planning/fpdor.js
+++ b/modules/releases/server/planning/fpdor.js
@@ -57,8 +57,17 @@ function hasLabelPrefix(feature, prefix) {
   return false
 }
 
+/**
+ * Trust rp-qg1-pass only when bot-verified.
+ *
+ * A bare label can be hand-applied in Jira; Org Pulse must not treat that as
+ * evidence for FPDoR shortcuts. Set feature.qg1PassVerified=true only when a
+ * Quality Gate bot comment with QG1-FP backs the label (enrichment / future
+ * gate-artifact ingest). Until then, field and strat-creator checks decide.
+ */
 function hasRpQg1Pass(feature) {
-  return hasLabel(feature, 'rp-qg1-pass')
+  if (!hasLabel(feature, 'rp-qg1-pass')) return false
+  return feature.qg1PassVerified === true
 }
 
 function hasStratCreatorRubricPass(feature) {
@@ -424,7 +433,12 @@ function evalFeatureHumanSignOff(feature) {
   if (hasRpQg1Pass(feature)) {
     return passViaLabel('Feature human sign-off', 'rp-qg1-pass', 'criteria')
   }
-  return evalItem('Feature human sign-off', false, 'Missing strat-creator-human* (or rp-qg1-pass) label', 'criteria')
+  return evalItem(
+    'Feature human sign-off',
+    false,
+    'Missing strat-creator-human* (or bot-verified rp-qg1-pass) label',
+    'criteria'
+  )
 }
 
 function evalChildEpics(feature) {

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -463,10 +463,9 @@ module.exports = async function registerPlanningRoutes(router, context) {
    *     tags: [releases-planning]
    *     security: [{ bearerAuth: [] }]
    *     description: >
-   *       Prioritized feature readiness built from the shared canonical Features
-   *       pipeline (RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE, RHELAI, RHAI).
-   *       Live Jira fetch excludes Cancelled only; buildCanonicalFeatures then
-   *       hides Closed/Done/Resolved for the active Features List planning view.
+   *       Prioritized feature readiness for Features List. Live Jira fetch is
+   *       open Features/Initiatives in RHAISTRAT and AIPCC only (timeout budget);
+   *       results are merged with caches and scored via buildCanonicalFeatures.
    *     responses:
    *       200:
    *         description: Feature readiness data with pendingReview and ready arrays

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -463,10 +463,10 @@ module.exports = async function registerPlanningRoutes(router, context) {
    *     tags: [releases-planning]
    *     security: [{ bearerAuth: [] }]
    *     description: >
-   *       Prioritized feature readiness for the shared Features pipeline
-   *       (RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE, RHELAI, RHAI).
-   *       Live Jira fetch excludes Cancelled only; this endpoint then hides
-   *       Closed/Done/Resolved for the active Features List planning view.
+   *       Prioritized feature readiness built from the shared canonical Features
+   *       pipeline (RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE, RHELAI, RHAI).
+   *       Live Jira fetch excludes Cancelled only; buildCanonicalFeatures then
+   *       hides Closed/Done/Resolved for the active Features List planning view.
    *     responses:
    *       200:
    *         description: Feature readiness data with pendingReview and ready arrays

--- a/modules/releases/server/pm-hub/canonical-load.js
+++ b/modules/releases/server/pm-hub/canonical-load.js
@@ -42,6 +42,18 @@ function canonicalToLoadRow(feature) {
     labels: feature.labels || [],
     riceScore: feature.riceScore != null ? feature.riceScore : null,
     linkedRfeKey: feature.sourceRfe || null,
+    bigRock: feature.bigRock || null,
+    team: feature.team || null,
+    size: feature.size || null,
+    effectivePriorityScore: feature.effectivePriorityScore != null
+      ? feature.effectivePriorityScore
+      : null,
+    priorityScoreBreakdown: feature.priorityScoreBreakdown || null,
+    recommendation: feature.recommendation || null,
+    scores: feature.scores || null,
+    reviewers: feature.reviewers || null,
+    humanReviewStatus: feature.humanReviewStatus || null,
+    needsAttention: !!feature.needsAttention,
     fpdor: feature.fpdor || null,
     isAiFirst: !!feature.isAiFirst,
     confidence: feature.confidence || null,

--- a/modules/releases/server/pm-hub/canonical-load.js
+++ b/modules/releases/server/pm-hub/canonical-load.js
@@ -1,0 +1,218 @@
+/**
+ * Build PM Hub Component Release Load groups from shared canonical features.
+ * Open-only by default (same population as Features List).
+ */
+
+const { filterCommittedFixVersions } = require('./committed-definition')
+const {
+  classifyForRelease,
+  isAlignedCategory
+} = require('../tv-fv-delta/alignment')
+
+/**
+ * Map a canonical feature to a PM Hub load row (FPDoR already computed).
+ * @param {object} feature
+ * @returns {object}
+ */
+function canonicalToLoadRow(feature) {
+  var fixVersions = Array.isArray(feature.fixVersions) && feature.fixVersions.length > 0
+    ? feature.fixVersions.slice()
+    : (feature.fixVersion ? [feature.fixVersion] : [])
+  var tv = Array.isArray(feature.targetVersions) ? feature.targetVersions.slice() : []
+  return {
+    key: feature.key,
+    summary: feature.title || '',
+    title: feature.title || '',
+    status: feature.status || null,
+    statusCategory: feature.statusCategory || null,
+    colorStatus: feature.colorStatus || null,
+    statusSummary: feature.statusSummary || null,
+    releaseType: feature.releaseType || null,
+    priority: feature.priority || null,
+    isBlocked: !!feature.isBlocked,
+    blockedBy: feature.blockedBy || [],
+    components: feature.components || [],
+    fixVersions: fixVersions,
+    targetVersions: tv,
+    alignmentCategory: null,
+    pmDoAligned: false,
+    assignee: feature.deliveryOwner || feature.assignee || null,
+    pmOwner: feature.pmOwner || null,
+    docsRequired: feature.docsRequired || null,
+    labels: feature.labels || [],
+    riceScore: feature.riceScore != null ? feature.riceScore : null,
+    linkedRfeKey: feature.sourceRfe || null,
+    fpdor: feature.fpdor || null,
+    isAiFirst: !!feature.isAiFirst,
+    confidence: feature.confidence || null,
+    dataSource: feature.dataSource || 'canonical'
+  }
+}
+
+/**
+ * @param {object} featureObj
+ * @param {string} release
+ * @param {object} releaseDates
+ * @returns {object}
+ */
+function attachAlignment(featureObj, release, releaseDates) {
+  if (!featureObj) return featureObj
+  var cat = release
+    ? classifyForRelease(
+      featureObj.targetVersions,
+      featureObj.fixVersions,
+      release,
+      releaseDates || {}
+    )
+    : null
+  featureObj.alignmentCategory = cat
+  featureObj.pmDoAligned = isAlignedCategory(cat)
+  return featureObj
+}
+
+function featureMatchesComponents(feature, componentNames) {
+  if (!componentNames || componentNames.length === 0) return true
+  var comps = feature.components || []
+  if (comps.length === 0) return false
+  for (var i = 0; i < comps.length; i++) {
+    if (componentNames.indexOf(comps[i]) !== -1) return true
+  }
+  return false
+}
+
+/**
+ * @param {object[]} canonicalFeatures
+ * @param {{ components: string[], versions: string[], releaseDates?: object }} filters
+ * @returns {{ groups: object[] }}
+ */
+function buildComponentReleaseLoadGroups(canonicalFeatures, filters) {
+  var componentNames = (filters && filters.components) || []
+  var versionNames = (filters && filters.versions) || []
+  var releaseDates = (filters && filters.releaseDates) || {}
+
+  var versionGroups = {}
+
+  function ensureGroup(vName, cName) {
+    if (!versionGroups[vName]) {
+      versionGroups[vName] = { version: vName, components: {} }
+    }
+    if (!versionGroups[vName].components[cName]) {
+      versionGroups[vName].components[cName] = {
+        component: cName,
+        requestedFeatures: [],
+        committedFeatures: [],
+        requestedCount: 0,
+        committedCount: 0,
+        blockedCount: 0
+      }
+    }
+    return versionGroups[vName].components[cName]
+  }
+
+  for (var fi = 0; fi < canonicalFeatures.length; fi++) {
+    var feature = canonicalFeatures[fi]
+    if (!featureMatchesComponents(feature, componentNames)) continue
+
+    var tvNames = Array.isArray(feature.targetVersions) ? feature.targetVersions : []
+    var fvList = Array.isArray(feature.fixVersions) && feature.fixVersions.length > 0
+      ? feature.fixVersions
+      : (feature.fixVersion ? [feature.fixVersion] : [])
+    var comps = feature.components && feature.components.length > 0
+      ? feature.components
+      : ['No Component']
+    if (componentNames.length > 0) {
+      comps = comps.filter(function(c) { return componentNames.indexOf(c) !== -1 })
+      if (comps.length === 0) continue
+    }
+
+    var baseRow = canonicalToLoadRow(feature)
+
+    if (versionNames.length === 0) {
+      var committedFvOnly = filterCommittedFixVersions(fvList, tvNames)
+      if (committedFvOnly.length === 0) continue
+      for (var ufi = 0; ufi < committedFvOnly.length; ufi++) {
+        for (var uci = 0; uci < comps.length; uci++) {
+          var uGroup = ensureGroup(committedFvOnly[ufi], comps[uci])
+          if (!uGroup.committedFeatures.some(function(e) { return e.key === feature.key })) {
+            uGroup.committedFeatures.push(
+              attachAlignment(Object.assign({}, baseRow), committedFvOnly[ufi], releaseDates)
+            )
+            uGroup.committedCount++
+            if (baseRow.isBlocked) uGroup.blockedCount++
+          }
+        }
+      }
+      continue
+    }
+
+    var matchingFv = []
+    var matchingTv = []
+    for (var fvi = 0; fvi < fvList.length; fvi++) {
+      if (versionNames.indexOf(fvList[fvi]) !== -1) matchingFv.push(fvList[fvi])
+    }
+    for (var tvi = 0; tvi < tvNames.length; tvi++) {
+      if (versionNames.indexOf(tvNames[tvi]) !== -1) matchingTv.push(tvNames[tvi])
+    }
+    if (matchingFv.length === 0 && matchingTv.length === 0) continue
+
+    var committedFv = filterCommittedFixVersions(matchingFv, tvNames)
+    var groupVersions = {}
+    for (var mf = 0; mf < committedFv.length; mf++) groupVersions[committedFv[mf]] = true
+    for (var mt = 0; mt < matchingTv.length; mt++) groupVersions[matchingTv[mt]] = true
+    var groupVersionKeys = Object.keys(groupVersions)
+    if (groupVersionKeys.length === 0) continue
+
+    var isRequested = matchingTv.length > 0
+    for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
+      var vKey = groupVersionKeys[gvi]
+      var featureObj = attachAlignment(Object.assign({}, baseRow), vKey, releaseDates)
+      for (var ci = 0; ci < comps.length; ci++) {
+        var group = ensureGroup(vKey, comps[ci])
+        if (committedFv.indexOf(vKey) !== -1) {
+          if (!group.committedFeatures.some(function(e) { return e.key === feature.key })) {
+            group.committedFeatures.push(featureObj)
+            group.committedCount++
+            if (featureObj.isBlocked) group.blockedCount++
+          }
+        }
+        if (isRequested && matchingTv.indexOf(vKey) !== -1) {
+          if (!group.requestedFeatures.some(function(e) { return e.key === feature.key })) {
+            group.requestedFeatures.push(featureObj)
+            group.requestedCount++
+          }
+        }
+      }
+    }
+  }
+
+  var groups = Object.keys(versionGroups).sort().map(function(vKey) {
+    var vg = versionGroups[vKey]
+    var compGroups = Object.keys(vg.components).sort().map(function(cKey) {
+      return vg.components[cKey]
+    })
+    var totalRequested = 0
+    var totalCommitted = 0
+    var totalBlocked = 0
+    for (var cgi = 0; cgi < compGroups.length; cgi++) {
+      totalRequested += compGroups[cgi].requestedCount
+      totalCommitted += compGroups[cgi].committedCount
+      totalBlocked += compGroups[cgi].blockedCount
+    }
+    return {
+      version: vg.version,
+      components: compGroups,
+      requestedCount: totalRequested,
+      committedCount: totalCommitted,
+      blockedCount: totalBlocked
+    }
+  })
+
+  return { groups: groups }
+}
+
+module.exports = {
+  canonicalToLoadRow: canonicalToLoadRow,
+  attachAlignment: attachAlignment,
+  featureMatchesComponents: featureMatchesComponents,
+  buildComponentReleaseLoadGroups: buildComponentReleaseLoadGroups
+}

--- a/modules/releases/server/pm-hub/committed-definition.js
+++ b/modules/releases/server/pm-hub/committed-definition.js
@@ -2,10 +2,8 @@
  * PM Hub "Committed" classification.
  *
  * Requested = Target Version intersects selected release scope (handled by caller).
- * Committed = Fix Version intersects selected release scope AND some Target Version
- *   either matches that Fix Version, or is later in the same release cycle
- *   (early delivery). Same cycle = same product + major.minor; milestone order
- *   EA1 < EA2 < GA via tv-fv-delta parse/compare helpers.
+ * Committed = Fix Version intersects selected release scope (FV only — no TV gate).
+ * TV/FV relationship is surfaced separately via alignmentCategory (Delta 5-category).
  */
 
 const {
@@ -15,6 +13,7 @@ const {
 
 /**
  * True when both names parse to the same product + major.minor.
+ * Kept for alignment / cycle helpers; not used to gate Committed.
  */
 function sameReleaseCycle(a, b) {
   var pa = parseReleaseName(a)
@@ -24,51 +23,20 @@ function sameReleaseCycle(a, b) {
 }
 
 /**
- * Whether a Target Version supports treating `fv` as Committed.
- * Match (same version) or early delivery (TV later in same cycle).
- */
-function tvSupportsCommittedFixVersion(fv, tvNames) {
-  if (!fv || !Array.isArray(tvNames) || tvNames.length === 0) return false
-
-  for (var i = 0; i < tvNames.length; i++) {
-    var tv = tvNames[i]
-    if (!tv) continue
-
-    // Exact string match (covers unparseable but identical labels)
-    if (tv === fv) return true
-
-    if (!sameReleaseCycle(fv, tv)) continue
-
-    // compareReleasesTemporally: negative = FV earlier than TV, 0 = same
-    var cmp = compareReleasesTemporally(fv, tv)
-    if (cmp !== null && cmp <= 0) return true
-  }
-
-  return false
-}
-
-/**
- * Filter selected-scope Fix Versions down to those that qualify as Committed
- * given the issue's Target Versions.
+ * Filter Fix Versions that intersect the selected release scope.
+ * Committed is FV-in-scope only; `tvNames` is ignored (kept for call-site compat).
  *
  * @param {string[]} matchingFv - Fix Versions that intersect the selected scope
- * @param {string[]} tvNames - All Target Versions on the issue
- * @returns {string[]} subset of matchingFv that are Committed
+ * @param {string[]} [_tvNames] - unused (TV does not gate Committed)
+ * @returns {string[]} matchingFv (or empty)
  */
-function filterCommittedFixVersions(matchingFv, tvNames) {
+function filterCommittedFixVersions(matchingFv, _tvNames) {
   if (!Array.isArray(matchingFv) || matchingFv.length === 0) return []
-  var out = []
-  for (var i = 0; i < matchingFv.length; i++) {
-    if (tvSupportsCommittedFixVersion(matchingFv[i], tvNames)) {
-      out.push(matchingFv[i])
-    }
-  }
-  return out
+  return matchingFv.slice()
 }
 
 module.exports = {
   sameReleaseCycle,
-  tvSupportsCommittedFixVersion,
   filterCommittedFixVersions,
   parseReleaseName,
   compareReleasesTemporally

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -6,19 +6,21 @@
  * and component-level release load data used by PM Hub reports.
  */
 
-const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
+const { CUSTOM_FIELDS } = require('../hygiene/jira-fetch')
 const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const { JIRA_HOST } = require('../../../../shared/server/jira')
 const { filterCommittedFixVersions, parseReleaseName, compareReleasesTemporally } = require('./committed-definition')
 const { parseDescriptionSignals } = require('../planning/health/description-scanner')
 const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
 const { loadIndex } = require('../planning/cache-reader')
-const { CLOSED_STATUSES, FEATURES_LIST_PROJECTS } = require('../planning/constants')
+const { FEATURES_LIST_PROJECTS } = require('../planning/constants')
+const { loadReleaseDatesMap } = require('../tv-fv-delta/alignment')
+const { buildCanonicalFeatures } = require('../planning/feature-readiness')
+const { fetchFeaturesWithTimeout } = require('../planning/feature-query')
 const {
-  classifyForRelease,
-  isAlignedCategory,
-  loadReleaseDatesMap
-} = require('../tv-fv-delta/alignment')
+  buildComponentReleaseLoadGroups,
+  attachAlignment: attachAlignmentFromCanonical
+} = require('./canonical-load')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 /** Same Feature/Initiative population as Features List live fetch (RHAISTRAT + AIPCC). */
@@ -377,19 +379,6 @@ function formatAvg(value) {
   return value % 1 === 0 ? String(value) : value.toFixed(1)
 }
 
-const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
-const FIELDS_TO_FETCH = [
-  'summary', 'status', 'issuetype', 'assignee', 'priority', 'fixVersions', 'versions',
-  'components', 'labels', 'issuelinks', 'description',
-  CUSTOM_FIELDS.team,
-  CUSTOM_FIELDS.releaseType,
-  CUSTOM_FIELDS.statusSummary,
-  CUSTOM_FIELDS.colorStatus,
-  CUSTOM_FIELDS.productManager,
-  CUSTOM_FIELDS.docsRequired,
-  CUSTOM_FIELDS.riceScore
-].join(',')
-
 /**
  * PM/DO Aligned (legacy binary): Yes when some Fix Version strictly matches some Target Version.
  * Prefer alignmentCategory from attachAlignment() (TV/FV Delta 5-category rules) in PM Hub rows.
@@ -423,18 +412,7 @@ function computePmDoAligned(fixVersions, targetVersions) {
  * Mutates and returns featureObj.
  */
 function attachAlignment(featureObj, release, releaseDates) {
-  if (!featureObj) return featureObj
-  var cat = release
-    ? classifyForRelease(
-      featureObj.targetVersions,
-      featureObj.fixVersions,
-      release,
-      releaseDates || {}
-    )
-    : null
-  featureObj.alignmentCategory = cat
-  featureObj.pmDoAligned = isAlignedCategory(cat)
-  return featureObj
+  return attachAlignmentFromCanonical(featureObj, release, releaseDates)
 }
 
 function computeConfidence(isReady, fixVersion) {
@@ -657,12 +635,14 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *     tags: [Releases]
    *     summary: Get component release load tracking data
    *     description: >
-   *       Queries Jira for Features/Initiatives grouped by version then component.
-   *       Closed/Done/Resolved/Cancelled issues are excluded (same as Features List).
-   *       F Requested = issues where Target Version (cf[10855]) matches a selected version.
-   *       F Committed = issues where fixVersion matches a selected version AND a Target
+   *       Builds Component Release Load from the shared Features pipeline
+   *       (buildCanonicalFeatures over RHAISTRAT + AIPCC, open only — same as
+   *       Features List). Groups by version then component.
+   *       F Requested = Target Version matches a selected version.
+   *       F Committed = fixVersion matches a selected version AND a Target
    *       Version either matches that fixVersion or is later in the same release cycle
    *       (early delivery; same product + major.minor, EA1 < EA2 < GA).
+   *       TV/FV Align uses the Delta 5-category classifier.
    *     parameters:
    *       - in: query
    *         name: components
@@ -765,222 +745,43 @@ module.exports = async function registerPmHubRoutes(router, context) {
     }
 
     try {
-      var releaseDates = await loadReleaseDatesMap(context.storage)
+      var storage = context.storage
+      var releaseDates = await loadReleaseDatesMap(storage)
 
-      var baseParts = [
-        'project IN (' + PM_HUB_PROJECTS.join(', ') + ')',
-        'issuetype IN (' + DEFAULT_ISSUE_TYPES.join(', ') + ')'
-      ]
-      // Requested/Committed exclude closed (same set as Features List). Velocity keeps Done.
-      var openParts = baseParts.concat([
-        'status NOT IN (' + CLOSED_STATUSES.join(', ') + ')'
-      ])
-
-      var componentClause = ''
-      if (componentNames.length > 0) {
-        var escapedComp = componentNames.map(function(c) {
-          return '"' + c.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
-        })
-        componentClause = 'component IN (' + escapedComp.join(', ') + ')'
+      // Same live population as Features List (RHAISTRAT + AIPCC, open only).
+      var jiraFeatures = null
+      try {
+        jiraFeatures = await fetchFeaturesWithTimeout(jiraClient)
+      } catch (jiraErr) {
+        console.warn('[releases/pm-hub] Jira feature query failed, falling back to caches:', jiraErr.message)
       }
 
-      var escapedVer = versionNames.map(function(v) {
-        return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+      var canonical = await buildCanonicalFeatures({
+        readFromStorage: storage.readFromStorage,
+        jiraFeatures: jiraFeatures,
+        listStorageFiles: storage.listStorageFiles || null,
+        includeClosed: false
       })
 
-      var fieldsWithTv = FIELDS_TO_FETCH + ',' + CUSTOM_FIELDS.targetVersion
-
-      // Parallelize live Jira + epic-index reads. Avoid expand=renderedFields —
-      // ADF in fields.description is enough for FPDoR description signals and
-      // rendered HTML roughly doubles payload (gateway ~30s timeout / 504).
-      var tvFetch = Promise.resolve([])
-      var fvFetch = Promise.resolve([])
-      if (versionNames.length > 0) {
-        var tvJqlParts = openParts.slice()
-        if (componentClause) tvJqlParts.push(componentClause)
-        tvJqlParts.push('cf[10855] IN (' + escapedVer.join(', ') + ')')
-        tvFetch = jiraClient.fetchAllJqlResults(tvJqlParts.join(' AND '), fieldsWithTv, {})
-
-        var fvJqlParts = openParts.slice()
-        if (componentClause) fvJqlParts.push(componentClause)
-        fvJqlParts.push('fixVersion IN (' + escapedVer.join(', ') + ')')
-        // FV candidates; Committed bucketing applies a stricter TV/FV rule after fetch.
-        fvFetch = jiraClient.fetchAllJqlResults(fvJqlParts.join(' AND '), fieldsWithTv, {})
-      } else if (componentNames.length > 0) {
-        var compOnlyParts = openParts.slice()
-        compOnlyParts.push(componentClause)
-        fvFetch = jiraClient.fetchAllJqlResults(compOnlyParts.join(' AND '), fieldsWithTv, {})
-      }
-
-      var parallel = await Promise.all([
-        tvFetch,
-        fvFetch,
-        loadEpicCountByKey(context.storage.readFromStorage)
-      ])
-      var requestedIssues = parallel[0]
-      var committedIssues = parallel[1]
-      var epicCountByKey = parallel[2]
-
-      var versionGroups = {}
-
-      function ensureGroup(vName, cName) {
-        if (!versionGroups[vName]) {
-          versionGroups[vName] = { version: vName, components: {} }
-        }
-        if (!versionGroups[vName].components[cName]) {
-          versionGroups[vName].components[cName] = {
-            component: cName,
-            requestedFeatures: [],
-            committedFeatures: [],
-            requestedCount: 0,
-            committedCount: 0,
-            blockedCount: 0
-          }
-        }
-        return versionGroups[vName].components[cName]
-      }
-
-      // Process all issues with OR display logic:
-      // Show issue if selected release matches fixVersion OR targetVersion.
-      // committedFeatures/Count = FV in scope + TV match or early delivery (same cycle).
-      // requestedFeatures/Count = targetVersion matches selected scope only.
-      var allIssues = {}
-
-      for (var ri = 0; ri < requestedIssues.length; ri++) {
-        var raw = requestedIssues[ri]
-        if (!allIssues[raw.key]) allIssues[raw.key] = { raw: raw }
-      }
-      for (var cii = 0; cii < committedIssues.length; cii++) {
-        var rawC = committedIssues[cii]
-        if (!allIssues[rawC.key]) allIssues[rawC.key] = { raw: rawC }
-      }
-
-      var issueKeys = Object.keys(allIssues)
-      for (var ik = 0; ik < issueKeys.length; ik++) {
-        var entry = allIssues[issueKeys[ik]]
-        var rawIssue = entry.raw
-        var f = transformIssue(rawIssue, {})
-        var tvNames = extractTargetVersions(rawIssue)
-        var fvList = f.fixVersions && f.fixVersions.length > 0 ? f.fixVersions : []
-        var compList = f.components && f.components.length > 0 ? f.components : ['No Component']
-
-        if (versionNames.length === 0) {
-          // Component-only mode: group by fixVersion; Committed still requires TV support
-          var committedFvOnly = filterCommittedFixVersions(fvList, tvNames)
-          if (committedFvOnly.length === 0) continue
-          for (var ufi = 0; ufi < committedFvOnly.length; ufi++) {
-            for (var uci = 0; uci < compList.length; uci++) {
-              var ucName = compList[uci]
-              if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
-              var uGroup = ensureGroup(committedFvOnly[ufi], ucName)
-              if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
-                uGroup.committedFeatures.push(
-                  attachAlignment(
-                    buildFeatureObj(f, tvNames, rawIssue, epicCountByKey),
-                    committedFvOnly[ufi],
-                    releaseDates
-                  )
-                )
-                uGroup.committedCount++
-                if (f.isBlocked) uGroup.blockedCount++
-              }
-            }
-          }
-          continue
-        }
-
-        // Determine which selected versions match each field
-        var matchingFv = []
-        var matchingTv = []
-        for (var fvi = 0; fvi < fvList.length; fvi++) {
-          if (versionNames.indexOf(fvList[fvi]) !== -1) matchingFv.push(fvList[fvi])
-        }
-        for (var tvi = 0; tvi < tvNames.length; tvi++) {
-          if (versionNames.indexOf(tvNames[tvi]) !== -1) matchingTv.push(tvNames[tvi])
-        }
-
-        // OR logic: skip if neither field matches any selected version
-        if (matchingFv.length === 0 && matchingTv.length === 0) continue
-
-        // Committed = selected FV + TV match or early delivery in same cycle
-        var committedFv = filterCommittedFixVersions(matchingFv, tvNames)
-
-        // Group only under versions that will receive this feature (avoid empty groups
-        // when FV is in scope but fails the Committed TV rule).
-        var groupVersions = {}
-        for (var mf = 0; mf < committedFv.length; mf++) groupVersions[committedFv[mf]] = true
-        for (var mt = 0; mt < matchingTv.length; mt++) groupVersions[matchingTv[mt]] = true
-        var groupVersionKeys = Object.keys(groupVersions)
-        if (groupVersionKeys.length === 0) continue
-
-        var isRequested = matchingTv.length > 0
-        var featureBase = buildFeatureObj(f, tvNames, rawIssue, epicCountByKey)
-
-        for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
-          var vKey = groupVersionKeys[gvi]
-          var featureObj = attachAlignment(
-            Object.assign({}, featureBase),
-            vKey,
-            releaseDates
-          )
-          for (var ci = 0; ci < compList.length; ci++) {
-            var cName = compList[ci]
-            if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
-            var group = ensureGroup(vKey, cName)
-
-            if (committedFv.indexOf(vKey) !== -1) {
-              if (!group.committedFeatures.some(function(e) { return e.key === f.key })) {
-                group.committedFeatures.push(featureObj)
-                group.committedCount++
-                if (f.isBlocked) group.blockedCount++
-              }
-            }
-            if (isRequested && matchingTv.indexOf(vKey) !== -1) {
-              if (!group.requestedFeatures.some(function(e) { return e.key === f.key })) {
-                group.requestedFeatures.push(featureObj)
-                group.requestedCount++
-              }
-            }
-          }
-        }
-      }
-
-      // Velocity KPI hidden for now (Pillar=All never supplied components; metric needs redesign).
-      // Keep computeVelocity() for a future dedicated report — do not fetch Done history here.
-      var velocity = null
-
-      var groups = Object.keys(versionGroups).sort().map(function(vKey) {
-        var vg = versionGroups[vKey]
-        var compGroups = Object.keys(vg.components).sort().map(function(cKey) {
-          return vg.components[cKey]
-        })
-        var totalRequested = 0
-        var totalCommitted = 0
-        var totalBlocked = 0
-        for (var cgi = 0; cgi < compGroups.length; cgi++) {
-          totalRequested += compGroups[cgi].requestedCount
-          totalCommitted += compGroups[cgi].committedCount
-          totalBlocked += compGroups[cgi].blockedCount
-        }
-        return {
-          version: vg.version,
-          components: compGroups,
-          requestedCount: totalRequested,
-          committedCount: totalCommitted,
-          blockedCount: totalBlocked
-        }
+      var built = buildComponentReleaseLoadGroups(canonical.features || [], {
+        components: componentNames,
+        versions: versionNames,
+        releaseDates: releaseDates
       })
 
+      // Velocity KPI hidden for now — keep computeVelocity() for a future report.
       res.json({
-        groups: groups,
-        velocity: velocity,
+        groups: built.groups,
+        velocity: null,
         fetchedAt: new Date().toISOString(),
-        filters: { components: componentNames, versions: versionNames }
+        filters: { components: componentNames, versions: versionNames },
+        source: jiraFeatures ? 'canonical-live' : 'canonical-cache'
       })
     } catch (err) {
       console.error('[releases/pm-hub] Component release load fetch failed:', err.message)
       res.status(500).json({ error: 'Failed to fetch component release load data' })
     }
+
   })
 }
 

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -14,6 +14,11 @@ const { parseDescriptionSignals } = require('../planning/health/description-scan
 const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
 const { loadIndex } = require('../planning/cache-reader')
 const { CLOSED_STATUSES, FEATURES_LIST_PROJECTS } = require('../planning/constants')
+const {
+  classifyForRelease,
+  isAlignedCategory,
+  loadReleaseDatesMap
+} = require('../tv-fv-delta/alignment')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 /** Same Feature/Initiative population as Features List live fetch (RHAISTRAT + AIPCC). */
@@ -386,9 +391,9 @@ const FIELDS_TO_FETCH = [
 ].join(',')
 
 /**
- * PM/DO Aligned: Yes when some Fix Version strictly matches some Target Version.
- * Match = identical string, or same normalized product + major.minor + event (cmp === 0).
- * Missing TV or FV → not aligned. Early delivery (FV before TV) is NOT aligned.
+ * PM/DO Aligned (legacy binary): Yes when some Fix Version strictly matches some Target Version.
+ * Prefer alignmentCategory from attachAlignment() (TV/FV Delta 5-category rules) in PM Hub rows.
+ * Missing TV or FV → not aligned. Early delivery (FV before TV) is NOT aligned under this binary helper.
  */
 function versionsStrictMatch(a, b) {
   if (!a || !b) return false
@@ -411,6 +416,25 @@ function computePmDoAligned(fixVersions, targetVersions) {
     }
   }
   return false
+}
+
+/**
+ * Attach Delta 5-category alignment for a specific release bucket.
+ * Mutates and returns featureObj.
+ */
+function attachAlignment(featureObj, release, releaseDates) {
+  if (!featureObj) return featureObj
+  var cat = release
+    ? classifyForRelease(
+      featureObj.targetVersions,
+      featureObj.fixVersions,
+      release,
+      releaseDates || {}
+    )
+    : null
+  featureObj.alignmentCategory = cat
+  featureObj.pmDoAligned = isAlignedCategory(cat)
+  return featureObj
 }
 
 function computeConfidence(isReady, fixVersion) {
@@ -508,6 +532,7 @@ function buildFeatureObj(f, targetVersions, rawIssue, epicCountByKey) {
     components: f.components || [],
     fixVersions: fixVersions,
     targetVersions: tv,
+    alignmentCategory: null,
     pmDoAligned: computePmDoAligned(fixVersions, tv),
     assignee: f.assignee || null,
     pmOwner: f.pmOwner || null,
@@ -740,6 +765,8 @@ module.exports = async function registerPmHubRoutes(router, context) {
     }
 
     try {
+      var releaseDates = await loadReleaseDatesMap(context.storage)
+
       var baseParts = [
         'project IN (' + PM_HUB_PROJECTS.join(', ') + ')',
         'issuetype IN (' + DEFAULT_ISSUE_TYPES.join(', ') + ')'
@@ -847,7 +874,13 @@ module.exports = async function registerPmHubRoutes(router, context) {
               if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
               var uGroup = ensureGroup(committedFvOnly[ufi], ucName)
               if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
-                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames, rawIssue, epicCountByKey))
+                uGroup.committedFeatures.push(
+                  attachAlignment(
+                    buildFeatureObj(f, tvNames, rawIssue, epicCountByKey),
+                    committedFvOnly[ufi],
+                    releaseDates
+                  )
+                )
                 uGroup.committedCount++
                 if (f.isBlocked) uGroup.blockedCount++
               }
@@ -881,10 +914,15 @@ module.exports = async function registerPmHubRoutes(router, context) {
         if (groupVersionKeys.length === 0) continue
 
         var isRequested = matchingTv.length > 0
-        var featureObj = buildFeatureObj(f, tvNames, rawIssue, epicCountByKey)
+        var featureBase = buildFeatureObj(f, tvNames, rawIssue, epicCountByKey)
 
         for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
           var vKey = groupVersionKeys[gvi]
+          var featureObj = attachAlignment(
+            Object.assign({}, featureBase),
+            vKey,
+            releaseDates
+          )
           for (var ci = 0; ci < compList.length; ci++) {
             var cName = compList[ci]
             if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
@@ -958,3 +996,4 @@ module.exports.extractTargetVersions = extractTargetVersions
 module.exports.filterCommittedFixVersions = filterCommittedFixVersions
 module.exports.computePmDoAligned = computePmDoAligned
 module.exports.versionsStrictMatch = versionsStrictMatch
+module.exports.attachAlignment = attachAlignment

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -13,10 +13,11 @@ const { filterCommittedFixVersions, parseReleaseName, compareReleasesTemporally 
 const { parseDescriptionSignals } = require('../planning/health/description-scanner')
 const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
 const { loadIndex } = require('../planning/cache-reader')
-const { CLOSED_STATUSES, FEATURE_PIPELINE_PROJECTS } = require('../planning/constants')
+const { CLOSED_STATUSES, FEATURES_LIST_PROJECTS } = require('../planning/constants')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
-const PM_HUB_PROJECTS = FEATURE_PIPELINE_PROJECTS
+/** Same Feature/Initiative population as Features List live fetch (RHAISTRAT + AIPCC). */
+const PM_HUB_PROJECTS = FEATURES_LIST_PROJECTS
 const PILLAR_CONFIG_FILE = 'releases/pm-hub/pillar-config.json'
 
 var DEFAULT_PILLAR_CONFIG = {
@@ -545,7 +546,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *   get:
    *     tags: [Releases]
    *     summary: List Jira components across PM Hub projects
-   *     description: Returns components from RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE, RHELAI, RHAI
+   *     description: Returns components from RHAISTRAT and AIPCC (same population as Features List)
    *     responses:
    *       200:
    *         description: Array of components with project keys
@@ -600,7 +601,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *   get:
    *     tags: [Releases]
    *     summary: List Jira versions across PM Hub projects
-   *     description: Returns versions from RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE, RHELAI, RHAI
+   *     description: Returns versions from RHAISTRAT and AIPCC (same population as Features List)
    *     responses:
    *       200:
    *         description: Array of versions with project keys
@@ -906,19 +907,9 @@ module.exports = async function registerPmHubRoutes(router, context) {
         }
       }
 
-      // Query 3: Velocity — resolved features in the last year with a fixVersion
-      var velocityIssues = []
-      if (componentClause) {
-        var velJqlParts = baseParts.slice()
-        velJqlParts.push(componentClause)
-        velJqlParts.push('statusCategory = Done')
-        velJqlParts.push('resolved >= -' + VELOCITY_LOOKBACK_WEEKS + 'w')
-        velJqlParts.push('fixVersion is not EMPTY')
-        var velJql = velJqlParts.join(' AND ')
-        velocityIssues = await jiraClient.fetchAllJqlResults(velJql, 'summary,status,fixVersions,components,resolutiondate', {})
-      }
-
-      var velocity = computeVelocity(velocityIssues, componentClause, null, componentNames)
+      // Velocity KPI hidden for now (Pillar=All never supplied components; metric needs redesign).
+      // Keep computeVelocity() for a future dedicated report — do not fetch Done history here.
+      var velocity = null
 
       var groups = Object.keys(versionGroups).sort().map(function(vKey) {
         var vg = versionGroups[vKey]

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -639,9 +639,8 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *       (buildCanonicalFeatures over RHAISTRAT + AIPCC, open only — same as
    *       Features List). Groups by version then component.
    *       F Requested = Target Version matches a selected version.
-   *       F Committed = fixVersion matches a selected version AND a Target
-   *       Version either matches that fixVersion or is later in the same release cycle
-   *       (early delivery; same product + major.minor, EA1 < EA2 < GA).
+   *       F Committed = Fix Version matches a selected version (FV only;
+   *       Target Version does not gate Committed — see TV/FV Align for TV/FV relationship).
    *       TV/FV Align uses the Delta 5-category classifier.
    *     parameters:
    *       - in: query

--- a/modules/releases/server/tv-fv-delta/alignment.js
+++ b/modules/releases/server/tv-fv-delta/alignment.js
@@ -1,0 +1,208 @@
+/**
+ * Shared TV/FV alignment helpers for PM Hub and (later) Features List.
+ *
+ * Wraps the TV vs FV Delta 5-category classifier so Plan views use the same
+ * semantics as Reports → TV vs FV Delta.
+ */
+
+const {
+  classifyFeatures,
+  buildReleaseDatesMap,
+  parseVersions
+} = require('./routes')
+
+var CATEGORY_PRIORITY = {
+  misaligned: 4,
+  tv_only: 3,
+  fv_only: 2,
+  aligned_late: 1,
+  aligned_on_time: 0
+}
+
+var ALIGNED_CATEGORIES = {
+  aligned_on_time: true,
+  aligned_late: true
+}
+
+var CATEGORY_LABELS = {
+  aligned_on_time: 'On time',
+  aligned_late: 'Late',
+  misaligned: 'Misaligned',
+  tv_only: 'TV only',
+  fv_only: 'FV only'
+}
+
+var CATEGORY_HELP = {
+  aligned_on_time: 'Fix Version matches Target Version, or ships earlier than planned.',
+  aligned_late: 'Fix Version is later than Target Version, but planning freeze for that Target Version has already passed — accepted slip.',
+  misaligned: 'Fix Version slips past Target Version before planning freeze, or TV/FV point at different products (for example RHOAI vs RHAII).',
+  tv_only: 'Target Version is set for this release, but Fix Version is empty.',
+  fv_only: 'Fix Version is set for this release, but Target Version is empty.'
+}
+
+/**
+ * @param {string[]} names
+ * @returns {string}
+ */
+function joinVersionNames(names) {
+  if (!Array.isArray(names) || names.length === 0) return ''
+  var out = []
+  for (var i = 0; i < names.length; i++) {
+    if (names[i]) out.push(String(names[i]).trim())
+  }
+  return out.join(', ')
+}
+
+/**
+ * Minimal feature shape for classifyFeatures().
+ * @param {string[]} targetVersions
+ * @param {string[]} fixVersions
+ * @returns {object}
+ */
+function buildClassifyFeature(targetVersions, fixVersions) {
+  var tvStr = joinVersionNames(targetVersions)
+  var fvStr = joinVersionNames(fixVersions)
+  return {
+    key: '',
+    url: '',
+    summary: '',
+    status: '',
+    target_version: tvStr,
+    fix_versions: fvStr,
+    tv_set: parseVersions(tvStr),
+    fv_set: parseVersions(fvStr),
+    color_status: '',
+    product_manager: '',
+    assignee: '',
+    components: [],
+    component: ''
+  }
+}
+
+/**
+ * Classify a single issue for one release (same rules as TV/FV Delta).
+ * @param {string[]} targetVersions
+ * @param {string[]} fixVersions
+ * @param {string} release
+ * @param {object} [releaseDates]
+ * @returns {string|null} category or null if release is not on TV or FV
+ */
+function classifyForRelease(targetVersions, fixVersions, release, releaseDates) {
+  if (!release) return null
+  var rows = classifyFeatures(
+    [buildClassifyFeature(targetVersions, fixVersions)],
+    [release],
+    releaseDates || {}
+  )
+  if (!rows || rows.length === 0) return null
+  return rows[0].category || null
+}
+
+/**
+ * Worst category across all releases that appear on TV or FV.
+ * @param {string[]} targetVersions
+ * @param {string[]} fixVersions
+ * @param {object} [releaseDates]
+ * @returns {string|null}
+ */
+function classifyOverall(targetVersions, fixVersions, releaseDates) {
+  var tvs = Array.isArray(targetVersions) ? targetVersions : []
+  var fvs = Array.isArray(fixVersions) ? fixVersions : []
+  var seen = {}
+  var releases = []
+  var lists = [tvs, fvs]
+  for (var li = 0; li < lists.length; li++) {
+    for (var i = 0; i < lists[li].length; i++) {
+      var name = lists[li][i]
+      if (!name || seen[name]) continue
+      seen[name] = true
+      releases.push(name)
+    }
+  }
+  if (releases.length === 0) return null
+  var rows = classifyFeatures(
+    [buildClassifyFeature(tvs, fvs)],
+    releases,
+    releaseDates || {}
+  )
+  return worstCategory(rows.map(function(r) { return r.category }))
+}
+
+/**
+ * @param {string[]} categories
+ * @returns {string|null}
+ */
+function worstCategory(categories) {
+  if (!Array.isArray(categories) || categories.length === 0) return null
+  var worst = null
+  var worstRank = -1
+  for (var i = 0; i < categories.length; i++) {
+    var cat = categories[i]
+    if (!cat) continue
+    var rank = CATEGORY_PRIORITY[cat]
+    if (rank === undefined) continue
+    if (rank > worstRank) {
+      worstRank = rank
+      worst = cat
+    }
+  }
+  return worst
+}
+
+/**
+ * PM/DO "aligned" for KPIs: on-time or accepted late slip.
+ * @param {string|null} category
+ * @returns {boolean}
+ */
+function isAlignedCategory(category) {
+  return !!(category && ALIGNED_CATEGORIES[category])
+}
+
+/**
+ * @param {string|null} category
+ * @returns {string}
+ */
+function categoryLabel(category) {
+  if (!category) return '—'
+  return CATEGORY_LABELS[category] || category
+}
+
+/**
+ * @param {string|null} category
+ * @returns {string}
+ */
+function categoryHelp(category) {
+  if (!category) return 'No Target Version or Fix Version in this release scope.'
+  return CATEGORY_HELP[category] || ''
+}
+
+/**
+ * Load Product Pages freeze/GA dates used by the Delta classifier.
+ * @param {{ readFromStorage: Function }} storage
+ * @returns {Promise<object>}
+ */
+async function loadReleaseDatesMap(storage) {
+  if (!storage || typeof storage.readFromStorage !== 'function') return {}
+  try {
+    var ppCache = await storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
+    return buildReleaseDatesMap(ppCache && ppCache.releases)
+  } catch (err) {
+    console.warn('[releases/tv-fv-alignment] Failed to load Product Pages cache:', err.message)
+    return {}
+  }
+}
+
+module.exports = {
+  CATEGORY_PRIORITY,
+  ALIGNED_CATEGORIES,
+  CATEGORY_LABELS,
+  CATEGORY_HELP,
+  classifyForRelease,
+  classifyOverall,
+  worstCategory,
+  isAlignedCategory,
+  categoryLabel,
+  categoryHelp,
+  loadReleaseDatesMap,
+  buildReleaseDatesMap
+}

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -618,6 +618,18 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     await readinessHeader.first().click();
     await expect(readinessHeader.first()).toHaveAttribute('aria-sort', 'ascending');
 
+    // Score cycle: default desc → asc → clear (aria-sort none; row order still score-desc via default)
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'ascending');
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'none');
+
+    var alignHeader = page.locator('thead th', { hasText: 'TV/FV Align' });
+    await expect(alignHeader.first()).toBeVisible();
+    await expect(alignHeader.first()).toHaveClass(/cursor-pointer/);
+
     expect(page.errors).toHaveLength(0);
   });
 
@@ -653,6 +665,8 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     await expect(page.getByRole('button', { name: /All products/i })).toBeVisible();
     await expect(page.getByText('Failed FPDoR', { exact: true }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Any failed item/i })).toBeVisible();
+    await expect(page.getByText('TV/FV Align', { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /All alignments/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /Export CSV/i })).toBeVisible();
 
     expect(page.errors).toHaveLength(0);
@@ -671,6 +685,9 @@ test.describe('Releases FPDoR Readiness @releases', () => {
 
     var reportCard = page.locator('text=Component Release Load Tracking');
     await expect(reportCard.first()).toBeVisible();
+
+    await expect(page.getByText('Not Aligned', { exact: true }).first()).toBeVisible();
+    await expect(page.locator('thead th', { hasText: 'TV/FV Align' }).first()).toBeVisible();
 
     expect(page.errors).toHaveLength(0);
   });

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -607,28 +607,28 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     var headerCount = await headerRow.count();
     expect(headerCount).toBeGreaterThan(5);
 
-    var scoreHeader = page.getByRole('columnheader', { name: /^Score$/i });
-    await expect(scoreHeader).toBeVisible();
-    await expect(scoreHeader).toHaveAttribute('aria-sort', 'descending');
+    // Use hasText (not getByRole name) — Score/Readiness/Align headers embed tooltip copy in the accessible name.
+    var scoreHeader = page.locator('thead th', { hasText: 'Score' });
+    await expect(scoreHeader.first()).toBeVisible();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
 
-    var readinessHeader = page.getByRole('columnheader', { name: /Readiness/i });
-    await expect(readinessHeader).toBeVisible();
-    await expect(readinessHeader).toHaveClass(/cursor-pointer/);
+    var readinessHeader = page.locator('thead th', { hasText: 'Readiness' });
+    await expect(readinessHeader.first()).toBeVisible();
+    await expect(readinessHeader.first()).toHaveClass(/cursor-pointer/);
 
-    await readinessHeader.click();
-    await expect(readinessHeader).toHaveAttribute('aria-sort', 'ascending');
+    await readinessHeader.first().click();
+    await expect(readinessHeader.first()).toHaveAttribute('aria-sort', 'ascending');
 
-    // Score cycle after switching columns: first click → desc, second → asc, third → clear (none)
-    await scoreHeader.click();
-    await expect(scoreHeader).toHaveAttribute('aria-sort', 'descending');
-    await scoreHeader.click();
-    await expect(scoreHeader).toHaveAttribute('aria-sort', 'ascending');
-    await scoreHeader.click();
-    await expect(scoreHeader).toHaveAttribute('aria-sort', 'none');
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'ascending');
+    await scoreHeader.first().click();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'none');
 
-    var alignHeader = page.getByRole('columnheader', { name: /TV\/FV Align/i });
-    await expect(alignHeader).toBeVisible();
-    await expect(alignHeader).toHaveClass(/cursor-pointer/);
+    var alignHeader = page.locator('thead th', { hasText: 'TV/FV Align' });
+    await expect(alignHeader.first()).toBeVisible();
+    await expect(alignHeader.first()).toHaveClass(/cursor-pointer/);
 
     expect(page.errors).toHaveLength(0);
   });
@@ -665,7 +665,6 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     await expect(page.getByRole('button', { name: /All products/i })).toBeVisible();
     await expect(page.getByText('Failed FPDoR', { exact: true }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Any failed item/i })).toBeVisible();
-    await expect(page.getByText('TV/FV Align', { exact: true }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /All alignments/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /Export CSV/i })).toBeVisible();
 
@@ -685,19 +684,6 @@ test.describe('Releases FPDoR Readiness @releases', () => {
 
     var reportCard = page.locator('text=Component Release Load Tracking');
     await expect(reportCard.first()).toBeVisible();
-
-    // KPI strip + feature table only render after a successful fetch with filters.
-    // Assert chrome that is always present; when the table is mounted, check Align/Readiness.
-    var alignHeader = page.getByRole('columnheader', { name: /TV\/FV Align/i });
-    var readinessHeader = page.getByRole('columnheader', { name: /^Readiness$/i });
-    if (await alignHeader.count() > 0) {
-      await expect(alignHeader).toBeVisible();
-      await expect(readinessHeader).toBeVisible();
-    }
-    var notAligned = page.getByText('Not Aligned', { exact: true });
-    if (await notAligned.count() > 0) {
-      await expect(notAligned.first()).toBeVisible();
-    }
 
     expect(page.errors).toHaveLength(0);
   });

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -607,28 +607,28 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     var headerCount = await headerRow.count();
     expect(headerCount).toBeGreaterThan(5);
 
-    var scoreHeader = page.locator('thead th', { hasText: 'Score' });
-    await expect(scoreHeader.first()).toBeVisible();
-    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
+    var scoreHeader = page.getByRole('columnheader', { name: /^Score$/i });
+    await expect(scoreHeader).toBeVisible();
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'descending');
 
-    var readinessHeader = page.locator('thead th', { hasText: 'Readiness' });
-    await expect(readinessHeader.first()).toBeVisible();
-    await expect(readinessHeader.first()).toHaveClass(/cursor-pointer/);
+    var readinessHeader = page.getByRole('columnheader', { name: /Readiness/i });
+    await expect(readinessHeader).toBeVisible();
+    await expect(readinessHeader).toHaveClass(/cursor-pointer/);
 
-    await readinessHeader.first().click();
-    await expect(readinessHeader.first()).toHaveAttribute('aria-sort', 'ascending');
+    await readinessHeader.click();
+    await expect(readinessHeader).toHaveAttribute('aria-sort', 'ascending');
 
-    // Score cycle: default desc → asc → clear (aria-sort none; row order still score-desc via default)
-    await scoreHeader.first().click();
-    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
-    await scoreHeader.first().click();
-    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'ascending');
-    await scoreHeader.first().click();
-    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'none');
+    // Score cycle after switching columns: first click → desc, second → asc, third → clear (none)
+    await scoreHeader.click();
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'descending');
+    await scoreHeader.click();
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'ascending');
+    await scoreHeader.click();
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'none');
 
-    var alignHeader = page.locator('thead th', { hasText: 'TV/FV Align' });
-    await expect(alignHeader.first()).toBeVisible();
-    await expect(alignHeader.first()).toHaveClass(/cursor-pointer/);
+    var alignHeader = page.getByRole('columnheader', { name: /TV\/FV Align/i });
+    await expect(alignHeader).toBeVisible();
+    await expect(alignHeader).toHaveClass(/cursor-pointer/);
 
     expect(page.errors).toHaveLength(0);
   });
@@ -686,9 +686,18 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     var reportCard = page.locator('text=Component Release Load Tracking');
     await expect(reportCard.first()).toBeVisible();
 
-    await expect(page.getByText('Not Aligned', { exact: true }).first()).toBeVisible();
-    await expect(page.locator('thead th', { hasText: 'TV/FV Align' }).first()).toBeVisible();
-    await expect(page.locator('thead th', { hasText: 'Readiness' }).first()).toBeVisible();
+    // KPI strip + feature table only render after a successful fetch with filters.
+    // Assert chrome that is always present; when the table is mounted, check Align/Readiness.
+    var alignHeader = page.getByRole('columnheader', { name: /TV\/FV Align/i });
+    var readinessHeader = page.getByRole('columnheader', { name: /^Readiness$/i });
+    if (await alignHeader.count() > 0) {
+      await expect(alignHeader).toBeVisible();
+      await expect(readinessHeader).toBeVisible();
+    }
+    var notAligned = page.getByText('Not Aligned', { exact: true });
+    if (await notAligned.count() > 0) {
+      await expect(notAligned.first()).toBeVisible();
+    }
 
     expect(page.errors).toHaveLength(0);
   });

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -688,6 +688,7 @@ test.describe('Releases FPDoR Readiness @releases', () => {
 
     await expect(page.getByText('Not Aligned', { exact: true }).first()).toBeVisible();
     await expect(page.locator('thead th', { hasText: 'TV/FV Align' }).first()).toBeVisible();
+    await expect(page.locator('thead th', { hasText: 'Readiness' }).first()).toBeVisible();
 
     expect(page.errors).toHaveLength(0);
   });

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -258,13 +258,14 @@ test.describe('Releases PM Hub @releases', () => {
     expect(body.error).toContain('filter');
   });
 
-  test('component-release-load returns velocity with age and component fields', async ({ request }) => {
+  test('component-release-load hides velocity while Feature/Initiative load remains', async ({ request }) => {
     const componentsRes = await request.get('/api/modules/releases/pm-hub/jira/components');
     const componentsBody = await componentsRes.json();
     if (!componentsBody.components || componentsBody.components.length === 0) {
       test.skip();
       return;
     }
+    expect(componentsBody.projects).toEqual(expect.arrayContaining(['RHAISTRAT', 'AIPCC']));
     var compName = componentsBody.components[0].name;
     var res = await request.get('/api/modules/releases/pm-hub/component-release-load?components=' + encodeURIComponent(compName));
     if (!res.ok()) {
@@ -272,28 +273,11 @@ test.describe('Releases PM Hub @releases', () => {
       return;
     }
     var body = await res.json();
-    expect(body).toHaveProperty('velocity');
-    var vel = body.velocity;
-    expect(vel).toHaveProperty('avgPerRelease');
-    expect(vel).toHaveProperty('totalResolved');
-    expect(vel).toHaveProperty('hasPartialYear');
-    expect(vel).toHaveProperty('components');
-    expect(vel).toHaveProperty('jql');
-    expect(typeof vel.hasPartialYear).toBe('boolean');
-    if (vel.components.length > 0) {
-      var comp = vel.components[0];
-      expect(comp).toHaveProperty('component');
-      expect(comp).toHaveProperty('resolved');
-      expect(comp).toHaveProperty('releases');
-      expect(comp).toHaveProperty('avgPerRelease');
-      expect(comp).toHaveProperty('activeWeeks');
-      expect(comp).toHaveProperty('isPartialYear');
-      expect(typeof comp.isPartialYear).toBe('boolean');
-      expect(typeof comp.activeWeeks).toBe('number');
-    }
+    expect(body).toHaveProperty('groups');
+    expect(body.velocity).toBeNull();
   });
 
-  test('should show velocity summary card and per-component badges', async ({ page }) => {
+  test('should show Requested/Committed load KPIs without velocity card', async ({ page }) => {
     await page.goto('/#/releases/plan');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
@@ -315,16 +299,10 @@ test.describe('Releases PM Hub @releases', () => {
       await firstOption.click();
       await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-      // Verify the Avg Features Delivered summary card is visible
-      var avgCard = page.locator('text=Avg Features Delivered');
-      await expect(avgCard.first()).toBeVisible();
-
-      // Check for component rows with velocity badges (avg/rel text)
-      var velocityBadges = page.locator('text=avg/rel');
-      var badgeCount = await velocityBadges.count();
-      // Velocity badges appear on component rows when data is loaded
-      // May be 0 if the component has no resolved features in the last year
-      expect(badgeCount).toBeGreaterThanOrEqual(0);
+      await expect(page.locator('text=Requested').first()).toBeVisible();
+      await expect(page.locator('text=Committed').first()).toBeVisible();
+      await expect(page.locator('text=Avg Features Delivered')).toHaveCount(0);
+      await expect(page.locator('text=avg/rel')).toHaveCount(0);
     }
 
     expect(page.errors).toHaveLength(0);

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -735,6 +735,18 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     expect(typeof sample.readinessGates.fpDorTotal).toBe('number');
     expect(typeof sample.readinessGates.fpDorApplicable).toBe('number');
     expect(typeof sample.readinessGates.pastRefinement).toBe('boolean');
+
+    // TV/FV Align (same categories as Reports → TV vs FV Delta / PM Hub)
+    expect(sample).toHaveProperty('alignmentCategory');
+    if (sample.alignmentCategory != null) {
+      expect([
+        'aligned_on_time',
+        'aligned_late',
+        'misaligned',
+        'tv_only',
+        'fv_only'
+      ]).toContain(sample.alignmentCategory);
+    }
   });
 
   test('feature-readiness API returns priority score breakdown', async ({ request }) => {

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -609,9 +609,14 @@ test.describe('Releases FPDoR Readiness @releases', () => {
 
     var scoreHeader = page.locator('thead th', { hasText: 'Score' });
     await expect(scoreHeader.first()).toBeVisible();
+    await expect(scoreHeader.first()).toHaveAttribute('aria-sort', 'descending');
 
     var readinessHeader = page.locator('thead th', { hasText: 'Readiness' });
     await expect(readinessHeader.first()).toBeVisible();
+    await expect(readinessHeader.first()).toHaveClass(/cursor-pointer/);
+
+    await readinessHeader.first().click();
+    await expect(readinessHeader.first()).toHaveAttribute('aria-sort', 'ascending');
 
     expect(page.errors).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Bring TV vs FV Delta’s 5-category alignment into PM Hub Component Release Load (On time / Late / Misaligned / TV only / FV only), using the same classifier + Product Pages freeze dates as the Delta report.
- Not Aligned KPI now matches Delta semantics (early delivery counts as aligned; late after freeze counts as aligned).
- Add sortable Features List columns (default Score descending).
- Lock Features pipeline population to RHAISTRAT + AIPCC.
- **Hardening:** FPDoR no longer trusts a bare `rp-qg1-pass` label for field/sign-off shortcuts. Shortcuts require `feature.qg1PassVerified === true` (bot gate comment / QG1-FP). Hand-applied pass labels are ignored for readiness scoring.

## Test plan
- [ ] Unit: `npm test -- --run modules/releases/server/tv-fv-delta/alignment.test.js modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js modules/releases/__tests__/client/plan/feature-readiness-sort.test.js`
- [ ] Unit: `npm test -- --run modules/releases/server/planning/__tests__/feature-readiness.test.js` (includes unverified vs bot-verified `rp-qg1-pass` cases)
- [ ] PM Hub → Component Release Load: TV/FV Align chips show categories; tooltips match Delta language; Not Aligned KPI updates with filters
- [ ] Spot-check a known early-delivery feature: category On time (not “No”)
- [ ] Spot-check TV-only / misaligned rows against Reports → TV vs FV Delta for the same release
- [ ] Features List: click Score/Key/Readiness headers; sort arrow + row order change; third click clears to default Score order
- [ ] Integration: Features List sortable header assertions in `tests/integration/releases.spec.js`
- [ ] Features with only a hand-applied `rp-qg1-pass` (no fields) stay Pending / fail the relevant FPDoR items