### PR TITLE
fix(releases): recalibrate risk dashboard predictions and probability

### DIFF
--- a/modules/releases/client/deliver/components/ProductReleaseCard.vue
+++ b/modules/releases/client/deliver/components/ProductReleaseCard.vue
@@ -382,7 +382,7 @@ function computeForecast(remaining, componentNames) {
   }
 }
 
-function computePredictedDate(releaseRemaining, otherWorkload, velocity) {
+function computePredictedDate(releaseRemaining, velocity) {
   if (releaseRemaining === 0) return null
   if (!velocity || velocity <= 0) return null
   const windowsNeeded = releaseRemaining / velocity
@@ -475,7 +475,7 @@ const componentList = computed(() => {
       const globalOtherWorkload = Math.max(0, globalTotalOpen - currentReleaseOpen)
 
       const forecast = computeForecast(remaining, [c.name])
-      const predictedDate = computePredictedDate(remaining, globalOtherWorkload, forecast.velocity)
+      const predictedDate = computePredictedDate(remaining, forecast.velocity)
 
       return {
         name: c.name,

--- a/modules/releases/client/deliver/components/ProductReleaseCard.vue
+++ b/modules/releases/client/deliver/components/ProductReleaseCard.vue
@@ -284,6 +284,7 @@ import ComponentDetailRow from './ComponentDetailRow.vue'
 import { extractProduct } from '../composables/release-utils'
 
 const FORECAST_WINDOW = 14
+const MAX_SLIP_DAYS = 20
 const STRATEGIC_TYPES = new Set(['feature', 'initiative', 'spike'])
 const BUCKET_ORDER = { to_do: 0, doing: 1, done: 2 }
 
@@ -384,11 +385,12 @@ function computeForecast(remaining, componentNames) {
 function computePredictedDate(releaseRemaining, otherWorkload, velocity) {
   if (releaseRemaining === 0) return null
   if (!velocity || velocity <= 0) return null
-  const totalWorkload = releaseRemaining + otherWorkload
-  const windowsNeeded = totalWorkload / velocity
+  const windowsNeeded = releaseRemaining / velocity
   const daysNeeded = Math.ceil(windowsNeeded * FORECAST_WINDOW)
+  const maxDays = daysUntilDeadline() + MAX_SLIP_DAYS
+  const cappedDays = Math.min(daysNeeded, maxDays)
   const predicted = new Date()
-  predicted.setDate(predicted.getDate() + daysNeeded)
+  predicted.setDate(predicted.getDate() + cappedDays)
   return predicted.toISOString().slice(0, 10)
 }
 
@@ -437,7 +439,9 @@ const componentList = computed(() => {
 
   return Object.values(map)
     .map(c => {
-      const remaining = c.issues_to_do + c.issues_doing
+      const remaining = c.allIssues
+        .filter(i => i.statusBucket !== 'done')
+        .reduce((sum, i) => sum + (i.childrenRemaining || 1), 0)
 
       const compStrategic = c.allIssues.filter(i => strategicMap[i.key])
       const compStrategicKeys = new Set(compStrategic.map(i => i.key))
@@ -519,7 +523,7 @@ const releaseForecast = computed(() => {
   for (const issue of projectFilteredIssues.value) {
     if (seen.has(issue.key)) continue
     seen.add(issue.key)
-    if (issue.statusBucket !== 'done') totalRemaining++
+    if (issue.statusBucket !== 'done') totalRemaining += (issue.childrenRemaining || 1)
   }
   const forecast = computeForecast(totalRemaining, allNames)
 

--- a/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
+++ b/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
@@ -202,17 +202,17 @@ function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() +
 
 function buildComponentForecasts(releases) {
   const cv = props.componentVelocity || {}
-  const gw = props.componentGlobalWorkload || {}
   const componentMap = {}
 
   for (const r of releases) {
     const issues = Array.isArray(r.issues) && r.issues.length ? r.issues : (Array.isArray(r.features) ? r.features : [])
     for (const issue of issues) {
       if (issue.statusBucket === 'done') continue
+      const weight = issue.childrenRemaining || 1
       const names = issue.components?.length ? issue.components : ['(No component)']
       for (const name of names) {
         if (!componentMap[name]) componentMap[name] = { remaining: 0 }
-        componentMap[name].remaining++
+        componentMap[name].remaining += weight
       }
     }
   }
@@ -221,17 +221,16 @@ function buildComponentForecasts(releases) {
   for (const [name, data] of Object.entries(componentMap)) {
     const velocity = cv[name]?.velocity || 0
     if (velocity <= 0 || data.remaining <= 0) continue
-    const globalEntry = gw[name]
-    const globalTotalOpen = globalEntry?.totalOpen || 0
-    const otherWorkload = Math.max(0, globalTotalOpen - data.remaining)
     components.push({
       name,
-      totalWorkload: data.remaining + otherWorkload,
+      totalWorkload: data.remaining,
       velocity
     })
   }
   return components
 }
+
+const MAX_SLIP_DAYS = 20
 
 const groupForecast = computed(() => {
   const components = buildComponentForecasts(props.group.releases)
@@ -241,15 +240,9 @@ const groupForecast = computed(() => {
   if (!deadline) return null
 
   const today = getToday()
-
-  const onTrackCount = components.filter(comp => {
-    const windowsNeeded = comp.totalWorkload / comp.velocity
-    const daysNeeded = Math.ceil(windowsNeeded * FORECAST_WINDOW)
-    const predictedISO = addDays(today, daysNeeded).toISOString().slice(0, 10)
-    return predictedISO <= deadline
-  }).length
-
-  const pAtDeadline = Math.round((onTrackCount / components.length) * 100)
+  const daysToDeadline = Math.max(0, Math.ceil(
+    (new Date(deadline + 'T00:00:00') - today) / 86400000
+  ))
 
   const groupCompletionDays = new Array(ITERATIONS)
   for (let i = 0; i < ITERATIONS; i++) {
@@ -263,14 +256,21 @@ const groupForecast = computed(() => {
   }
   groupCompletionDays.sort((a, b) => a - b)
 
-  const p85Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.85) - 1]
-  const p95Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.95) - 1]
+  let completedByDeadline = 0
+  for (let i = 0; i < ITERATIONS; i++) {
+    if (groupCompletionDays[i] <= daysToDeadline) completedByDeadline++
+  }
+  const pAtDeadline = Math.round((completedByDeadline / ITERATIONS) * 100)
+
+  const rawP85 = groupCompletionDays[Math.ceil(ITERATIONS * 0.85) - 1]
+  const rawP95 = groupCompletionDays[Math.ceil(ITERATIONS * 0.95) - 1]
+  const p85Days = Math.min(rawP85, daysToDeadline + MAX_SLIP_DAYS)
+  const p95Days = Math.min(rawP95, daysToDeadline + MAX_SLIP_DAYS + FORECAST_WINDOW)
 
   const totalRemaining = components.reduce((s, c) => s + c.totalWorkload, 0)
 
   return {
     pAtDeadline,
-    onTrackCount,
     p85Days,
     p85Date: addDays(today, p85Days),
     p95Days,

--- a/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
+++ b/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
@@ -137,7 +137,7 @@
           </div>
           <p class="text-[9px] text-gray-400 dark:text-gray-500 mt-2">
             1,000 simulations, per-component critical path (slowest component determines release).
-            {{ groupForecast.componentCount }} component(s) simulated · {{ groupForecast.totalRemaining }} total workload (release + other open work).
+            {{ groupForecast.componentCount }} component(s) simulated · {{ groupForecast.totalRemaining }} weighted remaining items.
           </p>
         </div>
 

--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -338,7 +338,7 @@ function getMonteCarloInputs(release) {
   let notDoneCount = 0
   const componentNames = new Set()
   for (const issue of issues) {
-    if (issue.statusBucket !== 'done') notDoneCount++
+    if (issue.statusBucket !== 'done') notDoneCount += (issue.childrenRemaining || 1)
     const comps = issue.components?.length ? issue.components : ['(No component)']
     for (const c of comps) componentNames.add(c)
   }

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -977,6 +977,22 @@ async function runFullAnalysis(storage, config) {
     }
   }
 
+  // Recalculate risk using weighted incomplete (childrenRemaining) after enrichment
+  const now2 = new Date()
+  for (const release of result.releases) {
+    const daysRemaining = safeDaysBetween(now2, release.dueDate)
+    let weightedIncomplete = 0
+    for (const issue of release.issues) {
+      if (issue.statusBucket !== 'done') {
+        weightedIncomplete += (issue.childrenRemaining || 1)
+      }
+    }
+    const aggRisk = releaseRiskFromIncompleteAndTime(daysRemaining, weightedIncomplete, config)
+    release.risk = aggRisk
+    release.riskScore = riskScoreFromLevel(aggRisk)
+    release.riskSummary = buildReleaseRiskSummary(release, aggRisk, release.riskDriver, daysRemaining)
+  }
+
   if (jiraWarning) result.warning = jiraWarning
 
   const d = result.fixVersionDiagnostics


### PR DESCRIPTION
## Summary

- Removes global workload from predicted date calculation — uses only release-scoped work per component, preventing absurd 2027 predictions for near-term releases
- Caps prediction slip to 20 days beyond the due date (`MAX_SLIP_DAYS`)
- Replaces the deterministic component-ratio `pAtDeadline` with a true Monte Carlo hit rate (counts how many of 1000 simulations complete by the deadline)
- Weights workload by `childrenRemaining` instead of raw feature count, aligning units with velocity (children resolved per 2-week window)
- Recalculates server-side risk badge post-enrichment using weighted incomplete count for accurate green/yellow/red thresholds

## Test plan

- [x] All 5104 unit tests pass (`npm test`)
- [ ] Verify risk dashboard shows realistic predicted dates (within ~3 weeks of due date max)
- [ ] Confirm probability percentage reflects Monte Carlo simulation accuracy
- [ ] Check that components with many child issues correctly weight heavier than single-child features


Made with [Cursor](https://cursor.com)