### PR TITLE
fix(okr-hub): change on-time releases default since to 2026-01-01

### DIFF
--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -87,7 +87,7 @@ var reports = [
   {
     id: 'on-time-releases',
     title: 'On Time Releases',
-    description: 'Did we hit the planned GA date? Tracks all point and major RHAI releases GA\'d after April 1, 2026.',
+    description: 'Did we hit the planned GA date? Tracks all point and major RHAI releases GA\'d after January 1, 2026.',
     icon: '🚀',
     iconBg: 'bg-blue-50 dark:bg-blue-900/30',
     measure: 'Number of Releases On Time - 100%',

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -98,14 +98,14 @@ module.exports = function registerRoutes(router, context) {
    *       - name: since
    *         in: query
    *         schema: { type: string }
-   *         description: ISO date cutoff for planned GA (default 2026-04-01)
+   *         description: ISO date cutoff for planned GA (default 2026-01-01)
    *     responses:
    *       200:
    *         description: Array of releases with on-time analysis
    */
   router.get('/reports/on-time-releases', requireScope('okr-hub:read'), async function(req, res) {
     try {
-      var since = req.query.since || '2026-04-01'
+      var since = req.query.since || '2026-01-01'
 
       var overrides = await storage.readFromStorage('okr-hub/on-time-overrides.json')
       var entries = (overrides && Array.isArray(overrides.releases)) ? overrides.releases : []


### PR DESCRIPTION
## Summary

- Change default `since` cutoff from `2026-04-01` to `2026-01-01` so Q1 releases configured via the gear icon are visible in the report
- Update description text to match

## Test plan

- [ ] Verify Q1 releases (planned GA in Jan/Feb/Mar 2026) now appear in the On Time Releases report
- [ ] Verify the report subtitle shows "after 2026-01-01"


Made with [Cursor](https://cursor.com)