### PR TITLE
feat(allocation): board-type explainer, self-service refresh, per-team basis config

### DIFF
--- a/platform/allocation/__tests__/client/TeamAllocationTab.test.js
+++ b/platform/allocation/__tests__/client/TeamAllocationTab.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+vi.mock('../../client/services/allocation-api', () => ({
+  getBoardSprints: vi.fn(),
+  getSprintIssues: vi.fn(),
+  getTeamAllocationSettings: vi.fn()
+}))
+
+vi.mock('../../client/composables/useAllocationStrategy', () => ({
+  useAllocationStrategy: () => ({
+    categories: { value: [{ key: 'new-features', name: 'New Features', color: 'blue', target: 40 }] },
+    name: { value: 'AI Engineering 40/40/20' }
+  })
+}))
+
+vi.mock('../../client/composables/useAllocationRefresh', async () => {
+  const { ref } = await import('vue')
+  return {
+    useAllocationRefresh: () => ({ refreshing: ref(false), message: ref(''), triggerRefresh: vi.fn() })
+  }
+})
+
+const { getBoardSprints, getSprintIssues, getTeamAllocationSettings } = await import('../../client/services/allocation-api')
+import TeamAllocationTab from '../../client/TeamAllocationTab.vue'
+
+const SCRUM_SPRINTS = {
+  synced: true,
+  lastUpdated: '2026-08-17T15:00:00.000Z',
+  sprints: [{ id: 100, name: 'Sprint 1', state: 'active', startDate: '2026-08-01', endDate: '2026-08-14' }]
+}
+const SCRUM_ISSUES = {
+  sprintId: 100, sprintName: 'Sprint 1', sprintState: 'active',
+  issues: [{ key: 'X-1', bucket: 'new-features', storyPoints: 5, resolution: null }],
+  summary: { totalPoints: 5, totalCount: 1, buckets: { 'new-features': { points: 5, count: 1 } } }
+}
+
+function mountTab(props) {
+  return mount(TeamAllocationTab, {
+    props,
+    global: {
+      stubs: {
+        SprintSelector: true, SprintStatusBadge: true, AllocationBar: true,
+        BucketBreakdown: true, MetricToggle: true, UnestimatedPanel: true, CompletionSummary: true
+      }
+    }
+  })
+}
+
+describe('TeamAllocationTab board selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getBoardSprints.mockResolvedValue(SCRUM_SPRINTS)
+    getSprintIssues.mockResolvedValue(SCRUM_ISSUES)
+    getTeamAllocationSettings.mockResolvedValue({ allocationMode: 'points', configured: true, canEdit: false })
+  })
+
+  it('auto-selects the board and renders the info block when boards are present at mount', async () => {
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+
+    expect(getBoardSprints).toHaveBeenCalledWith(1103, undefined)
+    expect(wrapper.text()).toContain('detected as a')
+    expect(wrapper.text()).toContain('Scrum board')
+  })
+
+  it('hides the settings button when the user cannot edit the team', async () => {
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="allocation-settings-button"]').exists()).toBe(false)
+  })
+
+  it('shows the settings button when the user can edit the team', async () => {
+    getTeamAllocationSettings.mockResolvedValue({ allocationMode: 'points', configured: true, canEdit: true })
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="allocation-settings-button"]').exists()).toBe(true)
+  })
+
+  it('shows the unconfigured banner when the team has no allocation basis set', async () => {
+    getTeamAllocationSettings.mockResolvedValue({ allocationMode: null, configured: false, canEdit: true })
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="allocation-unconfigured-banner"]').exists()).toBe(true)
+    // A manager gets a call-to-action to configure it.
+    expect(wrapper.find('[data-testid="allocation-unconfigured-cta"]').exists()).toBe(true)
+  })
+
+  it('hides the unconfigured banner once a basis is configured', async () => {
+    getTeamAllocationSettings.mockResolvedValue({ allocationMode: 'counts', configured: true, canEdit: true })
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="allocation-unconfigured-banner"]').exists()).toBe(false)
+  })
+
+  it('selects the board when teamDetail arrives asynchronously after mount', async () => {
+    // teamDetail is null at mount (the real-world async case that caused the bug)
+    const wrapper = mountTab({ team: { metadata: {} }, teamId: 'team_1', teamDetail: null })
+    await flushPromises()
+    expect(getBoardSprints).not.toHaveBeenCalled()
+    // "not set up" empty state while there are no boards
+    expect(wrapper.find('[data-testid="allocation-refresh-panel"]').exists()).toBe(true)
+
+    // teamDetail loads → board should be auto-selected and sprints fetched
+    await wrapper.setProps({ teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] } })
+    await flushPromises()
+
+    expect(getBoardSprints).toHaveBeenCalledWith(1103, undefined)
+    expect(wrapper.text()).toContain('Scrum board')
+  })
+
+  it('shows the never-synced state when the board has no data file', async () => {
+    getBoardSprints.mockResolvedValue({ synced: false, sprints: [] })
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain("hasn't been synced yet")
+  })
+
+  it('shows the synced-but-empty state when Jira returns no sprints', async () => {
+    getBoardSprints.mockResolvedValue({ synced: true, sprints: [], lastUpdated: '2026-08-17T15:00:00.000Z' })
+    const wrapper = mountTab({
+      team: { metadata: {} },
+      teamId: 'team_1',
+      teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] }
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('No sprints found for this board')
+  })
+})

--- a/platform/allocation/__tests__/client/allocation/AllocationRefreshPanel.test.js
+++ b/platform/allocation/__tests__/client/allocation/AllocationRefreshPanel.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AllocationRefreshPanel from '../../../client/allocation/AllocationRefreshPanel.vue'
+
+describe('AllocationRefreshPanel', () => {
+  it('renders title and description', () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'Never synced', description: 'Pull it in.' }
+    })
+    expect(wrapper.text()).toContain('Never synced')
+    expect(wrapper.text()).toContain('Pull it in.')
+  })
+
+  it('shows the refresh button when canRefresh is true and emits on click', async () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'x', canRefresh: true, buttonLabel: 'Refresh this team\'s data' }
+    })
+    const btn = wrapper.get('[data-testid="allocation-refresh-button"]')
+    expect(btn.text()).toContain("Refresh this team's data")
+    await btn.trigger('click')
+    expect(wrapper.emitted('refresh')).toBeTruthy()
+  })
+
+  it('shows a spinner and "Refreshing…" while refreshing', () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'x', canRefresh: true, refreshing: true }
+    })
+    const btn = wrapper.get('[data-testid="allocation-refresh-button"]')
+    expect(btn.text()).toContain('Refreshing…')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(wrapper.find('svg.animate-spin').exists()).toBe(true)
+  })
+
+  it('hides the button and shows the hint when canRefresh is false', () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'x', canRefresh: false, hint: 'Ask an admin.' }
+    })
+    expect(wrapper.find('[data-testid="allocation-refresh-button"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Ask an admin.')
+  })
+
+  it('renders a formatted last-synced timestamp when provided', () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'x', lastUpdated: '2026-08-14T15:15:38.649Z' }
+    })
+    expect(wrapper.text()).toContain('Last synced')
+  })
+
+  it('surfaces the status message', () => {
+    const wrapper = mount(AllocationRefreshPanel, {
+      props: { title: 'x', canRefresh: true, message: 'Fetching from Jira…' }
+    })
+    expect(wrapper.get('[data-testid="allocation-refresh-message"]').text()).toBe('Fetching from Jira…')
+  })
+})

--- a/platform/allocation/__tests__/client/allocation/AllocationSettingsModal.test.js
+++ b/platform/allocation/__tests__/client/allocation/AllocationSettingsModal.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+vi.mock('../../../client/services/allocation-api', () => ({
+  updateTeamAllocationSettings: vi.fn()
+}))
+
+const mockTriggerRefresh = vi.fn().mockResolvedValue({ status: 'started' })
+vi.mock('../../../client/composables/useAllocationRefresh', () => ({
+  useAllocationRefresh: () => ({ refreshing: { value: false }, message: { value: '' }, triggerRefresh: mockTriggerRefresh })
+}))
+
+const { updateTeamAllocationSettings } = await import('../../../client/services/allocation-api')
+import AllocationSettingsModal from '../../../client/allocation/AllocationSettingsModal.vue'
+
+function mountModal(currentMode = 'points') {
+  return mount(AllocationSettingsModal, { props: { teamId: 'team_1', currentMode } })
+}
+
+describe('AllocationSettingsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateTeamAllocationSettings.mockResolvedValue({ allocationMode: 'counts' })
+  })
+
+  it('requires an explicit choice on first-time config (no mode pre-selected)', async () => {
+    const wrapper = mountModal(null)
+    expect(wrapper.find('[data-testid="allocation-settings-firsttime"]').exists()).toBe(true)
+    expect(wrapper.get('input[value="points"]').element.checked).toBe(false)
+    expect(wrapper.get('input[value="counts"]').element.checked).toBe(false)
+    expect(wrapper.get('[data-testid="allocation-settings-save"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('input[value="points"]').setValue()
+    expect(wrapper.get('[data-testid="allocation-settings-save"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('disables Save until the mode changes', async () => {
+    const wrapper = mountModal('points')
+    expect(wrapper.get('[data-testid="allocation-settings-save"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('input[value="counts"]').setValue()
+    expect(wrapper.get('[data-testid="allocation-settings-save"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('persists the new mode, triggers a refresh, and emits saved', async () => {
+    const wrapper = mountModal('points')
+    await wrapper.get('input[value="counts"]').setValue()
+    await wrapper.get('[data-testid="allocation-settings-save"]').trigger('click')
+    await flushPromises()
+
+    expect(updateTeamAllocationSettings).toHaveBeenCalledWith('team_1', 'counts')
+    expect(mockTriggerRefresh).toHaveBeenCalledWith({ teamId: 'team_1' })
+    expect(wrapper.emitted('saved')).toBeTruthy()
+    expect(wrapper.emitted('saved')[0]).toEqual(['counts'])
+  })
+
+  it('shows a permission error on 403 and does not emit saved', async () => {
+    const err = new Error('forbidden'); err.status = 403
+    updateTeamAllocationSettings.mockRejectedValue(err)
+
+    const wrapper = mountModal('points')
+    await wrapper.get('input[value="counts"]').setValue()
+    await wrapper.get('[data-testid="allocation-settings-save"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="allocation-settings-error"]').text()).toContain("don't have permission")
+    expect(wrapper.emitted('saved')).toBeFalsy()
+  })
+
+  it('emits close on Cancel', async () => {
+    const wrapper = mountModal('points')
+    const cancel = wrapper.findAll('button').find(b => b.text() === 'Cancel')
+    await cancel.trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})

--- a/platform/allocation/__tests__/client/allocation/BoardTypeInfo.test.js
+++ b/platform/allocation/__tests__/client/allocation/BoardTypeInfo.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BoardTypeInfo from '../../../client/allocation/BoardTypeInfo.vue'
+
+describe('BoardTypeInfo', () => {
+  it('labels the board as Scrum by default', () => {
+    const wrapper = mount(BoardTypeInfo)
+    expect(wrapper.get('[data-testid="board-type-label"]').text()).toBe('Scrum board')
+    expect(wrapper.text()).toContain('the issues in the selected sprint')
+  })
+
+  it('labels the board as Kanban when boardType is kanban', () => {
+    const wrapper = mount(BoardTypeInfo, { props: { boardType: 'kanban' } })
+    expect(wrapper.get('[data-testid="board-type-label"]').text()).toBe('Kanban board')
+    expect(wrapper.text()).toContain('last 2 weeks')
+  })
+
+  it('hides the detailed explanation until toggled', async () => {
+    const wrapper = mount(BoardTypeInfo)
+    expect(wrapper.find('[data-testid="board-type-info-detail"]').exists()).toBe(false)
+
+    await wrapper.get('[data-testid="board-type-info-toggle"]').trigger('click')
+    expect(wrapper.find('[data-testid="board-type-info-detail"]').exists()).toBe(true)
+  })
+
+  it('explains the rolling 14-day window for kanban boards', async () => {
+    const wrapper = mount(BoardTypeInfo, { props: { boardType: 'kanban' } })
+    await wrapper.get('[data-testid="board-type-info-toggle"]').trigger('click')
+    expect(wrapper.get('[data-testid="board-type-info-detail"]').text()).toContain('resolved in the past 14 days')
+  })
+
+  it('explains sprint-based measurement for scrum boards', async () => {
+    const wrapper = mount(BoardTypeInfo, { props: { boardType: 'scrum' } })
+    await wrapper.get('[data-testid="board-type-info-toggle"]').trigger('click')
+    expect(wrapper.get('[data-testid="board-type-info-detail"]').text()).toContain('the sprint selected above')
+  })
+
+  it('reflects expanded state via aria-expanded', async () => {
+    const wrapper = mount(BoardTypeInfo)
+    const toggle = wrapper.get('[data-testid="board-type-info-toggle"]')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+  })
+})

--- a/platform/allocation/__tests__/client/composables/useAllocationRefresh.test.js
+++ b/platform/allocation/__tests__/client/composables/useAllocationRefresh.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAllocationRefresh } from '../../../client/composables/useAllocationRefresh'
+
+vi.mock('../../../client/services/allocation-api', () => ({
+  refreshAllocation: vi.fn(),
+  getRefreshStatus: vi.fn()
+}))
+
+const { refreshAllocation, getRefreshStatus } = await import('../../../client/services/allocation-api')
+
+describe('useAllocationRefresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('handles a "skipped" response without polling or calling onComplete', async () => {
+    getRefreshStatus.mockResolvedValue({ completedAt: 'T0', running: false })
+    refreshAllocation.mockResolvedValue({ status: 'skipped', message: 'Refresh disabled in demo mode' })
+    const onComplete = vi.fn()
+
+    const { triggerRefresh, phase, message, refreshing } = useAllocationRefresh()
+    await triggerRefresh({ teamId: 't1', onComplete })
+
+    expect(phase.value).toBe('unavailable')
+    expect(message.value).toContain('demo mode')
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(refreshing.value).toBe(false)
+  })
+
+  it('reloads immediately on "cooldown"', async () => {
+    getRefreshStatus.mockResolvedValue({ completedAt: 'T0', running: false })
+    refreshAllocation.mockResolvedValue({ status: 'cooldown', retryAfter: 30 })
+    const onComplete = vi.fn()
+
+    const { triggerRefresh, phase } = useAllocationRefresh()
+    await triggerRefresh({ teamId: 't1', onComplete })
+
+    expect(phase.value).toBe('done')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls until the run completes, then calls onComplete', async () => {
+    let call = 0
+    getRefreshStatus.mockImplementation(() => {
+      call++
+      if (call === 1) return Promise.resolve({ running: false, completedAt: 'T0' }) // before trigger
+      if (call === 2) return Promise.resolve({ running: true, completedAt: 'T0' })  // still running
+      return Promise.resolve({ running: false, completedAt: 'T1', lastResult: { status: 'success' } })
+    })
+    refreshAllocation.mockResolvedValue({ status: 'started', scope: 'team' })
+    const onComplete = vi.fn()
+
+    const { triggerRefresh, phase } = useAllocationRefresh({ pollIntervalMs: 1, maxPolls: 5 })
+    await triggerRefresh({ teamId: 't1', onComplete })
+
+    expect(refreshAllocation).toHaveBeenCalledWith('t1', false)
+    expect(phase.value).toBe('done')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets an error phase when the trigger throws', async () => {
+    getRefreshStatus.mockResolvedValue({ completedAt: 'T0', running: false })
+    refreshAllocation.mockRejectedValue(new Error('boom'))
+
+    const { triggerRefresh, phase, refreshing } = useAllocationRefresh()
+    const res = await triggerRefresh({ teamId: 't1' })
+
+    expect(res.status).toBe('error')
+    expect(phase.value).toBe('error')
+    expect(refreshing.value).toBe(false)
+  })
+
+  it('ignores re-entrant triggers while already refreshing', async () => {
+    getRefreshStatus.mockResolvedValue({ running: false, completedAt: 'T0' })
+    // Never-resolving trigger keeps refreshing=true
+    refreshAllocation.mockReturnValue(new Promise(() => {}))
+
+    const { triggerRefresh } = useAllocationRefresh()
+    triggerRefresh({ teamId: 't1' })
+    // allow the first trigger to flip refreshing on
+    await Promise.resolve()
+    await Promise.resolve()
+    const second = await triggerRefresh({ teamId: 't1' })
+
+    expect(second).toEqual({ status: 'busy' })
+    expect(refreshAllocation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/platform/allocation/__tests__/client/reports/AllocationReport.test.js
+++ b/platform/allocation/__tests__/client/reports/AllocationReport.test.js
@@ -24,6 +24,20 @@ vi.mock('../../../client/composables/useAllocationStrategy', () => ({
   })
 }))
 
+const mockIsAdmin = ref(false)
+vi.mock('@shared/client/composables/useAuth', () => ({
+  useAuth: () => ({ isAdmin: mockIsAdmin })
+}))
+
+const mockTriggerRefresh = vi.fn()
+vi.mock('../../../client/composables/useAllocationRefresh', () => ({
+  useAllocationRefresh: () => ({
+    refreshing: ref(false),
+    message: ref(''),
+    triggerRefresh: mockTriggerRefresh
+  })
+}))
+
 const mockSummary = {
   totalPoints: 100,
   totalCount: 20,
@@ -51,6 +65,26 @@ const mockSummary = {
         'learning-enablement': { points: 10, count: 2 },
         'uncategorized': { points: 0, count: 0 },
       },
+    },
+    {
+      teamId: 't2',
+      teamName: 'Data Science',
+      totalPoints: 30,
+      totalCount: 6,
+      boardCount: 1,
+      percentages: { 'tech-debt-quality': 40, 'new-features': 40, 'learning-enablement': 20 },
+      buckets: {},
+      allocationConfigured: false,
+    },
+    {
+      teamId: 't3',
+      teamName: 'Platform Infra',
+      totalPoints: 20,
+      totalCount: 4,
+      boardCount: 2,
+      percentages: { 'tech-debt-quality': 40, 'new-features': 40, 'learning-enablement': 20 },
+      buckets: {},
+      allocationConfigured: true,
     }
   ]
 }
@@ -63,6 +97,7 @@ vi.mock('../../../client/services/allocation-api', () => ({
 describe('AllocationReport', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockIsAdmin.value = false
   })
 
   function createWrapper() {
@@ -78,7 +113,7 @@ describe('AllocationReport', () => {
         },
         stubs: {
           AllocationBar: { template: '<div data-testid="allocation-bar">Bar</div>', props: ['buckets', 'totalPoints', 'totalCount', 'metricMode'] },
-          AllocationTeamCard: { template: '<div data-testid="allocation-team-card" @click="$emit(\'click\')">{{ teamName }}</div>', props: ['teamName', 'totalPoints', 'totalCount', 'boardCount', 'percentages', 'buckets', 'metricMode'], emits: ['click'] },
+          AllocationTeamCard: { template: '<div data-testid="allocation-team-card" @click="$emit(\'click\')"><span v-if="!configured" data-testid="allocation-unconfigured-badge">Not configured</span>{{ teamName }}</div>', props: ['teamName', 'totalPoints', 'totalCount', 'boardCount', 'percentages', 'buckets', 'metricMode', 'configured'], emits: ['click'] },
           MetricToggle: { template: '<div data-testid="metric-toggle">Toggle</div>', props: ['modelValue'], emits: ['update:modelValue'] },
           OrgSelector: { template: '<div data-testid="org-selector">Orgs</div>', props: ['orgs', 'modelValue'], emits: ['select'] },
         }
@@ -103,8 +138,48 @@ describe('AllocationReport', () => {
     const wrapper = createWrapper()
     await flushPromises()
     const cards = wrapper.findAll('[data-testid="allocation-team-card"]')
+    expect(cards.length).toBe(3)
+    expect(cards.map(c => c.text()).join(' ')).toContain('Model Serving')
+  })
+
+  it('blatantly calls out teams that have not configured allocation', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    const callout = wrapper.find('[data-testid="allocation-unconfigured-callout"]')
+    expect(callout.exists()).toBe(true)
+    expect(callout.text()).toContain('1 of 3 teams')
+    // The unconfigured team card carries a "Not configured" badge.
+    expect(wrapper.find('[data-testid="allocation-unconfigured-badge"]').exists()).toBe(true)
+  })
+
+  it('sorts unconfigured teams first', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    const cards = wrapper.findAll('[data-testid="allocation-team-card"]')
+    expect(cards[0].text()).toContain('Data Science') // the unconfigured one
+  })
+
+  it('renders a team search box', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="team-search"]').exists()).toBe(true)
+  })
+
+  it('filters team cards by search query (case-insensitive)', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    await wrapper.find('[data-testid="team-search"]').setValue('data')
+    const cards = wrapper.findAll('[data-testid="allocation-team-card"]')
     expect(cards.length).toBe(1)
-    expect(cards[0].text()).toContain('Model Serving')
+    expect(cards[0].text()).toContain('Data Science')
+  })
+
+  it('shows a no-match message when the search matches nothing', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    await wrapper.find('[data-testid="team-search"]').setValue('zzz')
+    expect(wrapper.findAll('[data-testid="allocation-team-card"]').length).toBe(0)
+    expect(wrapper.text()).toContain('No teams match "zzz"')
   })
 
   it('renders stat cards including estimated/unestimated', async () => {
@@ -125,5 +200,32 @@ describe('AllocationReport', () => {
     const wrapper = createWrapper()
     await flushPromises()
     expect(wrapper.find('[data-testid="org-selector"]').exists()).toBe(true)
+  })
+
+  it('shows the refresh panel with a full-refresh button for admins when there is no data', async () => {
+    const { getGlobalAllocationSummary } = await import('../../../client/services/allocation-api')
+    getGlobalAllocationSummary.mockResolvedValueOnce({ totalPoints: 0, totalCount: 0, teams: [], boardCount: 0 })
+    mockIsAdmin.value = true
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="allocation-refresh-panel"]').exists()).toBe(true)
+    const btn = wrapper.get('[data-testid="allocation-refresh-button"]')
+    await btn.trigger('click')
+    expect(mockTriggerRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows guidance without a refresh button for non-admins when there is no data', async () => {
+    const { getGlobalAllocationSummary } = await import('../../../client/services/allocation-api')
+    getGlobalAllocationSummary.mockResolvedValueOnce({ totalPoints: 0, totalCount: 0, teams: [], boardCount: 0 })
+    mockIsAdmin.value = false
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="allocation-refresh-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="allocation-refresh-button"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('ask an admin')
   })
 })

--- a/platform/allocation/__tests__/server/orchestration.test.js
+++ b/platform/allocation/__tests__/server/orchestration.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from 'vitest';
-import { processBoard, processKanbanBoard, refreshTeam, performRefresh } from '../../server/orchestration.js';
+import { processBoard, processKanbanBoard, refreshTeam, performRefresh, rebuildRollups } from '../../server/orchestration.js';
 
 const TEST_STRATEGY = {
   id: 'test-strategy',
@@ -517,5 +517,72 @@ describe('performRefresh', () => {
     expect(result.success).toBe(true);
     expect(result.teamCount).toBe(0);
     expect(result.orgCount).toBe(0);
+  });
+});
+
+describe('rebuildRollups', () => {
+  function teamSummary(id, name, orgKey, overrides = {}) {
+    return {
+      teamId: id, teamName: name, orgKey,
+      totalPoints: 10, totalCount: 2, boardCount: 1,
+      buckets: {}, percentages: {}, calculationMode: 'points',
+      ...overrides
+    };
+  }
+
+  function statefulStore(initial) {
+    const store = { ...initial };
+    return {
+      store,
+      readStorage: vi.fn(async key => store[key] ?? null),
+      writeStorage: vi.fn(async (key, data) => { store[key] = data; })
+    };
+  }
+
+  it('rebuilds org + global from ALL on-disk team summaries (no clobber)', async () => {
+    const { readStorage, writeStorage, store } = statefulStore({
+      'summaries/team-team_1.json': teamSummary('team_1', 'Alpha', 'org1'),
+      'summaries/team-team_2.json': teamSummary('team_2', 'Beta', 'org1'),
+      'summaries/team-team_3.json': teamSummary('team_3', 'Gamma', 'org2')
+    });
+    const teams = [{ id: 'team_1' }, { id: 'team_2' }, { id: 'team_3' }];
+
+    const result = await rebuildRollups({ strategy: TEST_STRATEGY, teams, readStorage, writeStorage });
+
+    expect(result.orgCount).toBe(2);
+    expect(store['summaries/global.json'].teams).toHaveLength(3);
+    expect(store['summaries/org-org1.json'].teams).toHaveLength(2);
+    expect(store['summaries/org-org2.json'].teams).toHaveLength(1);
+    // Configured-ness is intentionally NOT baked into the rollup (it's derived
+    // from live team metadata at read time).
+    expect(store['summaries/global.json'].teams[0]).not.toHaveProperty('allocationConfigured');
+  });
+
+  it('re-running for one team keeps the others in the global rollup', async () => {
+    // Simulate: three teams already summarized; team_2 gets re-fetched (its
+    // summary updated), then rollups rebuilt. Global must still list all three.
+    const { readStorage, writeStorage, store } = statefulStore({
+      'summaries/team-team_1.json': teamSummary('team_1', 'Alpha', 'org1'),
+      'summaries/team-team_2.json': teamSummary('team_2', 'Beta', 'org1', { totalPoints: 99 }),
+      'summaries/team-team_3.json': teamSummary('team_3', 'Gamma', 'org2')
+    });
+    const allTeams = [{ id: 'team_1' }, { id: 'team_2' }, { id: 'team_3' }];
+
+    await rebuildRollups({ strategy: TEST_STRATEGY, teams: allTeams, readStorage, writeStorage });
+
+    const globalTeams = store['summaries/global.json'].teams.map(t => t.teamId).sort();
+    expect(globalTeams).toEqual(['team_1', 'team_2', 'team_3']);
+    expect(store['summaries/global.json'].teams.find(t => t.teamId === 'team_2').totalPoints).toBe(99);
+  });
+
+  it('skips teams that have no summary on disk', async () => {
+    const { readStorage, writeStorage, store } = statefulStore({
+      'summaries/team-team_1.json': teamSummary('team_1', 'Alpha', 'org1')
+    });
+    const teams = [{ id: 'team_1' }, { id: 'team_missing' }];
+
+    await rebuildRollups({ strategy: TEST_STRATEGY, teams, readStorage, writeStorage });
+
+    expect(store['summaries/global.json'].teams).toHaveLength(1);
   });
 });

--- a/platform/allocation/client/TeamAllocationTab.vue
+++ b/platform/allocation/client/TeamAllocationTab.vue
@@ -1,24 +1,49 @@
 <template>
   <div>
+    <!-- Unconfigured banner: a manager must choose story points vs issue count.
+         Until then the team is flagged as unconfigured in org reports. -->
+    <div
+      v-if="teamId && settingsLoaded && !isConfigured"
+      data-testid="allocation-unconfigured-banner"
+      class="mb-4 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 p-4"
+    >
+      <div class="flex items-start gap-3">
+        <svg class="h-5 w-5 flex-shrink-0 text-amber-500 dark:text-amber-400 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+        </svg>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-sm font-semibold text-amber-900 dark:text-amber-100">Allocation reporting isn't configured for this team</h3>
+          <p class="text-sm text-amber-800 dark:text-amber-200 mt-0.5">
+            Choose whether this team's allocation is measured by <span class="font-medium">story points</span> or
+            <span class="font-medium">issue count</span>. Until it's set, the team is flagged as unconfigured in org reports<template v-if="!canEditSettings"> — ask a team manager or admin to set it</template>.
+          </p>
+          <button
+            v-if="canEditSettings"
+            type="button"
+            data-testid="allocation-unconfigured-cta"
+            class="mt-2 inline-flex items-center px-3 py-1.5 text-sm font-medium bg-amber-600 text-white rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
+            @click="showSettingsModal = true"
+          >
+            Choose a basis
+          </button>
+        </div>
+      </div>
+    </div>
+
     <!-- Empty state: strategy is configured but this team has no allocation boards.
          The tab is intentionally shown (not hidden) so managers get actionable
          guidance on how to enable allocation tracking for their team. -->
-    <div v-if="allocationBoards.length === 0" class="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center">
-      <svg class="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
-      </svg>
-      <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
-        Allocation tracking isn't set up for this team yet
-      </h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">
-        Add a Jira board (with its board URL) to this team's board settings to start
-        tracking how work is allocated across
-        <span class="font-medium">{{ strategyName || 'your categories' }}</span>.
-        Once a board is configured, an admin can run an allocation refresh from the
-        <span class="font-medium">{{ strategyName || 'Allocation' }}</span> settings tab to populate the data.
-      </p>
-    </div>
+    <AllocationRefreshPanel
+      v-if="allocationBoards.length === 0"
+      title="Allocation tracking isn't set up for this team yet"
+      :description="`Add a Jira board (with its board URL) to this team using “Edit boards” above, then refresh to pull how work is allocated across ${strategyName || 'your categories'}.`"
+      button-label="Refresh after adding a board"
+      :can-refresh="!!teamId"
+      :refreshing="refreshing"
+      :message="refreshMessage"
+      hint="Add a board to this team to start tracking allocation."
+      @refresh="handleRefresh"
+    />
 
     <template v-else>
       <!-- Board selector (only if multiple boards) -->
@@ -41,10 +66,31 @@
         </svg>
       </div>
 
-      <!-- No sprints -->
-      <div v-else-if="sprints.length === 0" class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center text-gray-500 dark:text-gray-400">
-        No sprint data available for this board.
-      </div>
+      <!-- Never synced: no data file exists for this board yet -->
+      <AllocationRefreshPanel
+        v-else-if="sprints.length === 0 && !boardSynced"
+        title="This board hasn't been synced yet"
+        description="Allocation data is pulled from Jira on a schedule, and this board hasn't been included in a sync yet. Refresh now to fetch its sprints and classify the work."
+        button-label="Refresh this team's data"
+        :can-refresh="!!teamId"
+        :refreshing="refreshing"
+        :message="refreshMessage"
+        hint="Ask an admin to run an allocation refresh to populate this board."
+        @refresh="handleRefresh"
+      />
+
+      <!-- Synced but empty: Jira returned no sprints for this board -->
+      <AllocationRefreshPanel
+        v-else-if="sprints.length === 0"
+        title="No sprints found for this board"
+        description="This board is synced, but Jira returned no active or recent sprints. Kanban boards only show work resolved in the last two weeks. If this looks wrong, refreshing will re-check Jira."
+        button-label="Refresh this team's data"
+        :can-refresh="!!teamId"
+        :refreshing="refreshing"
+        :message="refreshMessage"
+        :last-updated="boardLastUpdated"
+        @refresh="handleRefresh"
+      />
 
       <!-- Sprint content -->
       <template v-else>
@@ -61,9 +107,66 @@
           </span>
         </div>
 
-        <!-- Metric toggle -->
-        <div class="flex items-center justify-end mb-4">
-          <MetricToggle :modelValue="metricMode" @update:modelValue="handleMetricModeChange" />
+        <!-- Last synced + refresh, and metric toggle -->
+        <div class="flex items-start justify-between gap-3 mb-4 flex-wrap">
+          <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span v-if="boardLastUpdated">Last synced {{ formatDateTime(boardLastUpdated) }}</span>
+            <button
+              v-if="teamId"
+              type="button"
+              data-testid="allocation-inline-refresh"
+              :disabled="refreshing"
+              class="inline-flex items-center gap-1 font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:underline"
+              @click="handleRefresh"
+            >
+              <svg
+                class="h-3.5 w-3.5"
+                :class="{ 'animate-spin': refreshing }"
+                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              {{ refreshing ? 'Refreshing…' : 'Refresh' }}
+            </button>
+            <span v-if="refreshing && refreshMessage" class="text-gray-400 dark:text-gray-500">· {{ refreshMessage }}</span>
+          </div>
+          <div class="flex flex-col items-end gap-2">
+            <div class="flex items-center gap-2">
+              <MetricToggle :modelValue="metricMode" @update:modelValue="handleMetricModeChange" />
+              <button
+                v-if="canEditSettings"
+                type="button"
+                data-testid="allocation-settings-button"
+                title="Allocation settings"
+                aria-label="Allocation settings"
+                class="p-1.5 rounded-md border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                @click="showSettingsModal = true"
+              >
+                <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </button>
+            </div>
+
+            <!-- View-override callout: the toggle is a view control, not the team's saved default.
+                 Sits directly under the toggle so the distinction is obvious. -->
+            <div
+              v-if="isConfigured && metricMode !== teamAllocationMode"
+              data-testid="allocation-view-note"
+              class="flex items-start gap-1.5 max-w-xs rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 px-2.5 py-1.5 text-xs text-amber-800 dark:text-amber-200 shadow-sm"
+            >
+              <svg class="h-4 w-4 flex-shrink-0 mt-px" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <span>
+                Viewing by <span class="font-semibold">{{ metricLabel(metricMode) }}</span> — not this team's
+                default (<span class="font-semibold">{{ metricLabel(teamAllocationMode) }}</span>).<template v-if="canEditSettings">
+                  <button type="button" class="ml-1 font-semibold underline hover:no-underline focus:outline-none" @click="showSettingsModal = true">Change default</button></template>
+              </span>
+            </div>
+          </div>
         </div>
 
         <!-- Loading sprint issues -->
@@ -75,6 +178,11 @@
         </div>
 
         <template v-else-if="sprintData">
+          <!-- Board type explainer (helps managers understand how the % is derived) -->
+          <div class="mb-4">
+            <BoardTypeInfo :boardType="boardType" />
+          </div>
+
           <!-- Allocation bar -->
           <div class="mb-4">
             <AllocationBar
@@ -124,13 +232,21 @@
         </template>
       </template>
     </template>
+
+    <!-- Settings modal -->
+    <AllocationSettingsModal
+      v-if="showSettingsModal"
+      :teamId="teamId"
+      :currentMode="teamAllocationMode"
+      @close="showSettingsModal = false"
+      @saved="handleSettingsSaved"
+    />
   </div>
 </template>
 
 <script setup>
 import { computed, ref, watch, onMounted } from 'vue'
-import { apiRequest } from '@shared/client/services/api'
-import { getBoardSprints, getSprintIssues } from './services/allocation-api'
+import { getBoardSprints, getSprintIssues, getTeamAllocationSettings } from './services/allocation-api'
 import { useAllocationStrategy } from './composables/useAllocationStrategy'
 import SprintSelector from './allocation/SprintSelector.vue'
 import SprintStatusBadge from './allocation/SprintStatusBadge.vue'
@@ -139,6 +255,10 @@ import BucketBreakdown from './allocation/BucketBreakdown.vue'
 import MetricToggle from './allocation/MetricToggle.vue'
 import UnestimatedPanel from './allocation/UnestimatedPanel.vue'
 import CompletionSummary from './allocation/CompletionSummary.vue'
+import BoardTypeInfo from './allocation/BoardTypeInfo.vue'
+import AllocationRefreshPanel from './allocation/AllocationRefreshPanel.vue'
+import AllocationSettingsModal from './allocation/AllocationSettingsModal.vue'
+import { useAllocationRefresh } from './composables/useAllocationRefresh'
 
 const props = defineProps({
   team: { type: Object, required: true },
@@ -163,6 +283,27 @@ const sprintData = ref(null)
 const loadingSprints = ref(false)
 const loadingIssues = ref(false)
 const metricMode = ref('points')
+// Whether the selected board has ever been synced from Jira, and when.
+// Distinguishes "never synced" from "synced but no sprints" in the empty state.
+const boardSynced = ref(true)
+const boardLastUpdated = ref(null)
+
+// The team's persisted allocation basis (default view + server aggregation).
+// null until a manager configures it. The MetricToggle is a per-view override.
+const teamAllocationMode = ref(
+  props.team?.metadata?.allocationMode === 'counts' || props.team?.metadata?.allocationMode === 'points'
+    ? props.team.metadata.allocationMode
+    : null
+)
+const canEditSettings = ref(false)
+const showSettingsModal = ref(false)
+const settingsLoaded = ref(false)
+
+const isConfigured = computed(() =>
+  teamAllocationMode.value === 'points' || teamAllocationMode.value === 'counts'
+)
+
+const { refreshing, message: refreshMessage, triggerRefresh } = useAllocationRefresh()
 
 // --- Computed ---
 const allocationBoards = computed(() => {
@@ -177,6 +318,14 @@ const selectedBoard = computed(() =>
 const selectedSprint = computed(() =>
   sprints.value.find(s => s.id === selectedSprintId.value) || null
 )
+
+// Board type is derived from the sprint id: kanban boards produce a single
+// synthetic sprint with a `kanban-<boardId>` id (see server orchestration),
+// whereas scrum boards use numeric Jira sprint ids.
+const boardType = computed(() => {
+  const id = selectedSprint.value?.id ?? sprintData.value?.sprint?.id
+  return id != null && String(id).startsWith('kanban-') ? 'kanban' : 'scrum'
+})
 
 const displayTotal = computed(() => {
   if (!sprintData.value) return 0
@@ -256,6 +405,13 @@ function formatDate(dateString) {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
+function formatDateTime(dateString) {
+  if (!dateString) return ''
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return ''
+  return date.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+}
+
 // --- Sprint selection persistence ---
 function getSavedSprintId(boardId) {
   try {
@@ -295,7 +451,10 @@ async function loadSprints() {
   loadingSprints.value = true
   try {
     const data = await getBoardSprints(board.boardId, board.sprintFilter)
-    sprints.value = data.sprints || data || []
+    sprints.value = Array.isArray(data) ? data : (data.sprints || [])
+    // `synced: false` means the board has no data file yet (never refreshed).
+    boardSynced.value = Array.isArray(data) ? true : data.synced !== false
+    boardLastUpdated.value = (data && !Array.isArray(data) && data.lastUpdated) || null
 
     // Restore saved sprint or pick default
     const savedId = getSavedSprintId(board.boardId)
@@ -304,9 +463,18 @@ async function loadSprints() {
   } catch (error) {
     console.error('Failed to load sprints:', error)
     sprints.value = []
+    // Treat a load failure as "synced" so we don't wrongly claim it was never
+    // synced; the generic empty state + refresh still applies.
+    boardSynced.value = true
+    boardLastUpdated.value = null
   } finally {
     loadingSprints.value = false
   }
+}
+
+async function handleRefresh() {
+  if (!props.teamId) return
+  await triggerRefresh({ teamId: props.teamId, onComplete: loadSprints })
 }
 
 async function loadSprintIssues() {
@@ -334,26 +502,51 @@ function handleSelectSprint(sprintId) {
   }
 }
 
-async function handleMetricModeChange(newMode) {
+function metricLabel(mode) {
+  return mode === 'counts' ? 'Issue Count' : 'Story Points'
+}
+
+// The toggle is a per-view override only; it never changes the team's saved
+// default (that's done via the settings modal). The template surfaces a note
+// when the current view differs from the team default.
+function handleMetricModeChange(newMode) {
   metricMode.value = newMode
-  if (props.teamId) {
-    try {
-      await apiRequest(`/modules/team-tracker/structure/teams/${props.teamId}/fields`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ allocationMode: newMode })
-      })
-    } catch {
-      // Non-critical — mode still changes locally
-    }
+}
+
+async function loadSettings() {
+  if (!props.teamId) return
+  try {
+    const { allocationMode, configured, canEdit } = await getTeamAllocationSettings(props.teamId)
+    teamAllocationMode.value = configured ? allocationMode : null
+    canEditSettings.value = !!canEdit
+    // View defaults to the configured basis, or story points as a fallback.
+    metricMode.value = teamAllocationMode.value || 'points'
+  } catch {
+    // Non-fatal — keep the seed from team metadata; settings button stays hidden.
+  } finally {
+    settingsLoaded.value = true
   }
 }
 
+function handleSettingsSaved(newMode) {
+  teamAllocationMode.value = newMode
+  metricMode.value = newMode
+  showSettingsModal.value = false
+  // The modal already re-ran this team's allocation; reload sprint data so the
+  // "last synced" stamp and any recomputed figures reflect the refresh.
+  loadSprints()
+}
+
 // --- Watchers ---
+// NOTE: the selectedBoardId watcher is registered BEFORE the immediate
+// allocationBoards watcher below so that when the latter selects a board during
+// setup, this watcher is already active and triggers the initial load.
 watch(selectedBoardId, () => {
   sprints.value = []
   sprintData.value = null
   selectedSprintId.value = null
+  boardSynced.value = true
+  boardLastUpdated.value = null
   loadSprints()
 })
 
@@ -361,17 +554,25 @@ watch(selectedSprintId, () => {
   loadSprintIssues()
 })
 
+// Auto-select the first board whenever the board list becomes available.
+// `teamDetail` can arrive asynchronously after mount, so this must react to
+// allocationBoards changing rather than only running once in onMounted —
+// otherwise no board is ever selected and sprint data never loads.
+watch(allocationBoards, (boards) => {
+  if (!boards.length) return
+  const stillValid = selectedBoardId.value != null && boards.some(b => b.boardId === selectedBoardId.value)
+  if (!stillValid) selectedBoardId.value = boards[0].boardId
+}, { immediate: true })
+
 // --- Lifecycle ---
 onMounted(() => {
-  // Set initial metric mode from team metadata
+  // Seed from team metadata immediately (avoids a flash of the wrong default)…
   const savedMode = props.team?.metadata?.allocationMode
   if (savedMode === 'points' || savedMode === 'counts') {
+    teamAllocationMode.value = savedMode
     metricMode.value = savedMode
   }
-
-  // Auto-select first board
-  if (allocationBoards.value.length > 0) {
-    selectedBoardId.value = allocationBoards.value[0].boardId
-  }
+  // …then fetch the authoritative setting + edit permission.
+  loadSettings()
 })
 </script>

--- a/platform/allocation/client/allocation/AllocationRefreshPanel.vue
+++ b/platform/allocation/client/allocation/AllocationRefreshPanel.vue
@@ -1,0 +1,66 @@
+<template>
+  <div
+    data-testid="allocation-refresh-panel"
+    class="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center"
+  >
+    <svg class="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
+    </svg>
+
+    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">{{ title }}</h3>
+    <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">{{ description }}</p>
+
+    <p v-if="lastUpdated" class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+      Last synced {{ formattedLastUpdated }}
+    </p>
+
+    <!-- Refresh action -->
+    <div v-if="canRefresh" class="mt-4 flex flex-col items-center gap-2">
+      <button
+        type="button"
+        data-testid="allocation-refresh-button"
+        :disabled="refreshing"
+        class="inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary-600 text-white rounded-md font-medium hover:bg-primary-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        @click="$emit('refresh')"
+      >
+        <svg v-if="refreshing" class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+        {{ refreshing ? 'Refreshing…' : buttonLabel }}
+      </button>
+      <p v-if="message" data-testid="allocation-refresh-message" class="text-xs text-gray-500 dark:text-gray-400">
+        {{ message }}
+      </p>
+    </div>
+
+    <!-- Guidance when the viewer can't refresh from here -->
+    <p v-else-if="hint" class="mt-4 text-xs text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+      {{ hint }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  title: { type: String, required: true },
+  description: { type: String, default: '' },
+  buttonLabel: { type: String, default: 'Refresh data' },
+  canRefresh: { type: Boolean, default: false },
+  refreshing: { type: Boolean, default: false },
+  message: { type: String, default: '' },
+  hint: { type: String, default: '' },
+  lastUpdated: { type: String, default: null }
+})
+
+defineEmits(['refresh'])
+
+const formattedLastUpdated = computed(() => {
+  if (!props.lastUpdated) return ''
+  const d = new Date(props.lastUpdated)
+  return isNaN(d.getTime()) ? '' : d.toLocaleString()
+})
+</script>

--- a/platform/allocation/client/allocation/AllocationSettingsModal.vue
+++ b/platform/allocation/client/allocation/AllocationSettingsModal.vue
@@ -1,0 +1,137 @@
+<template>
+  <div
+    class="fixed inset-0 bg-gray-900/10 dark:bg-black/20 flex items-center justify-center z-50"
+    data-testid="allocation-settings-modal"
+    @click.self="close"
+  >
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-2xl ring-1 ring-black/10 dark:ring-white/10 w-full max-w-md mx-4">
+      <!-- Header -->
+      <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Allocation settings</h2>
+        <button
+          class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
+          :disabled="saving"
+          aria-label="Close"
+          @click="close"
+        >
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Calculate allocation by</p>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
+            Sets how this team's work is weighted across categories — everywhere allocation is
+            summarized, including the org report.
+          </p>
+
+          <p
+            v-if="isFirstTime"
+            data-testid="allocation-settings-firsttime"
+            class="text-sm text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-md px-3 py-2 mb-3"
+          >
+            This team hasn't been configured yet. Pick a basis so it's counted correctly in org reports.
+          </p>
+
+          <div class="space-y-2">
+            <label class="flex items-start gap-2 text-sm cursor-pointer p-2 rounded-md border"
+              :class="selectedMode === 'points' ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20' : 'border-gray-200 dark:border-gray-700'">
+              <input type="radio" value="points" v-model="selectedMode" class="mt-0.5 text-primary-600 focus:ring-primary-500" />
+              <span>
+                <span class="font-medium text-gray-900 dark:text-gray-100">Story Points</span>
+                <span class="block text-xs text-gray-500 dark:text-gray-400">Weight by estimate — a 5-point issue counts more than a 1-point one. Unestimated issues are excluded.</span>
+              </span>
+            </label>
+            <label class="flex items-start gap-2 text-sm cursor-pointer p-2 rounded-md border"
+              :class="selectedMode === 'counts' ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20' : 'border-gray-200 dark:border-gray-700'">
+              <input type="radio" value="counts" v-model="selectedMode" class="mt-0.5 text-primary-600 focus:ring-primary-500" />
+              <span>
+                <span class="font-medium text-gray-900 dark:text-gray-100">Issue Count</span>
+                <span class="block text-xs text-gray-500 dark:text-gray-400">Weight every issue equally, regardless of estimate.</span>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <p class="text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700 pt-3">
+          Saving re-runs this team's allocation so the change takes effect right away.
+        </p>
+
+        <p v-if="error" class="text-sm text-red-600 dark:text-red-400" data-testid="allocation-settings-error">{{ error }}</p>
+        <p v-else-if="saving && progressMessage" class="text-sm text-gray-500 dark:text-gray-400" data-testid="allocation-settings-progress">{{ progressMessage }}</p>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
+        <button
+          class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50"
+          :disabled="saving"
+          @click="close"
+        >
+          Cancel
+        </button>
+        <button
+          class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-60 disabled:cursor-not-allowed"
+          :disabled="saving || selectedMode === currentMode"
+          data-testid="allocation-settings-save"
+          @click="save"
+        >
+          <svg v-if="saving" class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+          </svg>
+          {{ saving ? 'Saving…' : 'Save changes' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { updateTeamAllocationSettings } from '../services/allocation-api'
+import { useAllocationRefresh } from '../composables/useAllocationRefresh'
+
+const props = defineProps({
+  teamId: { type: String, required: true },
+  // null/absent means the team has never been configured — the modal then
+  // requires an explicit choice before Save enables.
+  currentMode: { type: String, default: null }
+})
+
+const emit = defineEmits(['close', 'saved'])
+
+const isFirstTime = computed(() => props.currentMode !== 'points' && props.currentMode !== 'counts')
+const selectedMode = ref(isFirstTime.value ? null : props.currentMode)
+const saving = ref(false)
+const error = ref('')
+
+const { message: progressMessage, triggerRefresh } = useAllocationRefresh()
+
+function close() {
+  if (saving.value) return
+  emit('close')
+}
+
+async function save() {
+  if (selectedMode.value === props.currentMode) return
+  saving.value = true
+  error.value = ''
+  try {
+    await updateTeamAllocationSettings(props.teamId, selectedMode.value)
+    // Re-run this team's allocation so summaries reflect the new basis.
+    await triggerRefresh({ teamId: props.teamId })
+    emit('saved', selectedMode.value)
+  } catch (e) {
+    error.value = e?.status === 403
+      ? "You don't have permission to change this team's settings."
+      : 'Could not save settings. Please try again.'
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/platform/allocation/client/allocation/AllocationTeamCard.vue
+++ b/platform/allocation/client/allocation/AllocationTeamCard.vue
@@ -4,9 +4,22 @@
     class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 cursor-pointer hover:shadow-md hover:border-primary-300 dark:hover:border-primary-600 transition-all"
     data-testid="allocation-team-card"
   >
-    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate mb-3" :title="teamName">
-      {{ teamName }}
-    </h3>
+    <div class="flex items-start justify-between gap-2 mb-3">
+      <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate" :title="teamName">
+        {{ teamName }}
+      </h3>
+      <span
+        v-if="!configured"
+        data-testid="allocation-unconfigured-badge"
+        class="flex-shrink-0 inline-flex items-center gap-1 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700 px-2 py-0.5 text-xs font-medium"
+        title="This team hasn't chosen story points vs issue count"
+      >
+        <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+        </svg>
+        Not configured
+      </span>
+    </div>
 
     <AllocationBar
       :buckets="buckets"
@@ -48,7 +61,8 @@ const props = defineProps({
   boardCount: { type: Number, default: 0 },
   percentages: { type: Object, default: () => ({}) },
   buckets: { type: Object, default: () => ({}) },
-  metricMode: { type: String, default: 'points' }
+  metricMode: { type: String, default: 'points' },
+  configured: { type: Boolean, default: true }
 })
 
 defineEmits(['click'])

--- a/platform/allocation/client/allocation/BoardTypeInfo.vue
+++ b/platform/allocation/client/allocation/BoardTypeInfo.vue
@@ -1,0 +1,84 @@
+<template>
+  <div
+    data-testid="board-type-info"
+    class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4"
+  >
+    <div class="flex items-start gap-3">
+      <!-- Info icon -->
+      <svg class="h-5 w-5 text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+
+      <div class="flex-1 min-w-0">
+        <!-- Always-visible summary line -->
+        <p class="text-sm text-gray-800 dark:text-gray-200">
+          This team's board was detected as a
+          <span class="font-semibold" data-testid="board-type-label">{{ boardTypeLabel }} board</span>.
+          {{ summaryLine }}
+        </p>
+
+        <!-- Toggle for the detailed explanation -->
+        <button
+          type="button"
+          class="mt-1 inline-flex items-center gap-1 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 focus:outline-none focus:underline"
+          :aria-expanded="expanded"
+          data-testid="board-type-info-toggle"
+          @click="expanded = !expanded"
+        >
+          {{ expanded ? 'Hide details' : 'How is this calculated?' }}
+          <svg
+            class="h-4 w-4 transition-transform"
+            :class="{ 'rotate-180': expanded }"
+            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <!-- Expandable detail -->
+        <div v-if="expanded" data-testid="board-type-info-detail" class="mt-3 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+          <p>{{ methodExplanation }}</p>
+          <p>
+            Each issue is sorted into one of the allocation categories, and the bar below shows how
+            that work is split. By default, percentages are weighted by
+            <span class="font-medium">story points</span>, so a 5-point issue counts more than a
+            1-point one. Use the <span class="font-medium">Points / Issues</span> toggle to weight
+            every issue equally instead.
+          </p>
+          <p class="text-gray-500 dark:text-gray-400">
+            Only Bug, Task, Story, Spike, Vulnerability, and Weakness issues are counted. Issues
+            without an estimate are excluded from points-based percentages (see the unestimated
+            work panel below).
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  // 'scrum' or 'kanban'
+  boardType: { type: String, default: 'scrum' }
+})
+
+const expanded = ref(false)
+
+const isKanban = computed(() => props.boardType === 'kanban')
+
+const boardTypeLabel = computed(() => (isKanban.value ? 'Kanban' : 'Scrum'))
+
+const summaryLine = computed(() =>
+  isKanban.value
+    ? "Kanban boards don't have sprints, so allocation is measured over the work completed in the last 2 weeks."
+    : 'Allocation is measured across the issues in the selected sprint.'
+)
+
+const methodExplanation = computed(() =>
+  isKanban.value
+    ? 'Because a Kanban board has no sprints, allocation looks at every issue on the board that was resolved in the past 14 days. This is a rolling window that always reflects the most recent two weeks and updates as work is completed.'
+    : 'Allocation looks at the issues in the sprint selected above — that could be the active sprint or any recent one. Pick a different sprint from the selector to see how the split changed over time.'
+)
+</script>

--- a/platform/allocation/client/composables/useAllocationRefresh.js
+++ b/platform/allocation/client/composables/useAllocationRefresh.js
@@ -1,0 +1,126 @@
+import { ref, onUnmounted, getCurrentInstance } from 'vue'
+import { refreshAllocation, getRefreshStatus } from '../services/allocation-api'
+
+/**
+ * Drives a self-service allocation refresh with progress feedback.
+ *
+ * Flow (the "medium" async UX):
+ *   1. Trigger POST /allocation/refresh (optionally scoped to a teamId).
+ *   2. If it starts (or one is already running), poll GET /allocation/refresh/status
+ *      until the background run finishes.
+ *   3. Call `onComplete` so the caller can reload its data, then surface a result.
+ *
+ * The backend refresh state is global (a single in-memory run), so completion is
+ * detected by `running` returning to false with a `completedAt` newer than the
+ * value observed just before we triggered.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.pollIntervalMs] - Poll cadence (default 3000).
+ * @param {number} [opts.maxPolls] - Safety cap on poll attempts (default 60 ≈ 3 min).
+ */
+export function useAllocationRefresh(opts = {}) {
+  const pollIntervalMs = opts.pollIntervalMs ?? 3000
+  const maxPolls = opts.maxPolls ?? 60
+
+  const refreshing = ref(false)
+  // 'idle' | 'starting' | 'running' | 'done' | 'cooldown' | 'unavailable' | 'error'
+  const phase = ref('idle')
+  const message = ref('')
+
+  // Stop polling if the owning component unmounts (e.g. user navigates away
+  // mid-refresh) so the loop doesn't keep running in the background.
+  let cancelled = false
+  if (getCurrentInstance()) {
+    onUnmounted(() => { cancelled = true })
+  }
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  async function readStatusSafe() {
+    try {
+      return await getRefreshStatus()
+    } catch {
+      return null
+    }
+  }
+
+  async function pollUntilComplete(prevCompletedAt) {
+    for (let i = 0; i < maxPolls; i++) {
+      await sleep(pollIntervalMs)
+      if (cancelled) return false
+      const status = await readStatusSafe()
+      if (!status) continue
+      if (!status.running && status.completedAt && status.completedAt !== prevCompletedAt) {
+        return status.lastResult?.status !== 'error'
+      }
+    }
+    return false
+  }
+
+  /**
+   * @param {Object} [args]
+   * @param {string|null} [args.teamId] - Refresh a single team (self-service). Omit for a full, admin-only refresh.
+   * @param {boolean} [args.hardRefresh]
+   * @param {Function} [args.onComplete] - Awaited after the run finishes (e.g. reload data).
+   * @returns {Promise<Object>} the trigger response ({ status: ... })
+   */
+  async function triggerRefresh({ teamId = null, hardRefresh = false, onComplete } = {}) {
+    if (refreshing.value) return { status: 'busy' }
+
+    refreshing.value = true
+    phase.value = 'starting'
+    message.value = 'Starting refresh…'
+
+    try {
+      const before = await readStatusSafe()
+      const prevCompletedAt = before?.completedAt || null
+
+      const res = await refreshAllocation(teamId, hardRefresh)
+      const status = res?.status
+
+      if (status === 'skipped') {
+        phase.value = 'unavailable'
+        message.value = res.message || 'Refresh is unavailable right now.'
+        return res
+      }
+
+      if (status === 'cooldown') {
+        // A run finished within the cooldown window, so the latest data is
+        // already on disk — just reload it.
+        phase.value = 'done'
+        message.value = 'Just refreshed a moment ago — loading the latest data.'
+        if (onComplete) await onComplete()
+        return res
+      }
+
+      // 'started' or 'already_running' → wait for the background run to finish.
+      phase.value = 'running'
+      message.value = status === 'already_running'
+        ? 'A refresh is already in progress…'
+        : 'Fetching the latest data from Jira…'
+
+      const ok = await pollUntilComplete(prevCompletedAt)
+      if (cancelled) return res
+      if (onComplete) await onComplete()
+
+      if (ok) {
+        phase.value = 'done'
+        message.value = 'Done — data updated.'
+      } else {
+        phase.value = 'error'
+        message.value = 'The refresh is taking longer than expected. Please check back shortly.'
+      }
+      return res
+    } catch {
+      phase.value = 'error'
+      message.value = 'Refresh failed. Please try again.'
+      return { status: 'error' }
+    } finally {
+      refreshing.value = false
+    }
+  }
+
+  return { refreshing, phase, message, triggerRefresh }
+}

--- a/platform/allocation/client/reports/AllocationReport.vue
+++ b/platform/allocation/client/reports/AllocationReport.vue
@@ -1,21 +1,31 @@
 <script setup>
 import { ref, computed, onMounted, watch, inject } from 'vue'
+import { useAuth } from '@shared/client/composables/useAuth'
 import { useOrgList } from '../composables/useOrgList'
 import { useAllocationStrategy } from '../composables/useAllocationStrategy'
 import { getOrgAllocationSummary, getGlobalAllocationSummary } from '../services/allocation-api'
+import { useAllocationRefresh } from '../composables/useAllocationRefresh'
 import OrgSelector from '../allocation/OrgSelector.vue'
 import AllocationBar from '../allocation/AllocationBar.vue'
 import AllocationTeamCard from '../allocation/AllocationTeamCard.vue'
 import MetricToggle from '../allocation/MetricToggle.vue'
+import AllocationRefreshPanel from '../allocation/AllocationRefreshPanel.vue'
 
 const nav = inject('moduleNav')
+const { isAdmin } = useAuth()
 const { orgs, loadOrgs } = useOrgList()
 const { categories } = useAllocationStrategy()
+const { refreshing, message: refreshMessage, triggerRefresh } = useAllocationRefresh()
+
+function handleFullRefresh() {
+  triggerRefresh({ onComplete: fetchSummary })
+}
 
 const selectedOrg = ref(null)
 const metricMode = ref('points')
 const loading = ref(false)
 const summary = ref(null)
+const teamSearch = ref('')
 
 async function fetchSummary() {
   loading.value = true
@@ -51,6 +61,22 @@ const hasData = computed(() => {
 
 const teams = computed(() => summary.value?.teams || [])
 
+function isUnconfigured(team) {
+  return team.allocationConfigured === false
+}
+
+const unconfiguredCount = computed(() => teams.value.filter(isUnconfigured).length)
+
+const filteredTeams = computed(() => {
+  const q = teamSearch.value.trim().toLowerCase()
+  const base = q ? teams.value.filter(t => (t.teamName || '').toLowerCase().includes(q)) : teams.value
+  // Surface unconfigured teams first so they're impossible to miss.
+  return [...base].sort((a, b) => (isUnconfigured(a) ? 0 : 1) - (isUnconfigured(b) ? 0 : 1))
+})
+
+// Search is only meaningful once there are teams to search.
+const showTeamSearch = computed(() => hasData.value && teams.value.length > 0)
+
 const statCards = computed(() => {
   if (!summary.value) return []
   const s = summary.value
@@ -82,7 +108,10 @@ function teamBuckets(team) {
   return buckets
 }
 
-watch(selectedOrg, fetchSummary)
+watch(selectedOrg, () => {
+  teamSearch.value = ''
+  fetchSummary()
+})
 
 onMounted(() => {
   loadOrgs()
@@ -95,19 +124,54 @@ onMounted(() => {
     <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
       <div>
         <p v-if="hasData" class="text-sm text-gray-500 dark:text-gray-400">
-          {{ teams.length }} {{ teams.length === 1 ? 'team' : 'teams' }} across {{ summary?.boardCount || 0 }} boards
+          <template v-if="teamSearch.trim()">
+            {{ filteredTeams.length }} of {{ teams.length }} {{ teams.length === 1 ? 'team' : 'teams' }} match
+          </template>
+          <template v-else>
+            {{ teams.length }} {{ teams.length === 1 ? 'team' : 'teams' }} across {{ summary?.boardCount || 0 }} boards
+          </template>
         </p>
       </div>
       <MetricToggle v-model="metricMode" />
     </div>
 
-    <OrgSelector
-      v-if="orgs.length > 1"
-      :orgs="orgs"
-      :model-value="selectedOrg"
-      @select="selectOrg"
-      class="mb-6"
-    />
+    <div
+      v-if="orgs.length > 1 || showTeamSearch"
+      class="flex flex-col sm:flex-row sm:items-center gap-3 mb-6"
+    >
+      <OrgSelector
+        v-if="orgs.length > 1"
+        :orgs="orgs"
+        :model-value="selectedOrg"
+        @select="selectOrg"
+      />
+
+      <!-- Team search — aligned to the right of the org toggle bar -->
+      <div v-if="showTeamSearch" class="relative w-full sm:w-64 sm:ml-auto">
+        <svg class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
+        </svg>
+        <input
+          v-model="teamSearch"
+          type="text"
+          placeholder="Search teams…"
+          aria-label="Search teams"
+          data-testid="team-search"
+          class="w-full border border-gray-300 dark:border-gray-600 rounded-md pl-9 pr-9 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+        <button
+          v-if="teamSearch"
+          type="button"
+          aria-label="Clear search"
+          class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none"
+          @click="teamSearch = ''"
+        >
+          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
 
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center py-12" role="status" aria-live="polite">
@@ -116,13 +180,41 @@ onMounted(() => {
 
     <!-- No data -->
     <template v-else-if="!hasData">
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-8 text-center">
-        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">No allocation data available</h3>
-        <p class="text-sm text-gray-500 dark:text-gray-400">Run an allocation refresh from Settings to populate.</p>
-      </div>
+      <AllocationRefreshPanel
+        title="No allocation data available"
+        :description="isAdmin
+          ? 'Allocation data is pulled from Jira on a schedule. Run a full refresh to fetch and classify sprint data across all configured teams. This can take a few minutes.'
+          : 'Allocation data is pulled from Jira on a schedule and hasn\'t been populated yet.'"
+        button-label="Refresh allocation data"
+        :can-refresh="isAdmin"
+        :refreshing="refreshing"
+        :message="refreshMessage"
+        hint="Open a specific team's Allocation tab to refresh just that team, or ask an admin to run a full refresh."
+        @refresh="handleFullRefresh"
+      />
     </template>
 
     <template v-else>
+      <!-- Blatant call-out: teams that haven't chosen a reporting basis -->
+      <div
+        v-if="unconfiguredCount > 0"
+        data-testid="allocation-unconfigured-callout"
+        class="mb-6 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 p-4 flex items-start gap-3"
+      >
+        <svg class="h-5 w-5 flex-shrink-0 text-amber-500 dark:text-amber-400 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+        </svg>
+        <div>
+          <h3 class="text-sm font-semibold text-amber-900 dark:text-amber-100">
+            {{ unconfiguredCount }} of {{ teams.length }} {{ teams.length === 1 ? 'team' : 'teams' }} haven't configured allocation reporting
+          </h3>
+          <p class="text-sm text-amber-800 dark:text-amber-200 mt-0.5">
+            These teams haven't chosen whether allocation is measured by story points or issue count, so their
+            numbers here fall back to story points. They're tagged <span class="font-medium">Not configured</span> below.
+          </p>
+        </div>
+      </div>
+
       <!-- Aggregate allocation bar -->
       <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
         <AllocationBar
@@ -150,21 +242,29 @@ onMounted(() => {
         <p class="text-sm text-gray-500 dark:text-gray-400">No teams with allocation data in this org.</p>
       </div>
 
-      <!-- Team cards grid -->
-      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <AllocationTeamCard
-          v-for="team in teams"
-          :key="team.teamId"
-          :teamName="team.teamName"
-          :totalPoints="team.totalPoints || 0"
-          :totalCount="team.totalCount || 0"
-          :boardCount="team.boardCount || 0"
-          :percentages="team.percentages || {}"
-          :buckets="teamBuckets(team)"
-          :metricMode="metricMode"
-          @click="openTeam(team)"
-        />
-      </div>
+      <template v-else>
+        <!-- No teams match the search -->
+        <div v-if="filteredTeams.length === 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-8 text-center">
+          <p class="text-sm text-gray-500 dark:text-gray-400">No teams match "{{ teamSearch }}".</p>
+        </div>
+
+        <!-- Team cards grid -->
+        <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <AllocationTeamCard
+            v-for="team in filteredTeams"
+            :key="team.teamId"
+            :teamName="team.teamName"
+            :totalPoints="team.totalPoints || 0"
+            :totalCount="team.totalCount || 0"
+            :boardCount="team.boardCount || 0"
+            :percentages="team.percentages || {}"
+            :buckets="teamBuckets(team)"
+            :metricMode="metricMode"
+            :configured="team.allocationConfigured !== false"
+            @click="openTeam(team)"
+          />
+        </div>
+      </template>
     </template>
   </div>
 </template>

--- a/platform/allocation/client/services/allocation-api.js
+++ b/platform/allocation/client/services/allocation-api.js
@@ -6,6 +6,18 @@ export async function getTeamAllocationSummary(teamId) {
   return apiRequest(`${BASE}/team/${encodeURIComponent(teamId)}/summary`)
 }
 
+export async function getTeamAllocationSettings(teamId) {
+  return apiRequest(`${BASE}/team/${encodeURIComponent(teamId)}/settings`)
+}
+
+export async function updateTeamAllocationSettings(teamId, allocationMode) {
+  return apiRequest(`${BASE}/team/${encodeURIComponent(teamId)}/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ allocationMode })
+  })
+}
+
 export async function getBoardSprints(boardId, sprintFilter) {
   const params = sprintFilter ? `?sprintFilter=${encodeURIComponent(sprintFilter)}` : ''
   return apiRequest(`${BASE}/board/${encodeURIComponent(boardId)}/sprints${params}`)

--- a/platform/allocation/server/orchestration.js
+++ b/platform/allocation/server/orchestration.js
@@ -217,7 +217,12 @@ async function processKanbanBoard({ board, teamId, allocationMode, strategy, fet
  */
 async function refreshTeam({ team, strategy, hardRefresh, fetchSprints, fetchSprintIssues, fetchBoardConfiguration, fetchFilterJql, fetchIssuesByJql, fetchBoardType, readStorage, writeStorage }) {
   const teamId = team.id;
-  const allocationMode = team.metadata?.allocationMode || 'points';
+  // A team is "configured" only once a manager has explicitly chosen a basis.
+  // Until then we compute numbers using a story-points fallback. Configured-ness
+  // itself is NOT stored here — it's derived from live team metadata at read
+  // time (see the summary routes), so it can't go stale in this snapshot.
+  const configuredMode = team.metadata?.allocationMode;
+  const allocationMode = (configuredMode === 'points' || configuredMode === 'counts') ? configuredMode : 'points';
   const boards = (team.boards || []).filter(b => b.boardId);
 
   if (boards.length === 0) {
@@ -301,6 +306,109 @@ async function refreshTeam({ team, strategy, hardRefresh, fetchSprints, fetchSpr
 }
 
 /**
+ * Aggregate a set of team summaries into org + global rollups.
+ *
+ * Pure (no I/O) so it can be fed either freshly-computed team summaries (a full
+ * refresh) or the team summary files read from disk (a single-team refresh).
+ * This is the single source of the org/global aggregation math.
+ *
+ * @param {Array} teamSummaries - team summary objects (shape of summaries/team-*.json)
+ * @param {Object} strategy
+ * @returns {{ orgSummaries: Array<{orgKey: string, data: Object}>, globalData: Object }}
+ */
+function assembleRollups(teamSummaries, strategy) {
+  const now = new Date().toISOString();
+
+  const orgGroups = new Map();
+  for (const s of teamSummaries) {
+    const orgKey = s.orgKey || 'unknown';
+    if (!orgGroups.has(orgKey)) orgGroups.set(orgKey, []);
+    orgGroups.get(orgKey).push(s);
+  }
+
+  const orgSummaries = [];
+  for (const [orgKey, orgTeams] of orgGroups) {
+    const orgSummary = buildOrgSummary(orgTeams, strategy.categories);
+    orgSummaries.push({
+      orgKey,
+      data: {
+        orgKey,
+        strategyId: strategy.id,
+        lastUpdated: now,
+        ...orgSummary,
+        teams: orgTeams.map(t => ({
+          teamId: t.teamId,
+          teamName: t.teamName,
+          totalPoints: t.totalPoints,
+          totalCount: t.totalCount,
+          boardCount: t.boardCount,
+          percentages: t.percentages
+        }))
+      }
+    });
+  }
+
+  const globalSummary = buildOrgSummary(teamSummaries, strategy.categories);
+  const globalData = {
+    strategyId: strategy.id,
+    lastUpdated: now,
+    ...globalSummary,
+    teams: teamSummaries.map(t => ({
+      teamId: t.teamId,
+      teamName: t.teamName,
+      orgKey: t.orgKey,
+      totalPoints: t.totalPoints,
+      totalCount: t.totalCount,
+      boardCount: t.boardCount,
+      percentages: t.percentages
+    })),
+    orgs: orgSummaries.map(o => ({
+      orgKey: o.data.orgKey,
+      totalPoints: o.data.totalPoints,
+      totalCount: o.data.totalCount,
+      teamCount: o.data.teamCount,
+      boardCount: o.data.boardCount,
+      percentages: o.data.percentages
+    }))
+  };
+
+  return { orgSummaries, globalData };
+}
+
+/** Aggregate the given team summaries and persist org + global rollups. */
+async function writeRollups({ teamSummaries, strategy, writeStorage }) {
+  const { orgSummaries, globalData } = assembleRollups(teamSummaries, strategy);
+  for (const org of orgSummaries) {
+    await writeStorage(`summaries/org-${org.orgKey}.json`, org.data);
+  }
+  await writeStorage('summaries/global.json', globalData);
+  return { orgCount: orgSummaries.length };
+}
+
+/**
+ * Rebuild org + global rollups from the per-team summary files already on disk.
+ *
+ * Cheap (no Jira) — this decouples "fetch a team's data from Jira" from
+ * "aggregate the rollups", so a single-team refresh can update the org/global
+ * registries from the current on-disk team summaries without re-fetching every
+ * team and without clobbering the teams it didn't touch.
+ *
+ * @param {Object} opts
+ * @param {Object} opts.strategy
+ * @param {Array}  opts.teams - all teams (only `id` is used) whose summaries to aggregate
+ * @param {Function} opts.readStorage
+ * @param {Function} opts.writeStorage
+ */
+async function rebuildRollups({ strategy, teams, readStorage, writeStorage }) {
+  const teamSummaries = [];
+  for (const team of teams) {
+    const summary = await readStorage(`summaries/team-${team.id}.json`);
+    if (summary) teamSummaries.push(summary);
+  }
+  return writeRollups({ teamSummaries, strategy, writeStorage });
+}
+
+/**
  * Full refresh: read teams from team-store, process each, then build org and global summaries.
  */
 async function performRefresh({ teams, strategy, hardRefresh, fetchSprints, fetchSprintIssues, fetchBoardConfiguration, fetchFilterJql, fetchIssuesByJql, fetchBoardType, readStorage, writeStorage }) {
@@ -325,59 +433,8 @@ async function performRefresh({ teams, strategy, hardRefresh, fetchSprints, fetc
     }
   }
 
-  // Build org-level summaries
-  const orgGroups = new Map();
-  for (const result of teamResults) {
-    const orgKey = result.orgKey || 'unknown';
-    if (!orgGroups.has(orgKey)) orgGroups.set(orgKey, []);
-    orgGroups.get(orgKey).push(result);
-  }
-
-  const orgSummaries = [];
-  for (const [orgKey, orgTeams] of orgGroups) {
-    const orgSummary = buildOrgSummary(orgTeams, strategy.categories);
-    const orgData = {
-      orgKey,
-      strategyId: strategy.id,
-      lastUpdated: new Date().toISOString(),
-      ...orgSummary,
-      teams: orgTeams.map(t => ({
-        teamId: t.teamId,
-        teamName: t.teamName,
-        totalPoints: t.totalPoints,
-        totalCount: t.totalCount,
-        boardCount: t.boardCount,
-        percentages: t.percentages
-      }))
-    };
-    await writeStorage(`summaries/org-${orgKey}.json`, orgData);
-    orgSummaries.push(orgData);
-  }
-
-  // Build global summary
-  const globalSummary = buildOrgSummary(teamResults, strategy.categories);
-  await writeStorage('summaries/global.json', {
-    strategyId: strategy.id,
-    lastUpdated: new Date().toISOString(),
-    ...globalSummary,
-    teams: teamResults.map(t => ({
-      teamId: t.teamId,
-      teamName: t.teamName,
-      orgKey: t.orgKey,
-      totalPoints: t.totalPoints,
-      totalCount: t.totalCount,
-      boardCount: t.boardCount,
-      percentages: t.percentages
-    })),
-    orgs: orgSummaries.map(o => ({
-      orgKey: o.orgKey,
-      totalPoints: o.totalPoints,
-      totalCount: o.totalCount,
-      teamCount: o.teamCount,
-      boardCount: o.boardCount,
-      percentages: o.percentages
-    }))
-  });
+  // Aggregate org + global rollups from the teams processed this run.
+  const { orgCount } = await writeRollups({ teamSummaries: teamResults, strategy, writeStorage });
 
   const refreshElapsed = ((Date.now() - refreshStart) / 1000).toFixed(1);
   console.log(`[allocation] Refresh complete: ${teamResults.length}/${teams.length} teams succeeded (${refreshElapsed}s)`);
@@ -386,8 +443,8 @@ async function performRefresh({ teams, strategy, hardRefresh, fetchSprints, fetc
     success: true,
     teamCount: teamResults.length,
     failedTeamCount: teams.length - teamResults.length,
-    orgCount: orgGroups.size
+    orgCount
   };
 }
 
-module.exports = { processBoard, processKanbanBoard, refreshTeam, performRefresh };
+module.exports = { processBoard, processKanbanBoard, refreshTeam, performRefresh, assembleRollups, rebuildRollups };

--- a/platform/allocation/server/routes.js
+++ b/platform/allocation/server/routes.js
@@ -3,16 +3,19 @@
  * Mounted at /api/modules/team-tracker/allocation/ by the team-tracker server.
  */
 
-const { readTeams, extractBoardId } = require('../../../shared/server/team-store');
+const { readTeams, extractBoardId, updateTeamFields } = require('../../../shared/server/team-store');
 const { getOrgDisplayNames } = require('../../../shared/server/roster-sync/config');
+const permissions = require('../../../shared/server/permissions');
 const { allocationKey } = require('./config');
 
 function isValidBoardId(id) { return /^(\d+|kanban-\d+)$/.test(id); }
 function isValidSprintId(id) { return /^(\d+|kanban-\d+)$/.test(id); }
+function isValidTeamId(id) { return typeof id === 'string' && /^[A-Za-z0-9_-]{1,64}$/.test(id); }
 const REFRESH_COOLDOWN_MS = 60_000;
+const ALLOCATION_MODES = ['points', 'counts'];
 
 module.exports = function registerAllocationRoutes(router, context) {
-  const { storage, requireAdmin, requireScope } = context;
+  const { storage, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
 
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
@@ -28,11 +31,51 @@ module.exports = function registerAllocationRoutes(router, context) {
   const extraFields = strategy?.getJiraFields ? strategy.getJiraFields() : null;
   const jiraClient = createJiraClient({ jiraRequest, jiraHost: JIRA_HOST, extraFields });
 
-  const { performRefresh } = require('./orchestration');
+  const { performRefresh, refreshTeam, rebuildRollups } = require('./orchestration');
+
+  // Shared fetchers passed to the orchestration layer.
+  const jiraFetchers = {
+    fetchSprints: jiraClient.fetchSprints,
+    fetchSprintIssues: jiraClient.fetchSprintIssues,
+    fetchBoardConfiguration: jiraClient.fetchBoardConfiguration,
+    fetchFilterJql: jiraClient.fetchFilterJql,
+    fetchIssuesByJql: jiraClient.fetchIssuesByJql,
+    fetchBoardType: jiraClient.fetchBoardType
+  };
 
   // Storage helpers -- all allocation data under allocation/ prefix
   async function allocRead(key) { return await readFromStorage(allocationKey(key)); }
   async function allocWrite(key, data) { await writeToStorage(allocationKey(key), data); }
+
+  // Tag each team in a rollup with whether it has configured an allocation
+  // basis, derived from LIVE team metadata (not the summary snapshot) so the
+  // count is always current and reflects setting changes immediately.
+  async function enrichConfigured(teamsArr) {
+    if (!Array.isArray(teamsArr) || teamsArr.length === 0) return teamsArr;
+    const teamData = await readTeams(storage);
+    const teamsById = teamData.teams || {};
+    return teamsArr.map(t => {
+      const mode = teamsById[t.teamId]?.metadata?.allocationMode;
+      return { ...t, allocationConfigured: mode === 'points' || mode === 'counts' };
+    });
+  }
+
+  // Mirrors team-tracker's requireTeamPurview: admins, team-admins, and managers
+  // with a report on the team may edit team settings. Kept self-contained here
+  // (the extension can't import team-tracker internals) using shared/permissions.
+  async function hasTeamPurview(req, teamId) {
+    if (req.isAdmin || req.isTeamAdmin) return true;
+    if (!req.userUid) return false;
+    const registry = await readFromStorage('team-data/registry.json');
+    if (!registry || !registry.people) return false;
+    const managerMap = permissions.buildManagerMap(registry);
+    const managed = permissions.getManagedUids(req.userUid, managerMap);
+    for (const uid of managed) {
+      const person = registry.people[uid];
+      if (person && Array.isArray(person.teamIds) && person.teamIds.includes(teamId)) return true;
+    }
+    return false;
+  }
 
   // Strategy metadata endpoint
 
@@ -76,13 +119,17 @@ module.exports = function registerAllocationRoutes(router, context) {
    *   post:
    *     tags: ['Allocation']
    *     summary: Trigger allocation data refresh from Jira
-   *     security: [{ admin: [] }]
+   *     description: >
+   *       A team-scoped refresh (teamId provided) may be triggered by any
+   *       authenticated user and only updates that team's board/sprint data and
+   *       team summary. A full refresh (no teamId) rebuilds org/global summaries
+   *       and requires admin.
    *     parameters:
    *       - in: query
    *         name: teamId
    *         schema:
    *           type: string
-   *         description: Refresh a single team (optional)
+   *         description: Refresh a single team (optional). Omit for a full, admin-only refresh.
    *     requestBody:
    *       content:
    *         application/json:
@@ -96,8 +143,23 @@ module.exports = function registerAllocationRoutes(router, context) {
    *     responses:
    *       200:
    *         description: Refresh status
+   *       403:
+   *         description: Admin required for a full refresh
    */
-  router.post('/allocation/refresh', requireAdmin, requireScope('metrics:write'), async function(req, res) {
+  router.post('/allocation/refresh', requireScope('metrics:write'), async function(req, res) {
+    const teamId = req.query.teamId || req.body.teamId;
+    const hardRefresh = req.body.hardRefresh || false;
+
+    if (teamId && !isValidTeamId(teamId)) {
+      return res.status(400).json({ error: 'Invalid request parameter' });
+    }
+
+    // Full (unscoped) refresh rebuilds org/global summaries and stays admin-only.
+    // Team-scoped refreshes are self-service for any authenticated user.
+    if (!teamId && !req.isAdmin) {
+      return res.status(403).json({ error: 'Admin access required for a full refresh. Pass a teamId to refresh a single team.' });
+    }
+
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' });
     }
@@ -117,12 +179,9 @@ module.exports = function registerAllocationRoutes(router, context) {
       }
     }
 
-    const teamId = req.query.teamId || req.body.teamId;
-    const hardRefresh = req.body.hardRefresh || false;
-
     refreshState.running = true;
     refreshState.startedAt = new Date().toISOString();
-    res.json({ status: 'started' });
+    res.json({ status: 'started', scope: teamId ? 'team' : 'full' });
 
     setImmediate(async function() {
       try {
@@ -151,30 +210,30 @@ module.exports = function registerAllocationRoutes(router, context) {
         // Filter to teams with at least one board with a boardId
         teams = teams.filter(t => (t.boards || []).some(b => b.boardId));
 
-        console.log(`\n[allocation] Starting refresh: ${teams.length} teams with allocation boards`);
-
-        const result = await performRefresh({
-          teams,
-          strategy,
-          hardRefresh,
-          fetchSprints: jiraClient.fetchSprints,
-          fetchSprintIssues: jiraClient.fetchSprintIssues,
-          fetchBoardConfiguration: jiraClient.fetchBoardConfiguration,
-          fetchFilterJql: jiraClient.fetchFilterJql,
-          fetchIssuesByJql: jiraClient.fetchIssuesByJql,
-          fetchBoardType: jiraClient.fetchBoardType,
-          readStorage: allocRead,
-          writeStorage: allocWrite
-        });
+        let message;
+        if (teamId) {
+          // Team-scoped: fetch only this team's Jira data + write its team summary…
+          console.log(`\n[allocation] Starting team-scoped refresh for ${teamId}`);
+          for (const team of teams) {
+            await refreshTeam({ team, strategy, hardRefresh, ...jiraFetchers, readStorage: allocRead, writeStorage: allocWrite });
+          }
+          // …then rebuild org/global rollups from ALL teams' on-disk summaries.
+          // This is cheap (no Jira) and keeps other teams intact — no clobber.
+          const allTeams = Object.values(teamData.teams || {});
+          await rebuildRollups({ strategy, teams: allTeams, readStorage: allocRead, writeStorage: allocWrite });
+          message = teams.length ? `Refreshed team ${teamId}` : `Team ${teamId} has no allocation boards`;
+        } else {
+          console.log(`\n[allocation] Starting full refresh: ${teams.length} teams with allocation boards`);
+          const result = await performRefresh({
+            teams, strategy, hardRefresh, ...jiraFetchers, readStorage: allocRead, writeStorage: allocWrite
+          });
+          message = `Processed ${result.teamCount} teams`;
+        }
 
         const completedAt = new Date().toISOString();
-        refreshState.lastResult = {
-          status: 'success',
-          message: `Processed ${result.teamCount} teams`,
-          completedAt
-        };
+        refreshState.lastResult = { status: 'success', message, completedAt };
         refreshState.completedAt = completedAt;
-        console.log(`[allocation] Refresh complete: ${result.teamCount} teams processed`);
+        console.log(`[allocation] Refresh complete: ${message}`);
       } catch (error) {
         console.error('[allocation] Background refresh error:', error);
         const completedAt = new Date().toISOString();
@@ -302,6 +361,9 @@ module.exports = function registerAllocationRoutes(router, context) {
   router.get('/allocation/team/:teamId/summary', requireScope('metrics:read'), async function(req, res) {
     try {
       const { teamId } = req.params;
+      if (!isValidTeamId(teamId)) {
+        return res.status(400).json({ error: 'Invalid request parameter' });
+      }
       const data = await allocRead(`summaries/team-${teamId}.json`);
       if (!data) {
         return res.json({ lastUpdated: null, totalPoints: 0, boardCount: 0, buckets: {} });
@@ -309,6 +371,100 @@ module.exports = function registerAllocationRoutes(router, context) {
       res.json(data);
     } catch (error) {
       console.error('[allocation] Read team summary error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/allocation/team/{teamId}/settings:
+   *   get:
+   *     tags: ['Allocation']
+   *     summary: Get a team's allocation settings and the caller's edit permission
+   *     parameters:
+   *       - in: path
+   *         name: teamId
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: "{ allocationMode: 'points'|'counts'|null, configured: boolean, canEdit: boolean }"
+   */
+  router.get('/allocation/team/:teamId/settings', requireScope('metrics:read'), async function(req, res) {
+    try {
+      const { teamId } = req.params;
+      if (!isValidTeamId(teamId)) {
+        return res.status(400).json({ error: 'Invalid request parameter' });
+      }
+      const teamData = await readTeams(storage);
+      const team = teamData.teams && teamData.teams[teamId];
+      if (!team) return res.status(404).json({ error: 'Team not found' });
+      const mode = team.metadata?.allocationMode;
+      const configured = mode === 'points' || mode === 'counts';
+      const canEdit = await hasTeamPurview(req, teamId);
+      // allocationMode is null until a manager explicitly configures a basis.
+      res.json({ allocationMode: configured ? mode : null, configured, canEdit });
+    } catch (error) {
+      console.error('[allocation] Read team settings error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/allocation/team/{teamId}/settings:
+   *   put:
+   *     tags: ['Allocation']
+   *     summary: Update a team's allocation calculation basis
+   *     description: Requires team purview (admin, team-admin, or a manager with a report on the team).
+   *     parameters:
+   *       - in: path
+   *         name: teamId
+   *         required: true
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               allocationMode:
+   *                 type: string
+   *                 enum: [points, counts]
+   *     responses:
+   *       200:
+   *         description: Updated settings
+   *       400:
+   *         description: Invalid allocationMode
+   *       403:
+   *         description: Not authorized for this team
+   *       404:
+   *         description: Team not found
+   */
+  router.put('/allocation/team/:teamId/settings', requireScope('metrics:write'), async function(req, res) {
+    try {
+      const { teamId } = req.params;
+      const { allocationMode } = req.body || {};
+      if (!isValidTeamId(teamId)) {
+        return res.status(400).json({ error: 'Invalid request parameter' });
+      }
+      if (!ALLOCATION_MODES.includes(allocationMode)) {
+        return res.status(400).json({ error: `allocationMode must be one of: ${ALLOCATION_MODES.join(', ')}` });
+      }
+      if (DEMO_MODE) {
+        return res.status(403).json({ error: 'Settings are read-only in demo mode' });
+      }
+      if (!(await hasTeamPurview(req, teamId))) {
+        return res.status(403).json({ error: 'Not authorized for this team' });
+      }
+      const result = await updateTeamFields(storage, teamId, { allocationMode }, req.auditActor);
+      if (!result) return res.status(404).json({ error: 'Team not found' });
+      res.json({ allocationMode });
+    } catch (error) {
+      console.error('[allocation] Update team settings error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   });
@@ -345,6 +501,7 @@ module.exports = function registerAllocationRoutes(router, context) {
       if (!data) {
         return res.json({ lastUpdated: null, totalPoints: 0, teamCount: 0, boardCount: 0, buckets: {} });
       }
+      data.teams = await enrichConfigured(data.teams);
       res.json(data);
     } catch (error) {
       console.error('[allocation] Read org summary error:', error);
@@ -368,6 +525,7 @@ module.exports = function registerAllocationRoutes(router, context) {
       if (!data) {
         return res.json({ lastUpdated: null, totalPoints: 0, teamCount: 0, boardCount: 0, buckets: {} });
       }
+      data.teams = await enrichConfigured(data.teams);
       res.json(data);
     } catch (error) {
       console.error('[allocation] Read global summary error:', error);
@@ -410,14 +568,17 @@ module.exports = function registerAllocationRoutes(router, context) {
       if (sprintFilter) {
         const filterKey = sprintFilter.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
         const filtered = await allocRead(`sprints/board-${boardId}-${filterKey}.json`);
-        if (filtered) return res.json(filtered);
+        if (filtered) return res.json({ synced: true, ...filtered });
       }
 
       const data = await allocRead(`sprints/board-${boardId}.json`);
       if (!data) {
-        return res.json({ sprints: [] });
+        // No index file for this board yet — it has never been synced from Jira.
+        // `synced: false` lets the client distinguish this from a synced board
+        // that genuinely has no sprints.
+        return res.json({ synced: false, sprints: [] });
       }
-      res.json(data);
+      res.json({ synced: true, ...data });
     } catch (error) {
       console.error('[allocation] Read sprints error:', error);
       res.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
Improves the UX of the allocation feature on the team detail tab and the org rollup report.

## Team allocation tab
- **Kanban vs Scrum explainer**: an info callout above the chart explaining how the allocation percentage is calculated for the auto-detected board type (sprint-based for Scrum, trailing-2-weeks for Kanban).
- **Self-service refresh**: three distinct empty states — *no board configured*, *never synced*, *synced but no sprints* — each with a refresh action, plus an always-on "Last synced · Refresh" control. The refresh polls status and reloads when done.
- **Board-selection fix**: the board is now auto-selected reactively, so sprint data (and the explainer) render when `teamDetail` loads asynchronously after mount. This was the root cause of the chart/info block not appearing for some teams.
- **Per-team allocation basis**: a settings modal to choose **Story Points** vs **Issue Count**, gated by team purview (admins, team-admins, managers of the team), forcing an explicit first-time choice. The metric toggle is now a view-only override, with a clear callout when the view differs from the team's saved default. Saving persists the choice and re-runs the team's allocation.
- **Unconfigured state**: teams that haven't chosen a basis get an action-needed banner.

## Org rollup report
- **Team search box**, aligned with the org toggle bar.
- **Blatant unconfigured call-out**: a count banner + a "Not configured" badge per team card, with unconfigured teams sorted first. Configured-ness is derived from **live team metadata at read time**, so the count is always current (no staleness, no refresh needed).
- Improved empty state with an admin full-refresh action.

## Backend
- Team-scoped refresh is allowed for **non-admins**; full refresh stays admin-only.
- **Decoupled Jira fetch from rollup aggregation**: a single `assembleRollups()` powers both paths, and `rebuildRollups()` rebuilds org/global from on-disk team summaries (cheap, no Jira). A single-team refresh now updates the global registry **without clobbering** other teams.
- `board/{id}/sprints` returns a `synced` flag to distinguish never-synced from synced-but-empty.
- New team settings `GET`/`PUT` endpoints persist the basis via team-store with purview enforcement.

## Testing
- 202 unit tests passing (new coverage for the board-type explainer, refresh composable/panel, settings modal, per-team config, unconfigured rollup call-out, and rebuild-rollups no-clobber). Lint + OpenAPI validation clean.
- Verified end-to-end in the running app against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)