### PR TITLE
(feat): Add e2e blocker bug jira page to e2e health dashboard

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1887,6 +1887,56 @@ E2E (end-to-end) test health data for the opendatahub-operator repository. Conta
 - Component statistics use 30-day accumulated data for accurate failure rates
 - Daily status thresholds: 100% = healthy, ≥70% = stable, ≥50% = degraded, ≥20% = failing, <20% = broken
 
+## System Health — E2E Blocker JIRAs (`data/system-health/odh-e2e-blocker-jiras.json`)
+
+Snapshot of the currently-open Jira blocker bugs auto-filed by the
+opendatahub-operator `e2e-failure-triage` automation. The automation labels every
+bug it creates with `odh-operator-auto-e2e-blocker` (in project `RHOAIENG`) and
+links it to the template issue `RHOAIENG-79740`. The `odh-e2e-blocker-jiras`
+refresh handler queries Jira for open (`resolution = Unresolved`) issues carrying
+that label and writes a full snapshot.
+
+```json
+{
+  "lastSyncedAt": "2026-08-11T10:00:00.000Z",
+  "available": true,
+  "count": 3,
+  "jql": "project = RHOAIENG AND labels = \"odh-operator-auto-e2e-blocker\" AND resolution = Unresolved ORDER BY created DESC",
+  "jqlUrl": "https://redhat.atlassian.net/issues/?jql=...",
+  "templateIssue": "RHOAIENG-79740",
+  "issues": [
+    {
+      "key": "RHOAIENG-81234",
+      "summary": "[Auto] E2E blocker: dashboard tests failing",
+      "status": "New",
+      "priority": "Blocker",
+      "component": "Dashboard",
+      "affectsVersions": ["2.20 GA RHOAI RELEASE"],
+      "assignee": null,
+      "created": "2026-08-10T14:22:00.000Z",
+      "updated": "2026-08-11T08:15:00.000Z",
+      "url": "https://redhat.atlassian.net/browse/RHOAIENG-81234"
+    }
+  ]
+}
+```
+
+**Top-level fields:**
+- `lastSyncedAt`: ISO timestamp of the last successful fetch (may be preserved from a prior run on a failed refresh)
+- `available`: `false` when Jira credentials are missing or a fetch failed; `true` otherwise
+- `reason`: present when `available` is false (`missing-credentials`, `fetch-error`, or `no_data`)
+- `count`: number of open blocker issues
+- `jql` / `jqlUrl`: the JQL used and a deep link to view the issues in Jira
+- `templateIssue`: the clone template key (`RHOAIENG-79740`)
+- `issues`: array of open blocker issues (see per-issue fields below)
+
+**Per-issue fields:** `key`, `summary`, `status`, `priority`, `component` (comma-joined), `affectsVersions` (array), `assignee` (display name or null), `created`, `updated`, `url`.
+
+**Notes:**
+- Refreshed hourly by the `odh-e2e-blocker-jiras` handler. Requires the `jira` platform secret group (`JIRA_EMAIL` / `JIRA_TOKEN`).
+- **Snapshot semantics:** each successful run fully overwrites the file with the current open set — no merge/accumulate — so JIRAs resolved/closed since the last run are evicted automatically.
+- On a transient fetch failure the previous `issues` are preserved and `available` is set to `false` (the dashboard keeps showing last-known-good data). Missing credentials writes an empty list.
+
 ## System Health — Quality Reports (`data/system-health/quality/reports.json`)
 
 Quality analysis reports tracking repository testing, CI/CD, and code quality practices across 8 dimensions. Reports are pushed from the quality-repo-analysis CI pipeline via the bulk API, or pulled from GitLab CI artifacts.

--- a/fixtures/system-health/odh-e2e-blocker-jiras.json
+++ b/fixtures/system-health/odh-e2e-blocker-jiras.json
@@ -1,0 +1,46 @@
+{
+  "lastSyncedAt": "2026-08-11T10:00:00.000Z",
+  "available": true,
+  "count": 3,
+  "jql": "project = RHOAIENG AND labels = \"odh-operator-auto-e2e-blocker\" AND resolution = Unresolved ORDER BY created DESC",
+  "jqlUrl": "https://redhat.atlassian.net/issues/?jql=project%20%3D%20RHOAIENG%20AND%20labels%20%3D%20%22odh-operator-auto-e2e-blocker%22%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20created%20DESC",
+  "templateIssue": "RHOAIENG-79740",
+  "issues": [
+    {
+      "key": "RHOAIENG-81234",
+      "summary": "[Auto] E2E blocker: dashboard tests failing",
+      "status": "New",
+      "priority": "Blocker",
+      "component": "Dashboard",
+      "affectsVersions": ["2.20 GA RHOAI RELEASE"],
+      "assignee": null,
+      "created": "2026-08-10T14:22:00.000Z",
+      "updated": "2026-08-11T08:15:00.000Z",
+      "url": "https://redhat.atlassian.net/browse/RHOAIENG-81234"
+    },
+    {
+      "key": "RHOAIENG-81198",
+      "summary": "[Auto] E2E blocker: kserve tests failing",
+      "status": "In Progress",
+      "priority": "Blocker",
+      "component": "KServe",
+      "affectsVersions": ["2.20 GA RHOAI RELEASE"],
+      "assignee": "Jane Doe",
+      "created": "2026-08-09T09:05:00.000Z",
+      "updated": "2026-08-10T16:40:00.000Z",
+      "url": "https://redhat.atlassian.net/browse/RHOAIENG-81198"
+    },
+    {
+      "key": "RHOAIENG-81050",
+      "summary": "[Auto] E2E blocker: modelregistry tests failing",
+      "status": "New",
+      "priority": "Blocker",
+      "component": "Model Registry",
+      "affectsVersions": ["2.19 EA1 RHOAI RELEASE"],
+      "assignee": null,
+      "created": "2026-08-07T11:30:00.000Z",
+      "updated": "2026-08-08T12:00:00.000Z",
+      "url": "https://redhat.atlassian.net/browse/RHOAIENG-81050"
+    }
+  ]
+}

--- a/modules/system-health/client/components/BlockerJiraTable.vue
+++ b/modules/system-health/client/components/BlockerJiraTable.vue
@@ -1,0 +1,162 @@
+<script setup>
+import { computed } from 'vue'
+import { ExternalLink, AlertTriangle, RefreshCw } from 'lucide-vue-next'
+
+const props = defineProps({
+  issues: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  available: { type: Boolean, default: true },
+  reason: { type: String, default: null },
+  // Client-side load error (the call to our own API failed). Distinct from
+  // `reason`, which describes the server-side snapshot state.
+  error: { type: String, default: null },
+  jqlUrl: { type: String, default: '' },
+  lastSyncedAt: { type: String, default: null }
+})
+
+const hasIssues = computed(() => (props.issues || []).length > 0)
+
+function statusBadgeClass(status) {
+  const s = (status || '').toLowerCase()
+  if (s === 'new' || s === 'to do' || s === 'backlog') {
+    return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300'
+  }
+  if (s === 'in progress') {
+    return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+  }
+  if (s === 'review' || s === 'code review') {
+    return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300'
+  }
+  if (s === 'resolved' || s === 'done' || s === 'closed') {
+    return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+}
+
+function formatDate(value) {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+const unavailableMessage = computed(() => {
+  // A client-side load failure takes precedence — the snapshot never reached us.
+  if (props.error) {
+    return 'Could not load blocker JIRAs. Please try refreshing the page.'
+  }
+  if (props.reason === 'missing-credentials') {
+    return 'Jira credentials are not configured, so blocker JIRAs cannot be fetched.'
+  }
+  if (props.reason === 'fetch-error') {
+    return 'Could not reach Jira on the last refresh. Showing the last known data if available.'
+  }
+  return 'Blocker JIRA data is not yet available. Please check back later.'
+})
+</script>
+
+<template>
+  <div>
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+      <RefreshCw class="animate-spin w-5 h-5 mr-2" />
+      Loading blocker JIRAs…
+    </div>
+
+    <template v-else>
+      <!-- Unavailable (no creds / fetch error / no data) with no data to show -->
+      <div
+        v-if="!available && !hasIssues"
+        class="text-center py-12"
+      >
+        <AlertTriangle class="mx-auto h-10 w-10 text-gray-400" />
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">{{ unavailableMessage }}</p>
+      </div>
+
+      <!-- Empty (available, but zero open blockers) -->
+      <div
+        v-else-if="!hasIssues"
+        class="text-center py-12"
+      >
+        <p class="text-sm font-medium text-gray-900 dark:text-white">No open blocker JIRAs 🎉</p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          No auto-filed E2E blocker bugs are currently open.
+        </p>
+      </div>
+
+      <!-- Issue table -->
+      <div v-else class="-mx-4 sm:mx-0">
+        <!-- Stale-data banner when a fetch failed but we kept last-known-good data -->
+        <div
+          v-if="!available"
+          class="mb-3 flex items-center gap-2 rounded-md bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-800 dark:text-amber-300"
+        >
+          <AlertTriangle class="w-4 h-4 shrink-0" />
+          {{ unavailableMessage }}
+        </div>
+
+        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+          <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-600">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Key</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Summary</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Component</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Affects Version</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Assignee</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Created</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="issue in issues"
+                :key="issue.key"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                  <a
+                    v-if="issue.url"
+                    :href="issue.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center text-primary-600 hover:text-primary-900 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
+                  >
+                    {{ issue.key || '—' }}
+                    <ExternalLink class="inline ml-1 h-3 w-3" />
+                  </a>
+                  <span v-else class="font-medium text-gray-900 dark:text-white">{{ issue.key || '—' }}</span>
+                </td>
+                <td class="px-6 py-4 text-sm text-gray-900 dark:text-white max-w-md truncate" :title="issue.summary">
+                  {{ issue.summary || '—' }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
+                  {{ issue.component || '—' }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
+                  {{ (issue.affectsVersions || []).join(', ') || '—' }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <span
+                    class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                    :class="statusBadgeClass(issue.status)"
+                  >
+                    {{ issue.status }}
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
+                  {{ issue.assignee || 'Unassigned' }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
+                  {{ formatDate(issue.created) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div v-if="lastSyncedAt" class="mt-3 text-xs text-gray-400 dark:text-gray-500">
+          Last synced {{ new Date(lastSyncedAt).toLocaleString() }}
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/system-health/client/composables/useOdhOperatorE2eHealth.js
+++ b/modules/system-health/client/composables/useOdhOperatorE2eHealth.js
@@ -7,6 +7,12 @@ const loading = ref(false)
 const error = ref(null)
 let hasFetched = false
 
+// Auto-filed E2E blocker JIRAs (loaded lazily when the JIRAs tab is opened)
+const blockerJiras = ref(null)
+const blockerJirasLoading = ref(false)
+const blockerJirasError = ref(null)
+let hasFetchedBlockerJiras = false
+
 async function loadHealthData(force = false) {
   loading.value = true
   error.value = null
@@ -58,6 +64,27 @@ async function loadRunHistory(options = {}) {
     if (!append) {
       loading.value = false
     }
+  }
+}
+
+async function loadBlockerJiras(force = false) {
+  // Fetch once per session unless forced (lazy — triggered on tab open).
+  if (hasFetchedBlockerJiras && !force) return
+
+  hasFetchedBlockerJiras = true
+  blockerJirasLoading.value = true
+  blockerJirasError.value = null
+  try {
+    const cacheBuster = force ? `?_cb=${Date.now()}` : ''
+    const data = await apiRequest(`/modules/system-health/odh-e2e-health/blocker-jiras${cacheBuster}`)
+    blockerJiras.value = data
+  } catch (e) {
+    blockerJirasError.value = e.message || 'Failed to load E2E blocker JIRAs'
+    blockerJiras.value = null
+    // Allow retry after a failure
+    hasFetchedBlockerJiras = false
+  } finally {
+    blockerJirasLoading.value = false
   }
 }
 
@@ -161,6 +188,11 @@ export function useOdhOperatorE2eHealth() {
     loading,
     error,
 
+    // Blocker JIRAs
+    blockerJiras,
+    blockerJirasLoading,
+    blockerJirasError,
+
     // Computed insights
     currentlyBlockingComponents,
     suiteHealthSummary,
@@ -170,7 +202,8 @@ export function useOdhOperatorE2eHealth() {
 
     // Actions
     loadHealthData,
-    loadRunHistory
+    loadRunHistory,
+    loadBlockerJiras
   }
 }
 

--- a/modules/system-health/client/views/OdhOperatorE2eHealthView.vue
+++ b/modules/system-health/client/views/OdhOperatorE2eHealthView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, inject, ref, onMounted, onUnmounted } from 'vue'
 import { useOdhOperatorE2eHealth } from '../composables/useOdhOperatorE2eHealth.js'
+import BlockerJiraTable from '../components/BlockerJiraTable.vue'
 import { Line } from 'vue-chartjs'
 import {
   RefreshCw,
@@ -23,11 +24,33 @@ import {
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Title)
 
 const nav = inject('moduleNav', null)
-const { healthData, runHistory, loading, error, loadHealthData, loadRunHistory } = useOdhOperatorE2eHealth()
+const {
+  healthData,
+  runHistory,
+  loading,
+  error,
+  loadHealthData,
+  loadRunHistory,
+  blockerJiras,
+  blockerJirasLoading,
+  blockerJirasError,
+  loadBlockerJiras
+} = useOdhOperatorE2eHealth()
 
 // Filters
 const suiteFilter = ref('all')
 const statusFilter = ref('all')
+
+// Runs / Blocker JIRAs toggle
+const activeTab = ref('runs')
+
+function switchTab(tab) {
+  activeTab.value = tab
+  if (tab === 'jiras') {
+    // Lazy-load on first open (no-op if already fetched)
+    loadBlockerJiras()
+  }
+}
 
 
 // Enhanced 14-day window calculation with temporal status information
@@ -692,12 +715,51 @@ function loadMoreRuns() {
       <!-- Run History Filters -->
       <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
         <div class="px-4 py-5 sm:p-6">
+          <!-- Runs / Blocker JIRAs toggle -->
+          <div class="inline-flex rounded-md border border-gray-300 dark:border-gray-600 p-0.5 mb-5" role="group" aria-label="View toggle">
+            <button
+              type="button"
+              @click="switchTab('runs')"
+              :class="[
+                'px-3 py-1.5 text-sm font-medium rounded transition-colors',
+                activeTab === 'runs'
+                  ? 'bg-primary-600 text-white'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+              ]"
+            >
+              Runs
+            </button>
+            <button
+              type="button"
+              @click="switchTab('jiras')"
+              :class="[
+                'px-3 py-1.5 text-sm font-medium rounded transition-colors',
+                activeTab === 'jiras'
+                  ? 'bg-primary-600 text-white'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+              ]"
+            >
+              Blocker JIRAs
+              <span
+                v-if="blockerJiras?.count"
+                class="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-semibold"
+                :class="activeTab === 'jiras' ? 'bg-white/20 text-white' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'"
+              >{{ blockerJiras.count }}</span>
+            </button>
+          </div>
+
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white">Recent E2E Runs</h3>
-              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">History of recent test executions</p>
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+                {{ activeTab === 'runs' ? 'Recent E2E Runs' : 'Auto-filed Blocker JIRAs' }}
+              </h3>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ activeTab === 'runs'
+                  ? 'History of recent test executions'
+                  : 'Open Jira blockers auto-filed for failing E2E components' }}
+              </p>
             </div>
-            <div class="mt-4 sm:mt-0 flex space-x-3">
+            <div v-if="activeTab === 'runs'" class="mt-4 sm:mt-0 flex space-x-3">
               <select
                 v-model="suiteFilter"
                 class="block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm rounded-md dark:bg-gray-700 dark:text-white"
@@ -715,11 +777,22 @@ function loadMoreRuns() {
                 </option>
               </select>
             </div>
+            <div v-else-if="blockerJiras?.jqlUrl" class="mt-4 sm:mt-0">
+              <a
+                :href="blockerJiras.jqlUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                View all in Jira
+                <ExternalLink class="inline ml-1.5 h-3.5 w-3.5" />
+              </a>
+            </div>
           </div>
 
 
           <!-- Run History Table -->
-          <div class="mt-6 -mx-4 sm:mx-0">
+          <div v-if="activeTab === 'runs'" class="mt-6 -mx-4 sm:mx-0">
             <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
               <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-600">
                 <thead class="bg-gray-50 dark:bg-gray-700">
@@ -800,6 +873,19 @@ function loadMoreRuns() {
                 Load More Runs
               </button>
             </div>
+          </div>
+
+          <!-- Blocker JIRAs Table -->
+          <div v-else class="mt-6">
+            <BlockerJiraTable
+              :issues="blockerJiras?.issues || []"
+              :loading="blockerJirasLoading"
+              :available="blockerJiras?.available === true"
+              :reason="blockerJiras?.reason || null"
+              :error="blockerJirasError"
+              :jql-url="blockerJiras?.jqlUrl || ''"
+              :last-synced-at="blockerJiras?.lastSyncedAt || null"
+            />
           </div>
         </div>
       </div>

--- a/modules/system-health/module.json
+++ b/modules/system-health/module.json
@@ -22,7 +22,7 @@
     "entry": "./server/index.js"
   },
   "secrets": {
-    "platform": ["github", "gitlab"]
+    "platform": ["github", "gitlab", "jira"]
   },
   "export": {
     "files": [

--- a/modules/system-health/server/index.js
+++ b/modules/system-health/server/index.js
@@ -5,6 +5,7 @@ const registerQualityRoutes = require('./quality/routes');
 const qualityScheduler = require('./quality/scheduler');
 const aicpE2ERoutes = require('./odh-e2e-health/routes');
 const aicpE2EScheduler = require('./odh-e2e-health/scheduler');
+const blockerJiras = require('./odh-e2e-health/blocker-jiras');
 
 module.exports = function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireScope } = context;
@@ -81,6 +82,20 @@ module.exports = function registerRoutes(router, context) {
       }
     });
 
+    context.registerRefresh('odh-e2e-blocker-jiras', {
+      order: 91,
+      timeout: 120000, // 2 minutes
+      cadence: '1h',
+      description: 'Fetches auto-filed opendatahub-operator E2E blocker JIRAs from Jira.',
+      handler: async function () {
+        return blockerJiras.refreshBlockerJiras({
+          logger: console,
+          config: context.secrets,
+          storage: storage
+        });
+      }
+    });
+
   }
 
   if (context.registerDiagnostics) {
@@ -90,6 +105,7 @@ module.exports = function registerRoutes(router, context) {
       const qualityData = await storage.readFromStorage('system-health/quality/reports.json');
       const qualityLastFetch = await storage.readFromStorage('system-health/quality/last-fetch.json');
       const odhE2EData = await storage.readFromStorage('system-health/odh-e2e-health.json');
+      const blockerJiraData = await storage.readFromStorage('system-health/odh-e2e-blocker-jiras.json');
 
       return {
         disconnected: {
@@ -123,6 +139,12 @@ module.exports = function registerRoutes(router, context) {
           } : null,
           componentStats: odhE2EData ? Object.keys(odhE2EData.componentStats || {}).length : 0,
           historicalTrends: odhE2EData?.historical_trends ? odhE2EData.historical_trends.daily_status?.length || 0 : 0
+        },
+        blockerJiras: {
+          available: !!(blockerJiraData && blockerJiraData.available),
+          reason: blockerJiraData ? (blockerJiraData.reason || null) : null,
+          count: blockerJiraData ? (blockerJiraData.count || 0) : 0,
+          fetchedAt: blockerJiraData ? blockerJiraData.lastSyncedAt : null
         }
       };
     });

--- a/modules/system-health/server/odh-e2e-health/blocker-jiras.js
+++ b/modules/system-health/server/odh-e2e-health/blocker-jiras.js
@@ -1,0 +1,203 @@
+/**
+ * Auto-filed E2E blocker JIRAs
+ *
+ * The opendatahub-operator repo runs an "e2e-failure-triage" automation
+ * (.github/scripts/e2e-failure-triage/triage.py) that automatically files Jira
+ * blocker bugs when a component's E2E tests fail. Every auto-filed bug is created
+ * in the RHOAIENG project with the label `odh-operator-auto-e2e-blocker` (the
+ * automation's own dedup key — it files one open blocker per component, then
+ * comments on repeats) and is linked to the template issue RHOAIENG-79740 via a
+ * "Cloners" link.
+ *
+ * This module fetches the currently-open blockers (identified by that label) via
+ * a single JQL query and persists a snapshot to storage so the dashboard can
+ * serve it quickly. See the accompanying route + view for how leadership sees it.
+ *
+ * Data-flow note (hard constraint #3): this is lightweight fetch-and-serve — one
+ * bounded JQL query per refresh, not a compute pipeline.
+ */
+
+const { createJiraClient } = require('../../../../shared/server/jira');
+
+const AUTO_BLOCKER_LABEL = 'odh-operator-auto-e2e-blocker';
+const JIRA_PROJECT_KEY = 'RHOAIENG';
+const TEMPLATE_ISSUE_KEY = 'RHOAIENG-79740';
+const STORAGE_KEY = 'system-health/odh-e2e-blocker-jiras.json';
+
+// Only the currently-open blockers matter for leadership visibility. Filtering on
+// `resolution = Unresolved` here (combined with snapshot-overwrite semantics in
+// refreshBlockerJiras) means any JIRA that has been resolved/closed since the last
+// run naturally drops off the list.
+const JQL = `project = ${JIRA_PROJECT_KEY} AND labels = "${AUTO_BLOCKER_LABEL}" AND resolution = Unresolved ORDER BY created DESC`;
+
+const JQL_FIELDS = 'summary,status,priority,components,assignee,created,updated,versions';
+
+/**
+ * Build a Jira issue-search deep link for the blocker JQL, so the UI can offer a
+ * "View all in Jira" link.
+ * @param {string} host - Jira host (e.g. https://redhat.atlassian.net)
+ * @returns {string}
+ */
+function buildJqlDeepLink(host) {
+  return `${host}/issues/?jql=${encodeURIComponent(JQL)}`;
+}
+
+/**
+ * Map a raw Jira issue into the compact shape the UI consumes.
+ *
+ * Every field is defensively defaulted: Jira may omit optional fields entirely
+ * (no assignee, no components, no fix versions) or return objects without the
+ * nested property we read. We normalize to sensible defaults here so the UI
+ * never has to guard against `undefined` / `null` / partial shapes.
+ */
+function mapIssue(issue = {}, host) {
+  const f = issue.fields || {};
+
+  // Filter out entries that lack a name so a join never yields "undefined" or
+  // stray separators (e.g. ["a", undefined].join(', ') => "a, ").
+  const componentNames = (f.components || []).map((c) => c?.name).filter(Boolean);
+  const versionNames = (f.versions || []).map((v) => v?.name).filter(Boolean);
+
+  const key = issue.key || 'UNKNOWN';
+
+  return {
+    key,
+    summary: f.summary || '(no summary)',
+    status: f.status?.name || 'Unknown',
+    priority: f.priority?.name || 'Unset',
+    component: componentNames.length ? componentNames.join(', ') : null,
+    affectsVersions: versionNames,
+    assignee: f.assignee?.displayName || null,
+    created: f.created || null,
+    updated: f.updated || null,
+    url: issue.key ? `${host}/browse/${issue.key}` : null
+  };
+}
+
+/**
+ * Fetch the currently-open auto-filed E2E blocker JIRAs.
+ *
+ * Returns a result object for the expected states (demo mode, missing
+ * credentials, success). May throw on Jira/network errors (the underlying
+ * client calls can reject); the caller (`refreshBlockerJiras`) catches these
+ * and preserves the last-known-good snapshot.
+ * @param {Object} secrets - Resolved module secrets (JIRA_EMAIL / JIRA_TOKEN)
+ * @param {Object} [options]
+ * @param {boolean} [options.isDemoMode]
+ * @param {Object} [options.logger]
+ * @returns {Promise<{ available: boolean, reason?: string, issues: Array, jql: string, host: string }>}
+ */
+async function fetchBlockerJiras(secrets = {}, { isDemoMode = false, logger = console } = {}) {
+  const host = process.env.JIRA_HOST || 'https://redhat.atlassian.net';
+
+  // In demo mode the fixture is served straight from storage by the route; the
+  // refresh handler has nothing live to fetch.
+  if (isDemoMode) {
+    return { available: true, issues: [], jql: JQL, host };
+  }
+
+  const email = secrets.JIRA_EMAIL || '';
+  const token = secrets.JIRA_TOKEN || '';
+  if (!email || !token) {
+    logger.warn('[blocker-jiras] JIRA_EMAIL/JIRA_TOKEN not configured — skipping blocker JIRA fetch');
+    return { available: false, reason: 'missing-credentials', issues: [], jql: JQL, host };
+  }
+
+  const jira = createJiraClient({ email, token, host });
+  const rawIssues = await jira.fetchAllJqlResults(JQL, JQL_FIELDS, { maxResults: 100 });
+  const issues = rawIssues.map((issue) => mapIssue(issue, jira.JIRA_HOST));
+  return { available: true, issues, jql: JQL, host: jira.JIRA_HOST };
+}
+
+/**
+ * Refresh handler: fetch the open blocker JIRAs and persist a snapshot.
+ *
+ * Snapshot semantics: on a successful fetch we FULLY OVERWRITE the stored file
+ * with the current open set (no merge/accumulate), so newly-closed JIRAs are
+ * evicted on the next run. On a transient failure (network/VPN/API error) we do
+ * NOT wipe the last-known-good list — we preserve the previous `issues` and mark
+ * the snapshot unavailable, so an outage doesn't blank the dashboard.
+ *
+ * @param {Object} context - { logger, config (secrets), storage }
+ * @returns {Promise<Object>} Refresh result with status + metrics
+ */
+async function refreshBlockerJiras(context = {}) {
+  const { logger = console, config = {}, storage } = context;
+
+  if (!storage) {
+    throw new Error('Storage context is required for E2E blocker JIRA refresh');
+  }
+
+  const { readFromStorage, writeToStorage } = storage;
+  const isDemoMode = process.env.DEMO_MODE === 'true';
+
+  logger.info('Starting E2E blocker JIRA refresh...');
+
+  try {
+    const result = await fetchBlockerJiras(config, { isDemoMode, logger });
+
+    // Missing credentials: store an explicit unavailable snapshot (empty list is
+    // correct here — there is nothing to preserve).
+    if (!result.available && result.reason === 'missing-credentials') {
+      await writeToStorage(STORAGE_KEY, {
+        lastSyncedAt: new Date().toISOString(),
+        available: false,
+        reason: 'missing-credentials',
+        count: 0,
+        jql: result.jql,
+        jqlUrl: buildJqlDeepLink(result.host),
+        templateIssue: TEMPLATE_ISSUE_KEY,
+        issues: []
+      });
+      return { status: 'skipped', reason: 'missing-credentials', count: 0 };
+    }
+
+    await writeToStorage(STORAGE_KEY, {
+      lastSyncedAt: new Date().toISOString(),
+      available: true,
+      count: result.issues.length,
+      jql: result.jql,
+      jqlUrl: buildJqlDeepLink(result.host),
+      templateIssue: TEMPLATE_ISSUE_KEY,
+      issues: result.issues
+    });
+
+    logger.info(`E2E blocker JIRA refresh complete: ${result.issues.length} open blocker(s)`);
+    return { status: 'success', count: result.issues.length };
+  } catch (error) {
+    // Transient failure: preserve the last-known-good snapshot rather than wiping it.
+    logger.error(`E2E blocker JIRA refresh failed: ${error.message}`);
+    let previous;
+    try {
+      previous = await readFromStorage(STORAGE_KEY);
+    } catch {
+      previous = null;
+    }
+
+    // Note: the raw error is logged above but deliberately NOT persisted in the
+    // snapshot — it's served over the API and could leak internal details.
+    await writeToStorage(STORAGE_KEY, {
+      lastSyncedAt: previous?.lastSyncedAt || null,
+      available: false,
+      reason: 'fetch-error',
+      count: previous?.issues?.length || 0,
+      jql: JQL,
+      jqlUrl: buildJqlDeepLink(process.env.JIRA_HOST || 'https://redhat.atlassian.net'),
+      templateIssue: TEMPLATE_ISSUE_KEY,
+      issues: previous?.issues || []
+    });
+
+    return { status: 'error', error: error.message };
+  }
+}
+
+module.exports = {
+  AUTO_BLOCKER_LABEL,
+  JIRA_PROJECT_KEY,
+  TEMPLATE_ISSUE_KEY,
+  STORAGE_KEY,
+  JQL,
+  buildJqlDeepLink,
+  fetchBlockerJiras,
+  refreshBlockerJiras
+};

--- a/modules/system-health/server/odh-e2e-health/routes.js
+++ b/modules/system-health/server/odh-e2e-health/routes.js
@@ -5,6 +5,13 @@ const {
   mapSuiteToComponent
 } = require('./component-mapper');
 
+const {
+  STORAGE_KEY: BLOCKER_JIRAS_STORAGE_KEY,
+  JQL: BLOCKER_JIRAS_JQL,
+  buildJqlDeepLink: buildBlockerJqlDeepLink,
+  TEMPLATE_ISSUE_KEY: BLOCKER_TEMPLATE_ISSUE_KEY
+} = require('./blocker-jiras');
+
 /**
  * Generate contextual failing components based on current system state
  * @param {Object} suites - Suite health data
@@ -193,6 +200,109 @@ module.exports = function registerOpendatahubOperatorE2ERoutes(router, context) 
       console.error('Error fetching opendatahub-operator E2E health:', error);
       res.status(500).json({
         error: 'Failed to fetch E2E health data',
+        message: error.message
+      });
+    }
+  });
+
+  /**
+   * @openapi
+   * /api/modules/system-health/odh-e2e-health/blocker-jiras:
+   *   get:
+   *     tags: [System Health]
+   *     summary: List auto-filed opendatahub-operator E2E blocker JIRAs
+   *     description: >
+   *       Returns the currently-open Jira blocker bugs auto-filed by the
+   *       opendatahub-operator e2e-failure-triage automation (identified by the
+   *       label odh-operator-auto-e2e-blocker). Served from a snapshot refreshed
+   *       on a schedule.
+   *     responses:
+   *       200:
+   *         description: Open blocker JIRAs snapshot
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 lastSyncedAt:
+   *                   type: string
+   *                   format: date-time
+   *                   nullable: true
+   *                 available:
+   *                   type: boolean
+   *                   description: False when Jira credentials are missing or a fetch failed
+   *                 reason:
+   *                   type: string
+   *                   nullable: true
+   *                 count:
+   *                   type: integer
+   *                 jql:
+   *                   type: string
+   *                 jqlUrl:
+   *                   type: string
+   *                   description: Deep link to view these issues in Jira
+   *                 templateIssue:
+   *                   type: string
+   *                 issues:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       key:
+   *                         type: string
+   *                       summary:
+   *                         type: string
+   *                       status:
+   *                         type: string
+   *                       priority:
+   *                         type: string
+   *                         nullable: true
+   *                       component:
+   *                         type: string
+   *                         nullable: true
+   *                       affectsVersions:
+   *                         type: array
+   *                         items:
+   *                           type: string
+   *                       assignee:
+   *                         type: string
+   *                         nullable: true
+   *                       created:
+   *                         type: string
+   *                         format: date-time
+   *                         nullable: true
+   *                       updated:
+   *                         type: string
+   *                         format: date-time
+   *                         nullable: true
+   *                       url:
+   *                         type: string
+   *                         nullable: true
+   */
+  router.get('/blocker-jiras', async (_req, res) => {
+    try {
+      const data = await readFromStorage(BLOCKER_JIRAS_STORAGE_KEY);
+
+      if (!data) {
+        // No snapshot yet (refresh hasn't run). Return an explicit empty payload
+        // rather than 404 so the UI can render its empty/pending state.
+        return res.json({
+          lastSyncedAt: null,
+          available: false,
+          reason: 'no_data',
+          count: 0,
+          jql: BLOCKER_JIRAS_JQL,
+          jqlUrl: buildBlockerJqlDeepLink(process.env.JIRA_HOST || 'https://redhat.atlassian.net'),
+          templateIssue: BLOCKER_TEMPLATE_ISSUE_KEY,
+          issues: []
+        });
+      }
+
+      res.json(data);
+    } catch (error) {
+      console.error('Error fetching E2E blocker JIRAs:', error);
+      res.status(500).json({
+        error: 'Failed to fetch E2E blocker JIRAs',
         message: error.message
       });
     }

--- a/tests/integration/system-health.spec.js
+++ b/tests/integration/system-health.spec.js
@@ -790,4 +790,74 @@ test.describe('OpenDataHub E2E Health Features @system-health', () => {
 
     expect(page.errors).toHaveLength(0);
   });
+
+  test('should render the Runs / Blocker JIRAs view toggle', async ({ page }) => {
+    await page.goto('/#/system-health/odh-e2e-health');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // The card header carries a segmented toggle with a "Runs" and a "Blocker JIRAs" button
+    const toggleGroup = page.locator('[role="group"][aria-label="View toggle"]');
+    await expect(toggleGroup).toBeVisible();
+
+    await expect(toggleGroup.getByRole('button', { name: /^Runs/ })).toBeVisible();
+    await expect(toggleGroup.getByRole('button', { name: /Blocker JIRAs/ })).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should load blocker JIRAs when switching to the Blocker JIRAs tab', async ({ page }) => {
+    // Track calls to the blocker-jiras API endpoint
+    const blockerRequests = [];
+    page.on('request', request => {
+      if (request.url().includes('/api/modules/system-health/odh-e2e-health/blocker-jiras')) {
+        blockerRequests.push(request.url());
+      }
+    });
+
+    await page.goto('/#/system-health/odh-e2e-health');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Switch to the Blocker JIRAs tab (lazy-loads the data on first open)
+    const toggleGroup = page.locator('[role="group"][aria-label="View toggle"]');
+    await toggleGroup.getByRole('button', { name: /Blocker JIRAs/ }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // The blocker-jiras endpoint should have been requested
+    expect(blockerRequests.length).toBeGreaterThan(0);
+
+    // The panel header switches to the auto-filed blockers title
+    await expect(page.locator('text=/Auto-filed Blocker JIRAs/i')).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should display blocker JIRA rows with links in demo mode', async ({ page }) => {
+    await page.goto('/#/system-health/odh-e2e-health');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const toggleGroup = page.locator('[role="group"][aria-label="View toggle"]');
+    await toggleGroup.getByRole('button', { name: /Blocker JIRAs/ }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Demo fixture ships open blocker JIRAs — either the table renders rows
+    // linking to Jira, or the graceful empty/unavailable state is shown. Both are valid.
+    const jiraLinks = page.locator('a[href*="/browse/RHOAIENG-"]');
+    const linkCount = await jiraLinks.count();
+
+    if (linkCount > 0) {
+      await expect(jiraLinks.first()).toBeVisible();
+    } else {
+      const emptyOrUnavailable = page.locator(
+        'text=/No open blocker JIRAs|credentials|not yet available|could not reach jira/i'
+      );
+      await expect(emptyOrUnavailable.first()).toBeVisible();
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Adding a sub-tab in the e2e health dashboard which shows jiras created by the automation in the ODH operator.