### PR TITLE
feat(releases): PM Hub Align roll-up, delivered count, and Align popup

### DIFF
--- a/modules/releases/__tests__/client/plan/alignment-rollup.test.js
+++ b/modules/releases/__tests__/client/plan/alignment-rollup.test.js
@@ -1,0 +1,119 @@
+/**
+ * Filtered-view TV/FV Align roll-up helpers for PM Hub.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  uniqueFeaturesFromGroups,
+  countAlignment,
+  buildAlignmentRollup,
+  countDeliveredInVisibleVersions
+} from '../../../client/plan/utils/alignment-rollup.js'
+
+function feature(overrides) {
+  return Object.assign({
+    key: 'RHAISTRAT-1',
+    alignmentCategory: 'aligned_on_time',
+    pmDoAligned: true
+  }, overrides)
+}
+
+function groupsFrom(versionFeatures) {
+  return Object.keys(versionFeatures).map(function(version) {
+    return {
+      version: version,
+      components: [{
+        component: 'Dashboard',
+        requestedFeatures: versionFeatures[version],
+        committedFeatures: []
+      }]
+    }
+  })
+}
+
+describe('uniqueFeaturesFromGroups', function() {
+  it('counts each issue key once across components and buckets', function() {
+    var groups = [{
+      version: '3.6 EA2 RHOAI RELEASE',
+      components: [{
+        component: 'A',
+        requestedFeatures: [feature({ key: 'RHAISTRAT-1' })],
+        committedFeatures: [feature({ key: 'RHAISTRAT-1' })]
+      }, {
+        component: 'B',
+        requestedFeatures: [feature({ key: 'RHAISTRAT-1' })],
+        committedFeatures: []
+      }]
+    }]
+    expect(uniqueFeaturesFromGroups(groups)).toHaveLength(1)
+  })
+
+  it('keeps the worse category when the same key appears in two versions', function() {
+    var groups = groupsFrom({
+      '3.6 EA2 RHOAI RELEASE': [feature({ key: 'RHAISTRAT-2', alignmentCategory: 'aligned_on_time' })],
+      '3.6 EA2 RHAII RELEASE': [feature({ key: 'RHAISTRAT-2', alignmentCategory: 'tv_only' })]
+    })
+    var unique = uniqueFeaturesFromGroups(groups)
+    expect(unique).toHaveLength(1)
+    expect(unique[0].alignmentCategory).toBe('tv_only')
+  })
+})
+
+describe('countAlignment', function() {
+  it('computes Align % as on time plus late over unique keys', function() {
+    var counts = countAlignment([
+      feature({ key: 'A', alignmentCategory: 'aligned_on_time' }),
+      feature({ key: 'B', alignmentCategory: 'aligned_late' }),
+      feature({ key: 'C', alignmentCategory: 'tv_only' }),
+      feature({ key: 'D', alignmentCategory: 'fv_only' }),
+      feature({ key: 'E', alignmentCategory: 'misaligned' })
+    ])
+    expect(counts.total).toBe(5)
+    expect(counts.aligned_on_time).toBe(1)
+    expect(counts.aligned_late).toBe(1)
+    expect(counts.tv_only).toBe(1)
+    expect(counts.fv_only).toBe(1)
+    expect(counts.misaligned).toBe(1)
+    expect(counts.alignment_pct).toBe(40)
+  })
+})
+
+describe('buildAlignmentRollup', function() {
+  it('rolls unique keys to selected scope, then EA2, then product', function() {
+    var groups = groupsFrom({
+      '3.6 EA2 RHOAI RELEASE': [
+        feature({ key: 'RHAISTRAT-1', alignmentCategory: 'aligned_on_time' }),
+        feature({ key: 'RHAISTRAT-2', alignmentCategory: 'tv_only' })
+      ],
+      '3.6 EA2 RHAII RELEASE': [
+        feature({ key: 'RHAISTRAT-1', alignmentCategory: 'aligned_late' }),
+        feature({ key: 'RHAISTRAT-3', alignmentCategory: 'fv_only' })
+      ]
+    })
+    var rollup = buildAlignmentRollup(groups)
+    expect(rollup.scope.counts.total).toBe(3)
+    expect(rollup.scope.counts.tv_only).toBe(1)
+    expect(rollup.scope.counts.fv_only).toBe(1)
+    expect(rollup.cycles[0].milestones[0].label).toBe('3.6 EA2 Release')
+    expect(rollup.cycles[0].milestones[0].counts.total).toBe(3)
+    expect(rollup.cycles[0].milestones[0].rows.map(function(r) { return r.label })).toEqual([
+      'RHOAI',
+      'RHAII'
+    ])
+    expect(rollup.cycles[0].milestones[0].rows[0].counts.total).toBe(2)
+  })
+})
+
+describe('countDeliveredInVisibleVersions', function() {
+  it('counts unique keys whose Fix Version is still in the filtered versions', function() {
+    var issues = [
+      { key: 'RHAISTRAT-10', fixVersions: ['3.6 EA2 RHOAI RELEASE'] },
+      { key: 'RHAISTRAT-11', fixVersions: ['3.6 EA2 RHAII RELEASE'] },
+      { key: 'RHAISTRAT-10', fixVersions: ['3.6 EA2 RHOAI RELEASE'] }
+    ]
+    expect(countDeliveredInVisibleVersions(issues, ['3.6 EA2 RHOAI RELEASE'])).toBe(1)
+    expect(countDeliveredInVisibleVersions(issues, [
+      '3.6 EA2 RHOAI RELEASE',
+      '3.6 EA2 RHAII RELEASE'
+    ])).toBe(2)
+  })
+})

--- a/modules/releases/__tests__/client/plan/feature-readiness-row.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-row.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import FeatureReadinessRow from '../../../client/plan/components/FeatureReadinessRow.vue'
 
 function mountRow(feature) {
@@ -132,9 +133,25 @@ describe('FeatureReadinessRow fail chips', function() {
       key: 'RHAISTRAT-7',
       title: 'Aligned feature',
       alignmentCategory: 'aligned_on_time',
+      targetVersions: ['3.6 EA2 RHOAI RELEASE'],
+      fixVersions: ['3.6 EA2 RHOAI RELEASE'],
       fpdor: { passedCount: 17, applicableCount: 17, items: [] }
     })
     expect(wrapper.text()).toContain('On time')
-    expect(wrapper.find('[title*="Fix Version matches Target Version"]').exists()).toBe(true)
+    expect(wrapper.find('[aria-label="TV/FV alignment: On time"]').exists()).toBe(true)
+  })
+
+  it('opens Align popup with requested vs committed summary', async function() {
+    var wrapper = mountRow({
+      key: 'RHAISTRAT-8',
+      title: 'Slipped feature',
+      alignmentCategory: 'aligned_late',
+      targetVersions: ['3.6 EA1 RHOAI RELEASE'],
+      fixVersions: ['3.6 EA2 RHOAI RELEASE'],
+      fpdor: { passedCount: 17, applicableCount: 17, items: [] }
+    })
+    await wrapper.find('[aria-label="TV/FV alignment: Late"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Requested for EA1, committed for EA2.')
   })
 })

--- a/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
@@ -99,6 +99,7 @@ describe('PM Hub feature slide tray', function() {
     expect(wrapper.text()).toContain('RICE')
     expect(wrapper.text()).toContain('TV only')
     expect(wrapper.text()).toContain('TV/FV Align')
+    expect(wrapper.find('[aria-label="TV/FV alignment: TV only"]').exists()).toBe(true)
     // No empty AI review chrome for PM Hub rows without review meta
     expect(wrapper.text()).not.toContain('Awaiting Sign-off')
     expect(wrapper.text()).toContain('Jira')
@@ -117,5 +118,25 @@ describe('PM Hub feature slide tray', function() {
     expect(link.exists()).toBe(true)
     await link.trigger('click')
     expect(wrapper.emitted('select')).toBeFalsy()
+  })
+
+  it('does not emit select when Align popup is opened', async function() {
+    var groups = sampleGroups()
+    groups[0].components[0].requestedFeatures[0].alignmentCategory = 'tv_only'
+    var wrapper = mount(ComponentReleaseLoadTable, {
+      props: { groups: groups },
+      global: { stubs: { FPDoRPopover: true } }
+    })
+
+    await wrapper.find('tr.cursor-pointer').trigger('click')
+    await nextTick()
+
+    var align = wrapper.find('[aria-label="TV/FV alignment: TV only"]')
+    expect(align.exists()).toBe(true)
+    await align.trigger('click')
+    await nextTick()
+
+    expect(wrapper.emitted('select')).toBeFalsy()
+    expect(wrapper.text()).toContain('Requested for EA2, not committed.')
   })
 })

--- a/modules/releases/__tests__/client/plan/pm-hub-filter-persistence.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-filter-persistence.test.js
@@ -24,9 +24,10 @@ function saveFilters(state) {
       releaseType: state.releaseType || [],
       status: state.status || [],
       blocked: state.blocked !== undefined ? state.blocked : null,
-      hideClosed: state.hideClosed || false,
+      alignment: state.alignment || [],
       delOwner: state.delOwner || [],
       pmOwner: state.pmOwner || [],
+      docs: state.docs || [],
       sort: state.sort || { column: null, direction: 'asc' }
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
@@ -48,9 +49,10 @@ function restoreFilters() {
     if (state.releaseType && Array.isArray(state.releaseType)) result.releaseType = state.releaseType
     if (state.status && Array.isArray(state.status)) result.status = state.status
     if (state.blocked !== undefined) result.blocked = state.blocked
-    if (state.hideClosed !== undefined) result.hideClosed = !!state.hideClosed
+    if (state.alignment && Array.isArray(state.alignment)) result.alignment = state.alignment
     if (state.delOwner && Array.isArray(state.delOwner)) result.delOwner = state.delOwner
     if (state.pmOwner && Array.isArray(state.pmOwner)) result.pmOwner = state.pmOwner
+    if (state.docs && Array.isArray(state.docs)) result.docs = state.docs
     if (state.sort && typeof state.sort === 'object') result.sort = state.sort
     return result
   } catch { return null }
@@ -90,7 +92,7 @@ describe('saveFilters', function () {
       releaseType: ['Feature'],
       status: ['Green'],
       blocked: true,
-      hideClosed: true,
+      alignment: ['tv_only'],
       delOwner: ['Alice'],
       pmOwner: ['Bob'],
       sort: { column: 'key', direction: 'asc' }
@@ -107,7 +109,8 @@ describe('saveFilters', function () {
     expect(parsed.releaseType).toEqual(['Feature'])
     expect(parsed.status).toEqual(['Green'])
     expect(parsed.blocked).toBe(true)
-    expect(parsed.hideClosed).toBe(true)
+    expect(parsed.alignment).toEqual(['tv_only'])
+    expect(parsed.hideClosed).toBeUndefined()
     expect(parsed.delOwner).toEqual(['Alice'])
     expect(parsed.pmOwner).toEqual(['Bob'])
     expect(parsed.sort).toEqual({ column: 'key', direction: 'asc' })
@@ -119,20 +122,14 @@ describe('saveFilters', function () {
     expect(parsed.pillars).toEqual([])
     expect(parsed.components).toEqual([])
     expect(parsed.blocked).toBeNull()
-    expect(parsed.hideClosed).toBe(false)
+    expect(parsed.hideClosed).toBeUndefined()
     expect(parsed.sort).toEqual({ column: null, direction: 'asc' })
   })
 
-  it('saves hideClosed=true correctly', function () {
+  it('does not persist hideClosed', function () {
     saveFilters({ hideClosed: true })
     var parsed = JSON.parse(store[STORAGE_KEY])
-    expect(parsed.hideClosed).toBe(true)
-  })
-
-  it('saves hideClosed=false correctly', function () {
-    saveFilters({ hideClosed: false })
-    var parsed = JSON.parse(store[STORAGE_KEY])
-    expect(parsed.hideClosed).toBe(false)
+    expect(parsed.hideClosed).toBeUndefined()
   })
 
   it('saves blocked=false correctly', function () {
@@ -195,7 +192,7 @@ describe('restoreFilters', function () {
       releaseType: ['Feature'],
       status: ['Green'],
       blocked: true,
-      hideClosed: true,
+      alignment: ['tv_only'],
       delOwner: ['Alice'],
       pmOwner: ['Bob'],
       sort: { column: 'priority', direction: 'desc' }
@@ -210,22 +207,18 @@ describe('restoreFilters', function () {
     expect(restored.releaseType).toEqual(['Feature'])
     expect(restored.status).toEqual(['Green'])
     expect(restored.blocked).toBe(true)
-    expect(restored.hideClosed).toBe(true)
+    expect(restored.alignment).toEqual(['tv_only'])
+    expect(restored.hideClosed).toBeUndefined()
     expect(restored.delOwner).toEqual(['Alice'])
     expect(restored.pmOwner).toEqual(['Bob'])
     expect(restored.sort).toEqual({ column: 'priority', direction: 'desc' })
   })
 
-  it('restores hideClosed=true correctly', function () {
-    saveFilters({ hideClosed: true })
+  it('ignores stale hideClosed from older saved state', function () {
+    store[STORAGE_KEY] = JSON.stringify({ hideClosed: true, pillars: ['Inference'] })
     var restored = restoreFilters()
-    expect(restored.hideClosed).toBe(true)
-  })
-
-  it('restores hideClosed=false as false', function () {
-    saveFilters({ hideClosed: false })
-    var restored = restoreFilters()
-    expect(restored.hideClosed).toBe(false)
+    expect(restored.hideClosed).toBeUndefined()
+    expect(restored.pillars).toEqual(['Inference'])
   })
 
   it('restores blocked=false correctly', function () {
@@ -315,7 +308,7 @@ describe('save/restore round-trip', function () {
       releaseType: ['Feature', 'Enhancement'],
       status: ['Green', 'Yellow', 'Red'],
       blocked: true,
-      hideClosed: true,
+      alignment: ['misaligned'],
       delOwner: ['Alice', 'Bob'],
       pmOwner: ['Charlie', 'Diana'],
       sort: { column: 'priority', direction: 'desc' }
@@ -330,7 +323,8 @@ describe('save/restore round-trip', function () {
     expect(restored.releaseType).toEqual(original.releaseType)
     expect(restored.status).toEqual(original.status)
     expect(restored.blocked).toEqual(original.blocked)
-    expect(restored.hideClosed).toEqual(original.hideClosed)
+    expect(restored.alignment).toEqual(original.alignment)
+    expect(restored.hideClosed).toBeUndefined()
     expect(restored.delOwner).toEqual(original.delOwner)
     expect(restored.pmOwner).toEqual(original.pmOwner)
     expect(restored.sort).toEqual(original.sort)

--- a/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
+++ b/modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js
@@ -8,6 +8,7 @@ import {
   alignmentCategoryLabel,
   alignmentCategoryHelp,
   alignmentCategoryChipClass,
+  buildAlignmentDetail,
   ALIGNMENT_CATEGORY_LABELS,
   ALIGNMENT_CATEGORY_HELP
 } from '../../../client/plan/utils/tv-fv-alignment-display.js'
@@ -54,5 +55,69 @@ describe('tv-fv-alignment-display', function() {
     expect(alignmentCategoryChipClass('misaligned')).toContain('red')
     expect(alignmentCategoryChipClass('tv_only')).toContain('blue')
     expect(alignmentCategoryChipClass('fv_only')).toContain('violet')
+  })
+
+  it('summarizes requested EA1 vs committed EA2', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'aligned_late',
+      targetVersions: ['3.6 EA1 RHOAI RELEASE'],
+      fixVersions: ['3.6 EA2 RHOAI RELEASE']
+    })
+    expect(detail.summary).toBe('Requested for EA1, committed for EA2.')
+    expect(detail.categoryLabel).toBe('Late')
+  })
+
+  it('summarizes matching requested and committed milestones', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'aligned_on_time',
+      targetVersions: ['3.6 EA2 RHOAI RELEASE'],
+      fixVersions: ['3.6 EA2 RHOAI RELEASE']
+    })
+    expect(detail.summary).toBe('Requested and committed for EA2.')
+  })
+
+  it('summarizes Target Version only', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'tv_only',
+      targetVersions: ['3.6 EA2 RHOAI RELEASE'],
+      fixVersions: []
+    })
+    expect(detail.summary).toBe('Requested for EA2, not committed.')
+  })
+
+  it('summarizes Fix Version only', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'fv_only',
+      targetVersions: [],
+      fixVersions: ['3.6 EA2 RHOAI RELEASE']
+    })
+    expect(detail.summary).toBe('Committed for EA2, no Target Version.')
+  })
+
+  it('includes product names when TV and FV point at different products', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'misaligned',
+      targetVersions: ['3.6 EA1 RHOAI RELEASE'],
+      fixVersions: ['3.6 EA1 RHAII RELEASE']
+    })
+    expect(detail.summary).toBe('Requested for RHOAI EA1, committed for RHAII EA1.')
+  })
+
+  it('parses compact release names the same way as Jira names', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'aligned_late',
+      targetVersions: ['rhoai-3.6.EA1'],
+      fixVersions: ['rhoai-3.6.EA2']
+    })
+    expect(detail.summary).toBe('Requested for EA1, committed for EA2.')
+  })
+
+  it('falls back to fixVersion when fixVersions is empty', function() {
+    var detail = buildAlignmentDetail({
+      alignmentCategory: 'fv_only',
+      targetVersions: [],
+      fixVersion: '3.6 EA2 RHOAI RELEASE'
+    })
+    expect(detail.summary).toBe('Committed for EA2, no Target Version.')
   })
 })

--- a/modules/releases/__tests__/server/pm-hub/delivered-in-version.test.js
+++ b/modules/releases/__tests__/server/pm-hub/delivered-in-version.test.js
@@ -1,0 +1,114 @@
+/**
+ * Fail-soft delivered-in-version JQL and fetch.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+const {
+  DELIVERED_STATUSES,
+  buildDeliveredJql,
+  fetchDeliveredInVersion,
+  normalizeIssues,
+  quoteJql
+} = require('../../../server/pm-hub/delivered-in-version')
+
+describe('buildDeliveredJql', function() {
+  it('returns null when no versions are selected', function() {
+    expect(buildDeliveredJql([])).toBeNull()
+    expect(buildDeliveredJql(null)).toBeNull()
+  })
+
+  it('requires Fix Version in the selected releases and Closed/Done/Resolved only', function() {
+    var jql = buildDeliveredJql(['3.6 EA2 RHOAI RELEASE', '3.6 EA2 RHAII RELEASE'])
+    expect(jql).toContain('project IN (RHAISTRAT, AIPCC)')
+    expect(jql).toContain('issuetype IN (Feature, Initiative)')
+    expect(jql).toContain('status IN (Closed, Done, Resolved)')
+    expect(jql).toContain('fixVersion IN ("3.6 EA2 RHOAI RELEASE", "3.6 EA2 RHAII RELEASE")')
+    expect(jql).not.toContain('Cancelled')
+    expect(jql).not.toContain('Target Version')
+    expect(jql).not.toContain('statusCategory')
+  })
+
+  it('adds a component clause when components are selected', function() {
+    var jql = buildDeliveredJql(['3.6 EA2 RHOAI RELEASE'], ['GenAI Studio'])
+    expect(jql).toContain('component IN ("GenAI Studio")')
+  })
+
+  it('quotes names that contain quotes', function() {
+    expect(quoteJql('foo"bar')).toBe('"foo\\"bar"')
+  })
+})
+
+describe('normalizeIssues', function() {
+  it('dedupes by key and keeps fixVersions', function() {
+    var issues = normalizeIssues([
+      {
+        key: 'RHAISTRAT-1',
+        fields: {
+          fixVersions: [{ name: '3.6 EA2 RHOAI RELEASE' }],
+          components: [{ name: 'Dashboard' }]
+        }
+      },
+      {
+        key: 'RHAISTRAT-1',
+        fields: { fixVersions: [{ name: 'dup' }] }
+      }
+    ])
+    expect(issues).toHaveLength(1)
+    expect(issues[0].key).toBe('RHAISTRAT-1')
+    expect(issues[0].fixVersions).toEqual(['3.6 EA2 RHOAI RELEASE'])
+    expect(issues[0].components).toEqual(['Dashboard'])
+  })
+})
+
+describe('fetchDeliveredInVersion', function() {
+  it('skips Jira when no versions are selected', async function() {
+    var client = { fetchAllJqlResults: vi.fn() }
+    var result = await fetchDeliveredInVersion(client, { versions: [] })
+    expect(result.skipped).toBe('no-versions')
+    expect(result.issues).toEqual([])
+    expect(client.fetchAllJqlResults).not.toHaveBeenCalled()
+  })
+
+  it('returns timedOut when the search exceeds the timeout', async function() {
+    var client = {
+      fetchAllJqlResults: vi.fn().mockImplementation(function() {
+        return new Promise(function() { /* never resolves */ })
+      })
+    }
+    var result = await fetchDeliveredInVersion(client, {
+      versions: ['3.6 EA2 RHOAI RELEASE'],
+      timeoutMs: 20
+    })
+    expect(result.timedOut).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
+  it('returns issues on success', async function() {
+    var client = {
+      fetchAllJqlResults: vi.fn().mockResolvedValue([
+        {
+          key: 'RHAISTRAT-9',
+          fields: { fixVersions: [{ name: '3.6 EA2 RHOAI RELEASE' }], components: [] }
+        }
+      ])
+    }
+    var result = await fetchDeliveredInVersion(client, {
+      versions: ['3.6 EA2 RHOAI RELEASE']
+    })
+    expect(result.timedOut).toBe(false)
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].key).toBe('RHAISTRAT-9')
+    expect(client.fetchAllJqlResults.mock.calls[0][0]).toContain('status IN (' + DELIVERED_STATUSES.join(', ') + ')')
+  })
+
+  it('fails soft when Jira throws', async function() {
+    var client = {
+      fetchAllJqlResults: vi.fn().mockRejectedValue(new Error('Jira down'))
+    }
+    var result = await fetchDeliveredInVersion(client, {
+      versions: ['3.6 EA2 RHOAI RELEASE']
+    })
+    expect(result.error).toBe('fetch-failed')
+    expect(result.issues).toEqual([])
+  })
+})

--- a/modules/releases/__tests__/server/pm-hub/delivered-in-version.test.js
+++ b/modules/releases/__tests__/server/pm-hub/delivered-in-version.test.js
@@ -101,6 +101,22 @@ describe('fetchDeliveredInVersion', function() {
     expect(client.fetchAllJqlResults.mock.calls[0][0]).toContain('status IN (' + DELIVERED_STATUSES.join(', ') + ')')
   })
 
+  it('clears the timeout timer when Jira returns first', async function() {
+    vi.useFakeTimers()
+    try {
+      var client = {
+        fetchAllJqlResults: vi.fn().mockResolvedValue([])
+      }
+      await fetchDeliveredInVersion(client, {
+        versions: ['3.6 EA2 RHOAI RELEASE'],
+        timeoutMs: 8000
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('fails soft when Jira throws', async function() {
     var client = {
       fetchAllJqlResults: vi.fn().mockRejectedValue(new Error('Jira down'))

--- a/modules/releases/client/plan/components/AlignmentPopover.vue
+++ b/modules/releases/client/plan/components/AlignmentPopover.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { computed } from 'vue'
+import { usePopover } from '../composables/usePopover'
+import {
+  alignmentCategoryLabel,
+  alignmentCategoryChipClass,
+  buildAlignmentDetail
+} from '../utils/tv-fv-alignment-display.js'
+
+var props = defineProps({
+  feature: { type: Object, default: null }
+})
+
+var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
+
+var detail = computed(function() {
+  return buildAlignmentDetail(props.feature || {})
+})
+
+var chipLabel = computed(function() {
+  return alignmentCategoryLabel(props.feature && props.feature.alignmentCategory)
+})
+
+var chipClass = computed(function() {
+  return alignmentCategoryChipClass(props.feature && props.feature.alignmentCategory)
+})
+</script>
+
+<template>
+  <span
+    class="relative inline-flex"
+    :data-popover-trigger="popoverId"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @click.stop="onClick"
+    @keydown="onKeyDown"
+    :aria-expanded="isVisible"
+    tabindex="0"
+    role="button"
+    :aria-label="'TV/FV alignment: ' + chipLabel"
+  >
+    <span
+      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold cursor-pointer"
+      :class="chipClass"
+    >{{ chipLabel }}</span>
+
+    <div
+      v-if="isVisible"
+      :data-popover-id="popoverId"
+      role="dialog"
+      aria-live="polite"
+      class="absolute z-50 left-0 top-full mt-1 w-72 max-w-[min(288px,90vw)] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs text-left font-normal"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+        <div class="flex items-center gap-2">
+          <span class="font-semibold text-gray-900 dark:text-gray-100">TV/FV Align</span>
+          <span
+            class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
+            :class="chipClass"
+          >{{ chipLabel }}</span>
+        </div>
+        <button
+          v-if="isPinned"
+          type="button"
+          class="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+          aria-label="Close alignment details"
+          @click.stop="dismiss"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div class="px-3 py-2 text-gray-700 dark:text-gray-300 space-y-2">
+        <p class="font-medium text-gray-900 dark:text-gray-100">{{ detail.summary }}</p>
+        <p>{{ detail.categoryHelp }}</p>
+        <div v-if="detail.requested.length || detail.committed.length" class="space-y-1 text-[11px]">
+          <p v-if="detail.requested.length">
+            <span class="font-semibold text-gray-500 dark:text-gray-400">Target Version:</span>
+            {{ detail.requested.join(', ') }}
+          </p>
+          <p v-else>
+            <span class="font-semibold text-gray-500 dark:text-gray-400">Target Version:</span>
+            none
+          </p>
+          <p v-if="detail.committed.length">
+            <span class="font-semibold text-gray-500 dark:text-gray-400">Fix Version:</span>
+            {{ detail.committed.join(', ') }}
+          </p>
+          <p v-else>
+            <span class="font-semibold text-gray-500 dark:text-gray-400">Fix Version:</span>
+            none
+          </p>
+        </div>
+      </div>
+    </div>
+  </span>
+</template>

--- a/modules/releases/client/plan/components/AlignmentRollupTable.vue
+++ b/modules/releases/client/plan/components/AlignmentRollupTable.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { computed } from 'vue'
+import { alignmentCategoryLabel } from '../utils/tv-fv-alignment-display.js'
+
+var props = defineProps({
+  rollup: { type: Object, default: null }
+})
+
+var emit = defineEmits(['select-scope', 'select-milestone', 'select-product', 'select-category'])
+
+var showHierarchy = computed(function() {
+  var r = props.rollup
+  if (!r || !r.cycles) return false
+  var versionCount = (r.scope && r.scope.versionNames && r.scope.versionNames.length) || 0
+  return versionCount > 1
+})
+
+function pctClass(pct) {
+  if (pct < 50) return 'text-red-600 dark:text-red-400'
+  if (pct < 75) return 'text-amber-600 dark:text-amber-400'
+  return 'text-emerald-600 dark:text-emerald-400'
+}
+
+function onCategory(event, category) {
+  event.stopPropagation()
+  emit('select-category', category)
+}
+</script>
+
+<template>
+  <div v-if="rollup && rollup.scope" class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+    <table class="min-w-full text-left">
+      <caption class="sr-only">TV/FV Align roll-up for the current filters. Unique issue keys. On time and Late count as aligned.</caption>
+      <thead>
+        <tr class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/80">
+          <th scope="col" class="px-3 py-2 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Total</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ alignmentCategoryLabel('aligned_on_time') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ alignmentCategoryLabel('aligned_late') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ alignmentCategoryLabel('tv_only') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ alignmentCategoryLabel('fv_only') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ alignmentCategoryLabel('misaligned') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Align %</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+        <tr
+          class="bg-gray-50 dark:bg-gray-900/60 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+          @click="emit('select-scope')"
+        >
+          <th scope="row" class="px-3 py-2 text-xs font-semibold text-gray-800 dark:text-gray-100">{{ rollup.scope.label }}</th>
+          <td class="px-3 py-2 text-right text-xs font-semibold tabular-nums">{{ rollup.scope.counts.total }}</td>
+          <td class="px-3 py-2 text-right text-xs tabular-nums text-emerald-700 dark:text-emerald-400 cursor-pointer" @click="onCategory($event, 'aligned_on_time')">{{ rollup.scope.counts.aligned_on_time }}</td>
+          <td class="px-3 py-2 text-right text-xs tabular-nums text-amber-700 dark:text-amber-400 cursor-pointer" @click="onCategory($event, 'aligned_late')">{{ rollup.scope.counts.aligned_late }}</td>
+          <td class="px-3 py-2 text-right text-xs tabular-nums text-blue-700 dark:text-blue-400 cursor-pointer" @click="onCategory($event, 'tv_only')">{{ rollup.scope.counts.tv_only }}</td>
+          <td class="px-3 py-2 text-right text-xs tabular-nums text-violet-700 dark:text-violet-400 cursor-pointer" @click="onCategory($event, 'fv_only')">{{ rollup.scope.counts.fv_only }}</td>
+          <td class="px-3 py-2 text-right text-xs tabular-nums text-red-700 dark:text-red-400 cursor-pointer" @click="onCategory($event, 'misaligned')">{{ rollup.scope.counts.misaligned }}</td>
+          <td class="px-3 py-2 text-right text-xs font-semibold tabular-nums" :class="pctClass(rollup.scope.counts.alignment_pct)">{{ rollup.scope.counts.alignment_pct }}%</td>
+        </tr>
+        <template v-if="showHierarchy">
+          <template v-for="cycle in rollup.cycles" :key="cycle.key">
+            <template v-for="ms in cycle.milestones" :key="ms.key">
+              <tr
+                class="cursor-pointer hover:bg-blue-50/40 dark:hover:bg-blue-900/20"
+                @click="emit('select-milestone', ms)"
+              >
+                <th scope="row" class="px-3 py-2 pl-6 text-xs font-medium text-gray-700 dark:text-gray-200">{{ ms.label }}</th>
+                <td class="px-3 py-2 text-right text-xs tabular-nums">{{ ms.counts.total }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-emerald-700 dark:text-emerald-400 cursor-pointer" @click="onCategory($event, 'aligned_on_time')">{{ ms.counts.aligned_on_time }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-amber-700 dark:text-amber-400 cursor-pointer" @click="onCategory($event, 'aligned_late')">{{ ms.counts.aligned_late }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-blue-700 dark:text-blue-400 cursor-pointer" @click="onCategory($event, 'tv_only')">{{ ms.counts.tv_only }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-violet-700 dark:text-violet-400 cursor-pointer" @click="onCategory($event, 'fv_only')">{{ ms.counts.fv_only }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-red-700 dark:text-red-400 cursor-pointer" @click="onCategory($event, 'misaligned')">{{ ms.counts.misaligned }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums" :class="pctClass(ms.counts.alignment_pct)">{{ ms.counts.alignment_pct }}%</td>
+              </tr>
+              <tr
+                v-for="row in ms.rows"
+                :key="row.key"
+                class="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60"
+                @click="emit('select-product', row)"
+              >
+                <th scope="row" class="px-3 py-2 pl-10 font-mono text-xs font-medium text-gray-600 dark:text-gray-300">{{ row.label }}</th>
+                <td class="px-3 py-2 text-right text-xs tabular-nums">{{ row.counts.total }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-emerald-700 dark:text-emerald-400 cursor-pointer" @click="onCategory($event, 'aligned_on_time')">{{ row.counts.aligned_on_time }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-amber-700 dark:text-amber-400 cursor-pointer" @click="onCategory($event, 'aligned_late')">{{ row.counts.aligned_late }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-blue-700 dark:text-blue-400 cursor-pointer" @click="onCategory($event, 'tv_only')">{{ row.counts.tv_only }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-violet-700 dark:text-violet-400 cursor-pointer" @click="onCategory($event, 'fv_only')">{{ row.counts.fv_only }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums text-red-700 dark:text-red-400 cursor-pointer" @click="onCategory($event, 'misaligned')">{{ row.counts.misaligned }}</td>
+                <td class="px-3 py-2 text-right text-xs tabular-nums" :class="pctClass(row.counts.alignment_pct)">{{ row.counts.alignment_pct }}%</td>
+              </tr>
+            </template>
+          </template>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -2,6 +2,7 @@
 import { reactive, computed } from 'vue'
 import { getComponentLeads } from '../../composables/componentLeads'
 import FPDoRPopover from './FPDoRPopover.vue'
+import AlignmentPopover from './AlignmentPopover.vue'
 import { failedFpdorNames } from '../utils/feature-readiness-export.js'
 import {
   fpdorItemSeverity,
@@ -18,9 +19,6 @@ import {
   docsRequiredChipClass
 } from '../utils/docs-required-display.js'
 import {
-  alignmentCategoryLabel,
-  alignmentCategoryHelp,
-  alignmentCategoryChipClass,
   worseAlignmentCategory,
   isAlignedCategory
 } from '../utils/tv-fv-alignment-display.js'
@@ -564,11 +562,7 @@ defineExpose({ expandAll, collapseAll })
                 </svg>
               </td>
               <td class="px-3 py-2.5 text-center">
-                <span
-                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                  :class="alignmentCategoryChipClass(feature.alignmentCategory)"
-                  :title="alignmentCategoryHelp(feature.alignmentCategory)"
-                >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
+                <AlignmentPopover :feature="feature" />
               </td>
               <td class="px-3 py-2.5">
                 <div v-if="feature.fpdor" class="flex flex-wrap items-center gap-1 max-w-[14rem]">

--- a/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
@@ -8,11 +8,7 @@ import {
   pathChipClass,
   pathChipTitle
 } from '../utils/fpdor-severity.js'
-import {
-  alignmentCategoryLabel,
-  alignmentCategoryHelp,
-  alignmentCategoryChipClass
-} from '../utils/tv-fv-alignment-display.js'
+import AlignmentPopover from './AlignmentPopover.vue'
 
 const props = defineProps({
   feature: { type: Object, default: null },
@@ -328,12 +324,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               :class="pathChipClass(feature)"
               :title="pathChipTitle(feature)"
             >{{ pathLabel(feature) }}</span>
-            <span
-              v-if="feature.alignmentCategory"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
-              :class="alignmentCategoryChipClass(feature.alignmentCategory)"
-              :title="alignmentCategoryHelp(feature.alignmentCategory)"
-            >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
+            <AlignmentPopover :feature="feature" />
 
             <!-- Health pipeline badges -->
             <template v-if="isHealthPipeline">
@@ -620,13 +611,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
 
               <dt class="text-gray-400 dark:text-gray-500">TV/FV Align</dt>
               <dd>
-                <span
-                  v-if="feature.alignmentCategory"
-                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                  :class="alignmentCategoryChipClass(feature.alignmentCategory)"
-                  :title="alignmentCategoryHelp(feature.alignmentCategory)"
-                >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
-                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+                <AlignmentPopover :feature="feature" />
               </dd>
 
               <dt class="text-gray-400 dark:text-gray-500 self-start">Components</dt>

--- a/modules/releases/client/plan/components/FeatureReadinessRow.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessRow.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import RubricScoreBadge from '@shared/client/components/RubricScoreBadge.vue'
 import FPDoRPopover from './FPDoRPopover.vue'
+import AlignmentPopover from './AlignmentPopover.vue'
 import { failedFpdorNames } from '../utils/feature-readiness-export.js'
 import {
   fpdorItemSeverity,
@@ -12,11 +13,6 @@ import {
   pathChipClass,
   pathChipTitle
 } from '../utils/fpdor-severity.js'
-import {
-  alignmentCategoryLabel,
-  alignmentCategoryHelp,
-  alignmentCategoryChipClass
-} from '../utils/tv-fv-alignment-display.js'
 
 var MAX_VISIBLE_FAIL_CHIPS = 3
 
@@ -226,11 +222,7 @@ var scoreBreakdown = computed(function() {
 
     <!-- TV/FV Align -->
     <td class="px-3 py-2.5 text-center whitespace-nowrap">
-      <span
-        class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
-        :class="alignmentCategoryChipClass(feature.alignmentCategory)"
-        :title="alignmentCategoryHelp(feature.alignmentCategory)"
-      >{{ alignmentCategoryLabel(feature.alignmentCategory) }}</span>
+      <AlignmentPopover :feature="feature" />
     </td>
 
     <!-- Components -->

--- a/modules/releases/client/plan/utils/alignment-rollup.js
+++ b/modules/releases/client/plan/utils/alignment-rollup.js
@@ -1,0 +1,230 @@
+/**
+ * Filtered-view TV/FV Align roll-up for PM Hub.
+ * Unique issue keys; categories are the same five as Reports → TV vs FV Delta.
+ * Scope follows the groups already on screen (pillar / component / product / blocked / docs).
+ */
+
+import { worseAlignmentCategory } from './tv-fv-alignment-display.js'
+import {
+  extractCycle,
+  extractMilestoneGroup,
+  extractProduct,
+  cycleLabel,
+  milestoneGroupLabel,
+  productLabel
+} from '../../composables/useReleaseFamily.js'
+
+export var ALIGNMENT_COUNT_KEYS = [
+  'aligned_on_time',
+  'aligned_late',
+  'tv_only',
+  'fv_only',
+  'misaligned'
+]
+
+export function emptyAlignmentCounts() {
+  return {
+    total: 0,
+    aligned_on_time: 0,
+    aligned_late: 0,
+    tv_only: 0,
+    fv_only: 0,
+    misaligned: 0,
+    alignment_pct: 0
+  }
+}
+
+export function finishCounts(counts) {
+  var aligned = (counts.aligned_on_time || 0) + (counts.aligned_late || 0)
+  counts.alignment_pct = counts.total > 0 ? Math.round((aligned / counts.total) * 100) : 0
+  return counts
+}
+
+export function countAlignment(features) {
+  var counts = emptyAlignmentCounts()
+  var list = features || []
+  for (var i = 0; i < list.length; i++) {
+    counts.total++
+    var cat = list[i] && list[i].alignmentCategory
+    if (cat && counts[cat] != null) counts[cat]++
+  }
+  return finishCounts(counts)
+}
+
+/**
+ * Unique features across requested + committed lists.
+ * Worst alignmentCategory wins when the same key appears in more than one version.
+ */
+export function uniqueFeaturesFromGroups(groups) {
+  var byKey = {}
+  var groupsArr = groups || []
+  for (var gi = 0; gi < groupsArr.length; gi++) {
+    var version = groupsArr[gi].version
+    var comps = groupsArr[gi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var lists = [comps[ci].requestedFeatures || [], comps[ci].committedFeatures || []]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!f || !f.key) continue
+          if (!byKey[f.key]) {
+            byKey[f.key] = {
+              key: f.key,
+              alignmentCategory: f.alignmentCategory || null,
+              byVersion: {}
+            }
+          }
+          var nextCat = worseAlignmentCategory(
+            byKey[f.key].byVersion[version] || null,
+            f.alignmentCategory || null
+          )
+          byKey[f.key].byVersion[version] = nextCat
+          byKey[f.key].alignmentCategory = worseAlignmentCategory(
+            byKey[f.key].alignmentCategory,
+            f.alignmentCategory || null
+          )
+        }
+      }
+    }
+  }
+  var keys = Object.keys(byKey)
+  var out = []
+  for (var i = 0; i < keys.length; i++) out.push(byKey[keys[i]])
+  return out
+}
+
+export function visibleVersionNames(groups) {
+  var names = []
+  var src = groups || []
+  for (var i = 0; i < src.length; i++) {
+    if (src[i] && src[i].version) names.push(src[i].version)
+  }
+  return names
+}
+
+/**
+ * Count closed issues whose Fix Version intersects the versions still visible
+ * after client-side filters (for example Product).
+ */
+export function countDeliveredInVisibleVersions(deliveredIssues, versionNames) {
+  var allowed = {}
+  var names = versionNames || []
+  for (var i = 0; i < names.length; i++) allowed[names[i]] = true
+  var seen = {}
+  var count = 0
+  var issues = deliveredIssues || []
+  for (var di = 0; di < issues.length; di++) {
+    var issue = issues[di]
+    if (!issue || !issue.key || seen[issue.key]) continue
+    var fvs = issue.fixVersions || []
+    var match = false
+    for (var vi = 0; vi < fvs.length; vi++) {
+      if (allowed[fvs[vi]]) {
+        match = true
+        break
+      }
+    }
+    if (!match) continue
+    seen[issue.key] = true
+    count++
+  }
+  return count
+}
+
+function sortCycleKeys(keys) {
+  return keys.slice().sort(function(a, b) {
+    if (a === 'other') return 1
+    if (b === 'other') return -1
+    return String(b).localeCompare(String(a), undefined, { numeric: true })
+  })
+}
+
+function milestoneRank(key) {
+  if (/-EA1$/.test(key)) return 1
+  if (/-EA2$/.test(key)) return 2
+  if (/-GA$/.test(key)) return 3
+  return 9
+}
+
+/**
+ * Hierarchical roll-up of the filtered groups: selected scope → milestone → product.
+ */
+export function buildAlignmentRollup(groups) {
+  var src = groups || []
+  var scope = {
+    key: 'selected-scope',
+    kind: 'scope',
+    label: 'Selected scope',
+    versionNames: visibleVersionNames(src),
+    counts: countAlignment(uniqueFeaturesFromGroups(src))
+  }
+
+  var cycleMap = {}
+  var cycleOrder = []
+  for (var gi = 0; gi < src.length; gi++) {
+    var version = src[gi].version
+    var cycle = extractCycle(version) || 'other'
+    var milestone = extractMilestoneGroup(version) || (cycle + '-other')
+    var product = extractProduct(version)
+    if (!cycleMap[cycle]) {
+      cycleMap[cycle] = {
+        key: cycle,
+        label: cycle === 'other' ? 'Other' : cycleLabel(cycle),
+        milestones: {},
+        milestoneOrder: []
+      }
+      cycleOrder.push(cycle)
+    }
+    var c = cycleMap[cycle]
+    if (!c.milestones[milestone]) {
+      c.milestones[milestone] = {
+        key: milestone,
+        label: milestone.endsWith('-other') ? 'Other' : milestoneGroupLabel(milestone),
+        versionNames: [],
+        groups: []
+      }
+      c.milestoneOrder.push(milestone)
+    }
+    var ms = c.milestones[milestone]
+    ms.versionNames.push(version)
+    ms.groups.push(src[gi])
+    ms.rows = ms.rows || []
+    ms.rows.push({
+      key: version,
+      kind: 'product',
+      label: product ? productLabel(product) : version,
+      product: product ? productLabel(product) : null,
+      versionNames: [version],
+      counts: countAlignment(uniqueFeaturesFromGroups([src[gi]]))
+    })
+  }
+
+  cycleOrder = sortCycleKeys(cycleOrder)
+  var cycles = []
+  for (var ci = 0; ci < cycleOrder.length; ci++) {
+    var cyc = cycleMap[cycleOrder[ci]]
+    cyc.milestoneOrder.sort(function(a, b) {
+      return milestoneRank(a) - milestoneRank(b)
+    })
+    var milestones = []
+    for (var mi = 0; mi < cyc.milestoneOrder.length; mi++) {
+      var mk = cyc.milestoneOrder[mi]
+      var msRow = cyc.milestones[mk]
+      milestones.push({
+        key: msRow.key,
+        kind: 'milestone',
+        label: msRow.label,
+        versionNames: msRow.versionNames,
+        counts: countAlignment(uniqueFeaturesFromGroups(msRow.groups)),
+        rows: msRow.rows || []
+      })
+    }
+    cycles.push({
+      key: cyc.key,
+      label: cyc.label,
+      milestones: milestones
+    })
+  }
+
+  return { scope: scope, cycles: cycles }
+}

--- a/modules/releases/client/plan/utils/tv-fv-alignment-display.js
+++ b/modules/releases/client/plan/utils/tv-fv-alignment-display.js
@@ -67,3 +67,129 @@ export function alignmentCategoryChipClass(category) {
       return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
   }
 }
+
+var RELEASE_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+var JIRA_RELEASE_PATTERN = /^(\d+)\.(\d+)(?:\s+(EA\d+|GA))?\s+(RHOAI|RHAII|RHELAI)(?:\s+RELEASE)?$/i
+var PRODUCT_DISPLAY = { rhoai: 'RHOAI', rhelai: 'RHELAI', rhaii: 'RHAII' }
+
+function parseReleaseName(name) {
+  if (!name) return null
+  var s = String(name).trim()
+  var m = RELEASE_PATTERN.exec(s)
+  if (m) {
+    var eaNum = m[4] ? parseInt(m[4], 10) : 0
+    return {
+      product: m[1].toLowerCase(),
+      major: parseInt(m[2], 10),
+      minor: parseInt(m[3], 10),
+      milestone: eaNum ? 'EA' + eaNum : 'GA',
+      milestoneOrder: eaNum || 99,
+      raw: name
+    }
+  }
+  var jm = JIRA_RELEASE_PATTERN.exec(s)
+  if (jm) {
+    var product = jm[4].toLowerCase()
+    var phaseLabel = jm[3] ? String(jm[3]).toUpperCase() : 'GA'
+    var eaFromJira = /^EA(\d+)$/.test(phaseLabel) ? parseInt(phaseLabel.slice(2), 10) : 0
+    return {
+      product: product,
+      major: parseInt(jm[1], 10),
+      minor: parseInt(jm[2], 10),
+      milestone: eaFromJira ? 'EA' + eaFromJira : 'GA',
+      milestoneOrder: eaFromJira || 99,
+      raw: name
+    }
+  }
+  return null
+}
+
+function joinEnglish(parts) {
+  if (!parts || parts.length === 0) return ''
+  if (parts.length === 1) return parts[0]
+  if (parts.length === 2) return parts[0] + ' and ' + parts[1]
+  return parts.slice(0, -1).join(', ') + ', and ' + parts[parts.length - 1]
+}
+
+function compareParsed(a, b) {
+  if (a.product !== b.product) return a.product.localeCompare(b.product)
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.milestoneOrder - b.milestoneOrder
+}
+
+function uniqueMilestoneLabels(names, includeProduct) {
+  var items = []
+  var seen = {}
+  for (var i = 0; i < names.length; i++) {
+    var raw = names[i]
+    if (!raw) continue
+    var parsed = parseReleaseName(raw)
+    var label
+    if (parsed) {
+      label = includeProduct
+        ? (PRODUCT_DISPLAY[parsed.product] || parsed.product.toUpperCase()) + ' ' + parsed.milestone
+        : parsed.milestone
+    } else {
+      label = String(raw)
+    }
+    if (seen[label]) continue
+    seen[label] = true
+    items.push({ label: label, parsed: parsed })
+  }
+  items.sort(function(a, b) {
+    if (a.parsed && b.parsed) return compareParsed(a.parsed, b.parsed)
+    if (a.parsed) return -1
+    if (b.parsed) return 1
+    return a.label.localeCompare(b.label)
+  })
+  return items.map(function(item) { return item.label })
+}
+
+function listVersions(feature) {
+  var tvs = Array.isArray(feature && feature.targetVersions) ? feature.targetVersions.slice() : []
+  var fvs = Array.isArray(feature && feature.fixVersions) && feature.fixVersions.length > 0
+    ? feature.fixVersions.slice()
+    : (feature && feature.fixVersion ? [feature.fixVersion] : [])
+  return { tvs: tvs, fvs: fvs }
+}
+
+/**
+ * Plain-language requested vs committed summary for the Align popup.
+ * Example: "Requested for EA1, committed for EA2."
+ */
+export function buildAlignmentDetail(feature) {
+  var lists = listVersions(feature || {})
+  var tvs = lists.tvs
+  var fvs = lists.fvs
+  var parsedAll = tvs.concat(fvs).map(parseReleaseName).filter(Boolean)
+  var products = {}
+  for (var i = 0; i < parsedAll.length; i++) products[parsedAll[i].product] = true
+  var includeProduct = Object.keys(products).length > 1
+  var requestedLabels = uniqueMilestoneLabels(tvs, includeProduct)
+  var committedLabels = uniqueMilestoneLabels(fvs, includeProduct)
+  var category = feature && feature.alignmentCategory
+  var summary
+  if (requestedLabels.length === 0 && committedLabels.length === 0) {
+    summary = 'No Target Version or Fix Version.'
+  } else if (requestedLabels.length > 0 && committedLabels.length === 0) {
+    summary = 'Requested for ' + joinEnglish(requestedLabels) + ', not committed.'
+  } else if (requestedLabels.length === 0 && committedLabels.length > 0) {
+    summary = 'Committed for ' + joinEnglish(committedLabels) + ', no Target Version.'
+  } else if (
+    requestedLabels.length === committedLabels.length &&
+    requestedLabels.join('\0') === committedLabels.join('\0')
+  ) {
+    summary = 'Requested and committed for ' + joinEnglish(requestedLabels) + '.'
+  } else {
+    summary = 'Requested for ' + joinEnglish(requestedLabels) +
+      ', committed for ' + joinEnglish(committedLabels) + '.'
+  }
+  return {
+    summary: summary,
+    categoryLabel: alignmentCategoryLabel(category),
+    categoryHelp: alignmentCategoryHelp(category),
+    requested: tvs,
+    committed: fvs
+  }
+}

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -224,16 +224,6 @@
           {{ filterBlocked === true ? 'Blocked' : filterBlocked === false ? 'Not Blocked' : 'Blocked' }}
         </button>
 
-        <!-- Hide Closed -->
-        <button
-          type="button"
-          @click="hideClosed = !hideClosed; saveFilters()"
-          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
-          :class="hideClosed ? 'bg-gray-700 dark:bg-gray-200 border-gray-700 dark:border-gray-200 text-white dark:text-gray-800' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
-        >
-          Hide Closed
-        </button>
-
         <!-- Docs Required -->
         <div class="inline-flex items-center rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden">
           <button
@@ -244,6 +234,18 @@
             class="px-2.5 py-1 text-[11px] font-medium transition-colors"
             :class="filterDocs.includes(dv) ? 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
           >{{ dv === 'Not set' ? 'Docs Required ?' : 'Docs Required ' + dv }}</button>
+        </div>
+
+        <!-- TV/FV Align -->
+        <div class="inline-flex items-center rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden">
+          <button
+            v-for="cat in alignmentChipKeys"
+            :key="cat"
+            type="button"
+            @click="toggleFilter('filterAlignment', cat)"
+            class="px-2.5 py-1 text-[11px] font-medium transition-colors"
+            :class="filterAlignment.includes(cat) ? alignmentCategoryChipClass(cat) : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >{{ alignmentCategoryLabel(cat) }}</button>
         </div>
 
         <!-- Delivery Owner -->
@@ -291,63 +293,91 @@
     </div>
 
     <!--
-      Summary cards are display-only KPIs. Click-to-filter was removed because
-      toggling Requested/Committed via tiles made independent Requested (TV in
-      scope) and Committed (Fix Version in selected release scope) counts appear
-      correlated. Use REQ/COM (and other) filter chips in the bar above to filter
-      the table.
+      Summary cards are display-only KPIs except Align category clicks, which
+      filter the table. Requested/Committed stay independent of REQ/COM chips.
+      Delivered is Closed/Done/Resolved with Fix Version in the selected
+      releases — not planning load.
     -->
-    <div v-if="hasFetched && !loadingData" class="grid grid-cols-2 sm:grid-cols-5 gap-3">
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
-            <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Requested</span>
+    <div v-if="hasFetched && !loadingData" class="space-y-3">
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+          <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
+          <div class="flex items-center gap-2 mb-1.5">
+            <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
+              <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
+            </span>
+            <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Requested</span>
+          </div>
+          <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 ml-7">{{ totalRequested }}</div>
         </div>
-        <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 ml-7">{{ totalRequested }}</div>
-      </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-emerald-500 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-emerald-100 dark:bg-emerald-900/40">
-            <svg class="w-3 h-3 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Committed</span>
+        <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+          <div class="absolute top-0 left-0 w-1 h-full bg-emerald-500 rounded-l-xl" />
+          <div class="flex items-center gap-2 mb-1.5">
+            <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-emerald-100 dark:bg-emerald-900/40">
+              <svg class="w-3 h-3 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            </span>
+            <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Committed</span>
+          </div>
+          <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400 ml-7">{{ totalCommitted }}</div>
         </div>
-        <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400 ml-7">{{ totalCommitted }}</div>
-      </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
-            <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
+        <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+          <div class="absolute top-0 left-0 w-1 h-full bg-slate-500 rounded-l-xl" />
+          <div class="flex items-center gap-2 mb-1.5">
+            <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-slate-100 dark:bg-slate-700">
+              <svg class="w-3 h-3 text-slate-600 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+            </span>
+            <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Delivered</span>
+          </div>
+          <div
+            class="text-2xl font-bold ml-7 text-slate-700 dark:text-slate-200"
+            :title="deliveredTitle"
+          >{{ deliveredDisplay }}</div>
+          <p v-if="deliveredTimedOut" class="ml-7 text-[10px] text-amber-600 dark:text-amber-400">Timed out — open load is unchanged</p>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="totalBlocked > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlocked }}<span v-if="blockedPercent !== null" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-1">({{ blockedPercent }}%)</span></div>
-      </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-amber-500 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
-            <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Not Aligned</span>
+        <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+          <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
+          <div class="flex items-center gap-2 mb-1.5">
+            <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
+              <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
+            </span>
+            <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
+          </div>
+          <div class="text-2xl font-bold ml-7" :class="totalBlocked > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlocked }}<span v-if="blockedPercent !== null" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-1">({{ blockedPercent }}%)</span></div>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="totalNotAligned > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'" title="Not aligned = TV only, FV only, or misaligned (same categories as TV vs FV Delta). On time and Late count as aligned.">{{ totalNotAligned }}</div>
       </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
-        <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
-        <div class="flex items-center gap-2 mb-1.5">
-          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-gray-100 dark:bg-gray-700">
-            <svg class="w-3 h-3 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" /></svg>
-          </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Releases</span>
+
+      <div class="grid grid-cols-2 sm:grid-cols-6 gap-2">
+        <button
+          v-for="cat in alignmentChipKeys"
+          :key="cat"
+          type="button"
+          class="px-3 py-2 rounded-xl border text-left transition-colors"
+          :class="filterAlignment.length === 1 && filterAlignment[0] === cat
+            ? 'border-primary-400 ring-1 ring-primary-400 bg-white dark:bg-gray-800'
+            : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600'"
+          :title="'Filter the table to ' + alignmentCategoryLabel(cat) + '. Requested and Committed tiles stay unfiltered.'"
+          @click="setAlignmentFilter(cat)"
+        >
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold" :class="alignmentCategoryChipClass(cat)">{{ alignmentCategoryLabel(cat) }}</span>
+          <div class="mt-1 text-lg font-bold tabular-nums text-gray-900 dark:text-gray-100">{{ alignmentCounts[cat] }}</div>
+        </button>
+        <div class="px-3 py-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          <span class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Align %</span>
+          <div
+            class="mt-1 text-lg font-bold tabular-nums"
+            :class="alignmentPctClass"
+            title="(On time + Late) / unique keys with Target Version or Fix Version in this filtered view. Not the Requested count."
+          >{{ alignmentCounts.alignment_pct }}%</div>
         </div>
-        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ selectedVersions.length }}</div>
       </div>
+
+      <AlignmentRollupTable
+        :rollup="alignmentRollup"
+        @select-scope="onSelectScope"
+        @select-milestone="onSelectMilestone"
+        @select-product="onSelectProduct"
+        @select-category="setAlignmentFilter"
+      />
     </div>
 
     <!-- Loading -->
@@ -407,9 +437,22 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, inject } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import { buildComponentLeadsMap } from '../../composables/componentLeads'
 import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
+import AlignmentRollupTable from '../components/AlignmentRollupTable.vue'
 import PillarConfigPanel from '../components/PillarConfigPanel.vue'
 import FeatureReadinessDrawer from '../components/FeatureReadinessDrawer.vue'
 import { toDrawerFeature } from '../utils/feature-readiness-drawer-model.js'
+import {
+  ALIGNMENT_CATEGORY_LABELS,
+  alignmentCategoryLabel,
+  alignmentCategoryChipClass
+} from '../utils/tv-fv-alignment-display.js'
+import {
+  uniqueFeaturesFromGroups,
+  countAlignment,
+  buildAlignmentRollup,
+  countDeliveredInVisibleVersions,
+  visibleVersionNames
+} from '../utils/alignment-rollup.js'
 
 const nav = inject('moduleNav', null)
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -452,13 +495,16 @@ var componentError = ref(null)
 
 var groups = ref([])
 var loadingData = ref(false)
+var activeLoadController = null
 var dataError = ref(null)
 var hasFetched = ref(false)
 var tableRef = ref(null)
 var fetchedAt = ref(null)
 var autoRefreshTimer = ref(null)
-var activeLoadController = null
 var selectedFeature = ref(null)
+var deliveredIssues = ref([])
+var deliveredSkipped = ref(null)
+var deliveredTimedOut = ref(false)
 var drawerFeature = computed(function() {
   return toDrawerFeature(selectedFeature.value)
 })
@@ -468,7 +514,7 @@ var filterType = ref([])
 var filterReleaseType = ref([])
 var filterStatus = ref([])
 var filterBlocked = ref(null)
-var hideClosed = ref(false)
+var filterAlignment = ref([])
 var filterDelOwner = ref([])
 var filterPmOwner = ref([])
 var filterDocs = ref([])
@@ -501,7 +547,7 @@ function saveFilters() {
       releaseType: filterReleaseType.value,
       status: filterStatus.value,
       blocked: filterBlocked.value,
-      hideClosed: hideClosed.value,
+      alignment: filterAlignment.value,
       delOwner: filterDelOwner.value,
       pmOwner: filterPmOwner.value,
       docs: filterDocs.value,
@@ -524,7 +570,7 @@ function restoreFilters() {
     if (state.releaseType && Array.isArray(state.releaseType)) filterReleaseType.value = state.releaseType
     if (state.status && Array.isArray(state.status)) filterStatus.value = state.status
     if (state.blocked !== undefined) filterBlocked.value = state.blocked
-    if (state.hideClosed !== undefined) hideClosed.value = !!state.hideClosed
+    if (state.alignment && Array.isArray(state.alignment)) filterAlignment.value = state.alignment
     if (state.delOwner && Array.isArray(state.delOwner)) filterDelOwner.value = state.delOwner
     if (state.pmOwner && Array.isArray(state.pmOwner)) filterPmOwner.value = state.pmOwner
     if (state.docs && Array.isArray(state.docs)) filterDocs.value = state.docs
@@ -550,6 +596,7 @@ var filterRefs = {
   filterType: filterType,
   filterReleaseType: filterReleaseType,
   filterStatus: filterStatus,
+  filterAlignment: filterAlignment,
   filterDelOwner: filterDelOwner,
   filterPmOwner: filterPmOwner,
   filterDocs: filterDocs
@@ -572,9 +619,8 @@ function toggleInArray(arrRef, value) {
 var activeFilterCount = computed(function() {
   var count = selectedPillars.value.length + selectedComponents.value.length + selectedVersions.value.length
   count += filterProduct.value.length + filterType.value.length + filterReleaseType.value.length
-  count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length + filterDocs.value.length
+  count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length + filterDocs.value.length + filterAlignment.value.length
   if (filterBlocked.value !== null) count++
-  if (hideClosed.value) count++
   return count
 })
 
@@ -590,7 +636,7 @@ function clearAllFilters() {
   filterReleaseType.value = []
   filterStatus.value = []
   filterBlocked.value = null
-  hideClosed.value = false
+  filterAlignment.value = []
   filterDelOwner.value = []
   filterPmOwner.value = []
   filterDocs.value = []
@@ -676,18 +722,18 @@ var filteredPmOwners = computed(function() {
 
 /**
  * Apply client-side filters to groups.
- * @param {boolean} includeTypeFilter - when true, apply REQ/COM (filterType) for the table.
- *   KPI summary tiles intentionally omit type filter so Requested (TV in scope)
- *   and Committed (Fix Version in selected release scope) remain independent
- *   headline counts.
+ * @param {{ applyType?: boolean, applyAlignment?: boolean }} opts
+ *   KPI / roll-up omit REQ/COM and Align so Requested, Committed, and the
+ *   five Align counts stay independent headline numbers.
  */
-function filterGroups(includeTypeFilter) {
-  var applyType = includeTypeFilter && filterType.value.length > 0
+function filterGroups(opts) {
+  var applyType = !!(opts && opts.applyType) && filterType.value.length > 0
+  var applyAlignment = !!(opts && opts.applyAlignment) && filterAlignment.value.length > 0
   var hasOther = filterProduct.value.length > 0 || filterReleaseType.value.length > 0 ||
-    filterStatus.value.length > 0 || filterBlocked.value !== null || hideClosed.value ||
+    filterStatus.value.length > 0 || filterBlocked.value !== null ||
     filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
 
-  if (!applyType && !hasOther) return groups.value
+  if (!applyType && !applyAlignment && !hasOther) return groups.value
 
   return groups.value.map(function(g) {
     var version = g.version
@@ -728,6 +774,7 @@ function filterGroups(includeTypeFilter) {
           if (filterType.value.indexOf('committed') >= 0 && isCom) matches = true
           if (!matches) return false
         }
+        if (applyAlignment && filterAlignment.value.indexOf(f.alignmentCategory) === -1) return false
         if (filterReleaseType.value.length > 0 && filterReleaseType.value.indexOf(f.releaseType || '') === -1) return false
         if (filterStatus.value.length > 0) {
           var cs = (f.colorStatus || '').toLowerCase()
@@ -739,7 +786,6 @@ function filterGroups(includeTypeFilter) {
         }
         if (filterBlocked.value === true && !f.isBlocked) return false
         if (filterBlocked.value === false && f.isBlocked) return false
-        if (hideClosed.value && f.statusCategory === 'Done') return false
         if (filterDelOwner.value.length > 0 && filterDelOwner.value.indexOf(f.assignee || '') === -1) return false
         if (filterPmOwner.value.length > 0 && filterPmOwner.value.indexOf(f.pmOwner || '') === -1) return false
         if (filterDocs.value.length > 0) {
@@ -779,14 +825,14 @@ function filterGroups(includeTypeFilter) {
   }).filter(function(g) { return g.components.length > 0 })
 }
 
-/** Table/groups view — includes REQ/COM type chips. */
+/** Table — includes REQ/COM and Align category chips. */
 var clientFilteredGroups = computed(function() {
-  return filterGroups(true)
+  return filterGroups({ applyType: true, applyAlignment: true })
 })
 
-/** KPI tiles — ignore filterType so Requested and Committed stay independent. */
+/** KPI tiles and Align roll-up — ignore REQ/COM and Align filters. */
 var summaryFilteredGroups = computed(function() {
-  return filterGroups(false)
+  return filterGroups({ applyType: false, applyAlignment: false })
 })
 
 var HIDDEN_COMPONENTS = ['lllm-d']
@@ -969,27 +1015,66 @@ var blockedPercent = computed(function() {
   return Math.round((totalBlocked.value / total) * 100)
 })
 
-var totalNotAligned = computed(function() {
-  var source = summaryFilteredGroups.value
-  var seen = {}
-  var count = 0
-  for (var gi = 0; gi < source.length; gi++) {
-    var comps = source[gi].components || []
-    for (var ci = 0; ci < comps.length; ci++) {
-      var lists = [comps[ci].requestedFeatures || [], comps[ci].committedFeatures || []]
-      for (var li = 0; li < lists.length; li++) {
-        for (var fi = 0; fi < lists[li].length; fi++) {
-          var f = lists[li][fi]
-          if (!seen[f.key] && !f.pmDoAligned) {
-            seen[f.key] = true
-            count++
-          }
-        }
-      }
-    }
-  }
-  return count
+var alignmentChipKeys = Object.keys(ALIGNMENT_CATEGORY_LABELS)
+
+var alignmentCounts = computed(function() {
+  return countAlignment(uniqueFeaturesFromGroups(summaryFilteredGroups.value))
 })
+
+var alignmentRollup = computed(function() {
+  return buildAlignmentRollup(summaryFilteredGroups.value)
+})
+
+var alignmentPctClass = computed(function() {
+  var pct = alignmentCounts.value.alignment_pct
+  if (pct < 50) return 'text-red-600 dark:text-red-400'
+  if (pct < 75) return 'text-amber-600 dark:text-amber-400'
+  return 'text-emerald-600 dark:text-emerald-400'
+})
+
+var deliveredCount = computed(function() {
+  if (deliveredSkipped.value === 'no-versions' || deliveredTimedOut.value) return null
+  return countDeliveredInVisibleVersions(
+    deliveredIssues.value,
+    visibleVersionNames(summaryFilteredGroups.value)
+  )
+})
+
+var deliveredDisplay = computed(function() {
+  if (deliveredCount.value == null) return '—'
+  return String(deliveredCount.value)
+})
+
+var deliveredTitle = computed(function() {
+  if (deliveredSkipped.value === 'no-versions') {
+    return 'Select a release to see Closed/Done/Resolved issues with Fix Version in that version. This is not planning load.'
+  }
+  if (deliveredTimedOut.value) {
+    return 'Delivered query timed out. Open Requested/Committed/Align numbers are unchanged.'
+  }
+  return 'Closed, Done, or Resolved with Fix Version in the versions still visible after filters. Not included in Requested, Committed, or Align %.'
+})
+
+function setAlignmentFilter(category) {
+  if (filterAlignment.value.length === 1 && filterAlignment.value[0] === category) {
+    filterAlignment.value = []
+    return
+  }
+  filterAlignment.value = [category]
+}
+
+function onSelectScope() {
+  filterProduct.value = []
+  filterAlignment.value = []
+}
+
+function onSelectMilestone() {
+  filterProduct.value = []
+}
+
+function onSelectProduct(row) {
+  if (row && row.product) filterProduct.value = [row.product]
+}
 
 var formattedFetchedAt = computed(function() {
   if (!fetchedAt.value) return null
@@ -1147,12 +1232,19 @@ async function loadData(opts) {
     var data = await response.json()
     groups.value = data.groups || []
     fetchedAt.value = data.fetchedAt || null
+    var delivered = data.delivered || {}
+    deliveredIssues.value = delivered.issues || []
+    deliveredSkipped.value = delivered.skipped || null
+    deliveredTimedOut.value = !!delivered.timedOut
   } catch (err) {
     if (err.name === 'AbortError') return
     if (!silent) dataError.value = err.message
     if (!silent) {
       groups.value = []
       fetchedAt.value = null
+      deliveredIssues.value = []
+      deliveredSkipped.value = null
+      deliveredTimedOut.value = false
     }
   } finally {
     if (activeLoadController === controller) {
@@ -1175,6 +1267,9 @@ watch([selectedComponents, selectedVersions, selectedPillars], function() {
     if (activeLoadController) activeLoadController.abort()
     groups.value = []
     hasFetched.value = false
+    deliveredIssues.value = []
+    deliveredSkipped.value = null
+    deliveredTimedOut.value = false
     return
   }
   loadData()
@@ -1182,7 +1277,7 @@ watch([selectedComponents, selectedVersions, selectedPillars], function() {
 
 // Save filters to localStorage on any filter change
 watch(
-  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, hideClosed, filterDelOwner, filterPmOwner, filterDocs],
+  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, filterAlignment, filterDelOwner, filterPmOwner, filterDocs],
   saveFilters,
   { deep: true }
 )

--- a/modules/releases/server/pm-hub/delivered-in-version.js
+++ b/modules/releases/server/pm-hub/delivered-in-version.js
@@ -88,8 +88,9 @@ async function fetchDeliveredInVersion(jiraClient, options) {
 
   var jql = buildDeliveredJql(versions, components)
   var timedOut = false
+  var timer = null
   var timeout = new Promise(function(resolve) {
-    setTimeout(function() {
+    timer = setTimeout(function() {
       timedOut = true
       resolve(null)
     }, timeoutMs)
@@ -108,6 +109,8 @@ async function fetchDeliveredInVersion(jiraClient, options) {
   } catch (err) {
     console.warn('[releases/pm-hub] Delivered-in-version fetch failed:', err && err.message)
     return emptyResult({ error: 'fetch-failed' })
+  } finally {
+    if (timer) clearTimeout(timer)
   }
 }
 

--- a/modules/releases/server/pm-hub/delivered-in-version.js
+++ b/modules/releases/server/pm-hub/delivered-in-version.js
@@ -1,0 +1,121 @@
+/**
+ * Fail-soft delivered-in-version fetch for PM Hub.
+ *
+ * Closed/Done/Resolved with Fix Version in the selected releases — execution
+ * fact, not planning load. Requires version names. Times out on its own so a
+ * slow Jira search cannot 504 the open Component Release Load request.
+ */
+
+var { FEATURES_LIST_PROJECTS } = require('../planning/constants')
+
+var DELIVERED_STATUSES = ['Closed', 'Done', 'Resolved']
+var DELIVERED_FIELDS = 'summary,status,fixVersions,components'
+var DELIVERED_TIMEOUT_MS = 8000
+
+function quoteJql(value) {
+  return '"' + String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+}
+
+/**
+ * @param {string[]} versions
+ * @param {string[]} [components]
+ * @returns {string|null}
+ */
+function buildDeliveredJql(versions, components) {
+  if (!Array.isArray(versions) || versions.length === 0) return null
+  var parts = [
+    'project IN (' + FEATURES_LIST_PROJECTS.join(', ') + ')',
+    'issuetype IN (Feature, Initiative)',
+    'status IN (' + DELIVERED_STATUSES.join(', ') + ')',
+    'fixVersion IN (' + versions.map(quoteJql).join(', ') + ')'
+  ]
+  if (Array.isArray(components) && components.length > 0) {
+    parts.push('component IN (' + components.map(quoteJql).join(', ') + ')')
+  }
+  return parts.join(' AND ')
+}
+
+function emptyResult(extra) {
+  return Object.assign({
+    issues: [],
+    skipped: null,
+    timedOut: false
+  }, extra || {})
+}
+
+function normalizeIssues(rawIssues) {
+  var seen = {}
+  var issues = []
+  var list = Array.isArray(rawIssues) ? rawIssues : []
+  for (var i = 0; i < list.length; i++) {
+    var raw = list[i]
+    if (!raw || !raw.key || seen[raw.key]) continue
+    seen[raw.key] = true
+    var fields = raw.fields || {}
+    var fvs = []
+    if (Array.isArray(fields.fixVersions)) {
+      for (var vi = 0; vi < fields.fixVersions.length; vi++) {
+        var name = fields.fixVersions[vi] && fields.fixVersions[vi].name
+        if (name) fvs.push(name)
+      }
+    }
+    var comps = []
+    if (Array.isArray(fields.components)) {
+      for (var ci = 0; ci < fields.components.length; ci++) {
+        var cName = fields.components[ci] && fields.components[ci].name
+        if (cName) comps.push(cName)
+      }
+    }
+    issues.push({ key: raw.key, fixVersions: fvs, components: comps })
+  }
+  return issues
+}
+
+/**
+ * @param {object} jiraClient
+ * @param {{ versions: string[], components?: string[], timeoutMs?: number }} options
+ * @returns {Promise<{ issues: object[], skipped: string|null, timedOut: boolean, error?: string }>}
+ */
+async function fetchDeliveredInVersion(jiraClient, options) {
+  var versions = (options && options.versions) || []
+  var components = (options && options.components) || []
+  var timeoutMs = options && options.timeoutMs != null ? options.timeoutMs : DELIVERED_TIMEOUT_MS
+
+  if (!versions.length) return emptyResult({ skipped: 'no-versions' })
+  if (!jiraClient || !jiraClient.fetchAllJqlResults) {
+    return emptyResult({ error: 'no-client' })
+  }
+
+  var jql = buildDeliveredJql(versions, components)
+  var timedOut = false
+  var timeout = new Promise(function(resolve) {
+    setTimeout(function() {
+      timedOut = true
+      resolve(null)
+    }, timeoutMs)
+  })
+
+  try {
+    var result = await Promise.race([
+      jiraClient.fetchAllJqlResults(jql, DELIVERED_FIELDS, { maxResults: 100 }),
+      timeout
+    ])
+    if (timedOut || result == null) {
+      console.warn('[releases/pm-hub] Delivered-in-version fetch exceeded ' + timeoutMs + 'ms')
+      return emptyResult({ timedOut: true })
+    }
+    return emptyResult({ issues: normalizeIssues(result) })
+  } catch (err) {
+    console.warn('[releases/pm-hub] Delivered-in-version fetch failed:', err && err.message)
+    return emptyResult({ error: 'fetch-failed' })
+  }
+}
+
+module.exports = {
+  DELIVERED_STATUSES: DELIVERED_STATUSES,
+  DELIVERED_TIMEOUT_MS: DELIVERED_TIMEOUT_MS,
+  quoteJql: quoteJql,
+  buildDeliveredJql: buildDeliveredJql,
+  fetchDeliveredInVersion: fetchDeliveredInVersion,
+  normalizeIssues: normalizeIssues
+}

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -21,6 +21,7 @@ const {
   buildComponentReleaseLoadGroups,
   attachAlignment: attachAlignmentFromCanonical
 } = require('./canonical-load')
+const { fetchDeliveredInVersion } = require('./delivered-in-version')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 /** Same Feature/Initiative population as Features List live fetch (RHAISTRAT + AIPCC). */
@@ -642,6 +643,10 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *       F Committed = Fix Version matches a selected version (FV only;
    *       Target Version does not gate Committed — see TV/FV Align for TV/FV relationship).
    *       TV/FV Align uses the Delta 5-category classifier.
+   *       delivered is a fail-soft Closed/Done/Resolved list for selected Fix
+   *       Versions (not merged into planning load). Empty when no versions are
+   *       selected; timedOut true if that extra Jira search exceeds its own
+   *       short timeout.
    *     parameters:
    *       - in: query
    *         name: components
@@ -747,6 +752,13 @@ module.exports = async function registerPmHubRoutes(router, context) {
       var storage = context.storage
       var releaseDates = await loadReleaseDatesMap(storage)
 
+      // Closed-in-version is a separate, version-required query. Do not fold it
+      // into the open Features pipeline (gateway timeout). Fail soft.
+      var deliveredPromise = fetchDeliveredInVersion(jiraClient, {
+        versions: versionNames,
+        components: componentNames
+      })
+
       // Same live population as Features List (RHAISTRAT + AIPCC, open only).
       var jiraFeatures = null
       try {
@@ -768,10 +780,13 @@ module.exports = async function registerPmHubRoutes(router, context) {
         releaseDates: releaseDates
       })
 
+      var delivered = await deliveredPromise
+
       // Velocity KPI hidden for now — keep computeVelocity() for a future report.
       res.json({
         groups: built.groups,
         velocity: null,
+        delivered: delivered,
         fetchedAt: new Date().toISOString(),
         filters: { components: componentNames, versions: versionNames },
         source: jiraFeatures ? 'canonical-live' : 'canonical-cache'

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -135,6 +135,7 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -231,6 +231,7 @@ test.describe('Releases PM Hub @releases', () => {
     const releaseFilter = page.locator('text=Release');
     await expect(componentFilter.first()).toBeVisible();
     await expect(releaseFilter.first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Hide Closed' })).toHaveCount(0);
 
     expect(page.errors).toHaveLength(0);
   });
@@ -275,6 +276,11 @@ test.describe('Releases PM Hub @releases', () => {
     var body = await res.json();
     expect(body).toHaveProperty('groups');
     expect(body.velocity).toBeNull();
+    expect(body).toHaveProperty('delivered');
+    expect(body.delivered).toHaveProperty('issues');
+    expect(Array.isArray(body.delivered.issues)).toBe(true);
+    expect(body.delivered).toHaveProperty('timedOut');
+    expect(body.delivered.skipped).toBe('no-versions');
   });
 
   test('should show Requested/Committed load KPIs without velocity card', async ({ page }) => {
@@ -301,6 +307,9 @@ test.describe('Releases PM Hub @releases', () => {
 
       await expect(page.locator('text=Requested').first()).toBeVisible();
       await expect(page.locator('text=Committed').first()).toBeVisible();
+      await expect(page.locator('text=Delivered').first()).toBeVisible();
+      await expect(page.getByText('On time', { exact: true }).first()).toBeVisible();
+      await expect(page.locator('text=Selected scope').first()).toBeVisible();
       await expect(page.locator('text=Avg Features Delivered')).toHaveCount(0);
       await expect(page.locator('text=avg/rel')).toHaveCount(0);
     }


### PR DESCRIPTION
## Summary
- Remove Hide Closed from PM Hub. That filter used Jira status category Done, which dropped Release Pending from Requested (154 vs Jira 156).
- Align cells now open a popup that states requested vs committed milestones (for example: requested for EA1, committed for EA2).
- Add a filtered five-way Align roll-up and Align % on the same unique-key set as Requested/Committed. Clicking an Align count filters the table only.
- Add a version-required, fail-soft Delivered count: Closed/Done/Resolved with Fix Version in the selected chips. Cancelled stays out. Closed rows stay out of the planning table. A timeout does not 504 the open load.

## Test plan
- [ ] PM Hub with selected versions: Requested matches Jira Target Version in those versions, including Release Pending.
- [ ] Hide Closed chip is gone; stale localStorage `hideClosed` does not change counts.
- [ ] Align popup on a row, drawer header, and table cell states requested vs committed without opening the drawer from the cell.
- [ ] Align roll-up matches the filtered unique-key set; Product/scope clicks update it; REQ/COM and Align table filters do not change Requested/Committed/Align % tiles.
- [ ] Delivered requires versions; components-only shows skipped (`—`); timeout shows a warning without changing open load.
- [ ] Clicking On time / Early / Late / Partial / Not aligned filters the table; click again clears.
- [ ] Unit: `npm test -- modules/releases/__tests__/client/plan/alignment-rollup.test.js modules/releases/__tests__/server/pm-hub/delivered-in-version.test.js modules/releases/__tests__/client/plan/tv-fv-alignment-display.test.js modules/releases/__tests__/client/plan/pm-hub-filter-persistence.test.js`
- [ ] Integration: Hide Closed button count is 0; KPI load includes Delivered and On time; API `delivered.skipped` is `no-versions` when only components are passed.


Made with [Cursor](https://cursor.com)