### PR TITLE
fix(releases): correct pipeline links and show all release branches

### DIFF
--- a/fixtures/releases/component-architectures/latest.json
+++ b/fixtures/releases/component-architectures/latest.json
@@ -1,176 +1,345 @@
 {
   "fetchedAt": "2026-08-18T12:00:00.000Z",
-  "source": { "owner": "red-hat-data-services", "repo": "konflux-central" },
+  "source": {
+    "owner": "red-hat-data-services",
+    "repo": "konflux-central"
+  },
   "branches": {
     "rhoai-3.5": {
       "generatedAt": "2026-08-18T10:00:00.000Z",
       "branch": "rhoai-3.5",
-      "architectures": ["amd64", "arm64", "ppc64le", "s390x"],
+      "architectures": [
+        "amd64",
+        "arm64",
+        "ppc64le",
+        "s390x"
+      ],
       "components": [
         {
           "name": "odh-ai-gateway-operator",
           "imageName": "odh-ai-gateway-operator-rhel9",
           "image": "quay.io/rhoai/odh-ai-gateway-operator-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-v3-5-push.yaml"
         },
         {
           "name": "odh-automl",
           "imageName": "odh-automl-rhel9",
           "image": "quay.io/rhoai/odh-automl-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/pipelines-components/.tekton/odh-automl-v3-5-push.yaml"
         },
         {
           "name": "odh-dashboard",
           "imageName": "odh-dashboard-rhel9",
           "image": "quay.io/rhoai/odh-dashboard-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-dashboard/.tekton/odh-dashboard-v3-5-push.yaml"
         },
         {
           "name": "odh-data-science-pipelines-operator-controller",
           "imageName": "odh-data-science-pipelines-operator-controller-rhel9",
           "image": "quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-5-push.yaml"
         },
         {
           "name": "odh-kserve-controller",
           "imageName": "odh-kserve-controller-rhel9",
           "image": "quay.io/rhoai/odh-kserve-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kserve/.tekton/odh-kserve-controller-v3-5-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-api-server-v2",
           "imageName": "odh-ml-pipelines-api-server-v2-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-38736", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38736", "reason": "ppc64le enablement" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38737", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38737", "reason": "s390x enablement" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38736",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38736",
+              "reason": "ppc64le enablement"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38737",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38737",
+              "reason": "s390x enablement"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-5-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-driver",
           "imageName": "odh-ml-pipelines-driver-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-driver-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-38738", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38738", "reason": "ppc64le enablement" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38739", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38739", "reason": "s390x enablement" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38738",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38738",
+              "reason": "ppc64le enablement"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38739",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38739",
+              "reason": "s390x enablement"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-5-push.yaml"
         },
         {
           "name": "odh-mlmd-grpc-server",
           "imageName": "odh-mlmd-grpc-server-rhel9",
           "image": "quay.io/rhoai/odh-mlmd-grpc-server-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38728", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728", "reason": "Not yet implemented" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38728",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728",
+              "reason": "Not yet implemented"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v3-5-push.yaml"
         },
         {
           "name": "odh-model-controller",
           "imageName": "odh-model-controller-rhel9",
           "image": "quay.io/rhoai/odh-model-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-12345", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-12345", "reason": "s390x enablement in progress" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-12345",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-12345",
+              "reason": "s390x enablement in progress"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-model-controller/.tekton/odh-model-controller-v3-5-push.yaml"
         },
         {
           "name": "odh-notebook-controller",
           "imageName": "odh-notebook-controller-rhel9",
           "image": "quay.io/rhoai/odh-notebook-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kubeflow/.tekton/odh-notebook-controller-v3-5-push.yaml"
         },
         {
           "name": "odh-rhel9-operator",
           "imageName": "odh-rhel9-operator",
           "image": "quay.io/rhoai/odh-rhel9-operator",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/rhods-operator/.tekton/odh-rhel9-operator-v3-5-push.yaml"
         },
         {
           "name": "odh-trustyai-service",
           "imageName": "odh-trustyai-service-rhel9",
           "image": "quay.io/rhoai/odh-trustyai-service-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/trustyai-service/.tekton/odh-trustyai-service-v3-5-push.yaml"
         },
         {
           "name": "odh-vllm-gaudi",
           "imageName": "odh-vllm-gaudi-rhel9",
           "image": "quay.io/rhoai/odh-vllm-gaudi-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "gaudi" },
-            "ppc64le": { "status": "incompatible", "accelerator": "gaudi" },
-            "s390x": { "status": "incompatible", "accelerator": "gaudi" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-gaudi-v3-5-push.yaml"
         },
         {
           "name": "odh-vllm-rocm",
           "imageName": "odh-vllm-rocm-rhel9",
           "image": "quay.io/rhoai/odh-vllm-rocm-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "rocm" },
-            "ppc64le": { "status": "incompatible", "accelerator": "rocm" },
-            "s390x": { "status": "incompatible", "accelerator": "rocm" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-rocm-v3-5-push.yaml"
         },
         {
           "name": "odh-workbench-cuda",
           "imageName": "odh-workbench-cuda-rhel9",
           "image": "quay.io/rhoai/odh-workbench-cuda-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "incompatible", "accelerator": "cuda" },
-            "s390x": { "status": "incompatible", "accelerator": "cuda" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/notebooks/.tekton/odh-workbench-cuda-v3-5-push.yaml"
         }
       ],
       "summary": {
@@ -179,320 +348,632 @@
         "withExceptions": 4,
         "withIncompatible": 3,
         "withNotBuilt": 1
-      }
+      },
+      "reportAvailable": true
     },
     "rhoai-3.6-ea.1": {
       "generatedAt": "2026-08-19T08:00:00.000Z",
       "branch": "rhoai-3.6-ea.1",
-      "architectures": ["amd64", "arm64", "ppc64le", "s390x"],
+      "architectures": [
+        "amd64",
+        "arm64",
+        "ppc64le",
+        "s390x"
+      ],
       "components": [
         {
           "name": "odh-ai-gateway-operator",
           "imageName": "odh-ai-gateway-operator-rhel9",
           "image": "quay.io/rhoai/odh-ai-gateway-operator-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ai-gateway-operator/.tekton/odh-ai-gateway-operator-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-ai-gateway-payload-processing",
           "imageName": "odh-ai-gateway-payload-processing-rhel9",
           "image": "quay.io/rhoai/odh-ai-gateway-payload-processing-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ai-gateway-payload-processing/.tekton/odh-ai-gateway-payload-processing-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-automl",
           "imageName": "odh-automl-rhel9",
           "image": "quay.io/rhoai/odh-automl-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/pipelines-components/.tekton/odh-automl-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-codeflare-operator",
           "imageName": "odh-codeflare-operator-rhel9",
           "image": "quay.io/rhoai/odh-codeflare-operator-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/codeflare-operator/.tekton/odh-codeflare-operator-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-dashboard",
           "imageName": "odh-dashboard-rhel9",
           "image": "quay.io/rhoai/odh-dashboard-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-dashboard/.tekton/odh-dashboard-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-data-science-pipelines-argo-workflowcontroller",
           "imageName": "odh-data-science-pipelines-argo-workflowcontroller-rhel9",
           "image": "quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-40100", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-40100", "reason": "ppc64le enablement blocked by upstream" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-40101", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-40101", "reason": "s390x enablement blocked by upstream" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-40100",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-40100",
+              "reason": "ppc64le enablement blocked by upstream"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-40101",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-40101",
+              "reason": "s390x enablement blocked by upstream"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-data-science-pipelines-operator-controller",
           "imageName": "odh-data-science-pipelines-operator-controller-rhel9",
           "image": "quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-feast-operator",
           "imageName": "odh-feast-operator-rhel9",
           "image": "quay.io/rhoai/odh-feast-operator-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-41200", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41200", "reason": "Feast upstream lacks ppc64le support" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-41201", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41201", "reason": "Feast upstream lacks s390x support" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-41200",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41200",
+              "reason": "Feast upstream lacks ppc64le support"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-41201",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41201",
+              "reason": "Feast upstream lacks s390x support"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/feast/.tekton/odh-feast-operator-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-feature-server",
           "imageName": "odh-feature-server-rhel9",
           "image": "quay.io/rhoai/odh-feature-server-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-41202", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41202", "reason": "Feature server not available on ppc64le" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-41203", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41203", "reason": "Feature server not available on s390x" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-41202",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41202",
+              "reason": "Feature server not available on ppc64le"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-41203",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-41203",
+              "reason": "Feature server not available on s390x"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/feast/.tekton/odh-feature-server-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-kf-notebook-controller",
           "imageName": "odh-kf-notebook-controller-rhel9",
           "image": "quay.io/rhoai/odh-kf-notebook-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kubeflow/.tekton/odh-kf-notebook-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-kserve-controller",
           "imageName": "odh-kserve-controller-rhel9",
           "image": "quay.io/rhoai/odh-kserve-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kserve/.tekton/odh-kserve-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-kuberay-operator-controller",
           "imageName": "odh-kuberay-operator-controller-rhel9",
           "image": "quay.io/rhoai/odh-kuberay-operator-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38740", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38740", "reason": "s390x enablement pending" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38740",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38740",
+              "reason": "s390x enablement pending"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kuberay/.tekton/odh-kuberay-operator-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-api-server-v2",
           "imageName": "odh-ml-pipelines-api-server-v2-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-38736", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38736", "reason": "ppc64le enablement" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38737", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38737", "reason": "s390x enablement" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38736",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38736",
+              "reason": "ppc64le enablement"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38737",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38737",
+              "reason": "s390x enablement"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-driver",
           "imageName": "odh-ml-pipelines-driver-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-driver-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-38738", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38738", "reason": "ppc64le enablement" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38739", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38739", "reason": "s390x enablement" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38738",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38738",
+              "reason": "ppc64le enablement"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38739",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38739",
+              "reason": "s390x enablement"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-launcher",
           "imageName": "odh-ml-pipelines-launcher-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-launcher-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-38741", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38741", "reason": "ppc64le enablement" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38742", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38742", "reason": "s390x enablement" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38741",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38741",
+              "reason": "ppc64le enablement"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38742",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38742",
+              "reason": "s390x enablement"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-launcher-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-mlmd-grpc-server",
           "imageName": "odh-mlmd-grpc-server-rhel9",
           "image": "quay.io/rhoai/odh-mlmd-grpc-server-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38728", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728", "reason": "Not yet implemented" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38728",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728",
+              "reason": "Not yet implemented"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-model-controller",
           "imageName": "odh-model-controller-rhel9",
           "image": "quay.io/rhoai/odh-model-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-model-controller/.tekton/odh-model-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-modelmesh-runtime-adapter",
           "imageName": "odh-modelmesh-runtime-adapter-rhel9",
           "image": "quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/modelmesh-runtime-adapter/.tekton/odh-modelmesh-runtime-adapter-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-modelmesh-serving-controller",
           "imageName": "odh-modelmesh-serving-controller-rhel9",
           "image": "quay.io/rhoai/odh-modelmesh-serving-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/modelmesh-serving/.tekton/odh-modelmesh-serving-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-notebook-controller",
           "imageName": "odh-notebook-controller-rhel9",
           "image": "quay.io/rhoai/odh-notebook-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kubeflow/.tekton/odh-notebook-controller-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-rhel9-operator",
           "imageName": "odh-rhel9-operator",
           "image": "quay.io/rhoai/odh-rhel9-operator",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/rhods-operator/.tekton/odh-rhel9-operator-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-training-cuda121-torch24-py311",
           "imageName": "odh-training-cuda121-torch24-py311-rhel9",
           "image": "quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "incompatible", "accelerator": "cuda" },
-            "s390x": { "status": "incompatible", "accelerator": "cuda" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/distributed-workloads/.tekton/odh-training-cuda121-torch24-py311-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-training-cuda128-torch29-py312",
           "imageName": "odh-training-cuda128-torch29-py312-rhel9",
           "image": "quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "incompatible", "accelerator": "cuda" },
-            "s390x": { "status": "incompatible", "accelerator": "cuda" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/distributed-workloads/.tekton/odh-training-cuda128-torch29-py312-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-trustyai-service",
           "imageName": "odh-trustyai-service-rhel9",
           "image": "quay.io/rhoai/odh-trustyai-service-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/trustyai-service/.tekton/odh-trustyai-service-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-vllm-cpu",
           "imageName": "odh-vllm-cpu-rhel9",
           "image": "quay.io/rhoai/odh-vllm-cpu-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "not_built" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "not_built"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-cpu-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-vllm-gaudi",
           "imageName": "odh-vllm-gaudi-rhel9",
           "image": "quay.io/rhoai/odh-vllm-gaudi-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "gaudi" },
-            "ppc64le": { "status": "incompatible", "accelerator": "gaudi" },
-            "s390x": { "status": "incompatible", "accelerator": "gaudi" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-gaudi-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-vllm-rocm",
           "imageName": "odh-vllm-rocm-rhel9",
           "image": "quay.io/rhoai/odh-vllm-rocm-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "rocm" },
-            "ppc64le": { "status": "incompatible", "accelerator": "rocm" },
-            "s390x": { "status": "incompatible", "accelerator": "rocm" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-rocm-v3-6-ea-1-push.yaml"
         },
         {
           "name": "odh-workbench-cuda",
           "imageName": "odh-workbench-cuda-rhel9",
           "image": "quay.io/rhoai/odh-workbench-cuda-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "incompatible", "accelerator": "cuda" },
-            "s390x": { "status": "incompatible", "accelerator": "cuda" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/notebooks/.tekton/odh-workbench-cuda-v3-6-ea-1-push.yaml"
         }
       ],
       "summary": {
@@ -501,166 +982,315 @@
         "withExceptions": 8,
         "withIncompatible": 5,
         "withNotBuilt": 2
-      }
+      },
+      "reportAvailable": true
     },
     "rhoai-3.4": {
       "generatedAt": "2026-08-15T10:00:00.000Z",
       "branch": "rhoai-3.4",
-      "architectures": ["amd64", "arm64", "ppc64le", "s390x"],
+      "architectures": [
+        "amd64",
+        "arm64",
+        "ppc64le",
+        "s390x"
+      ],
       "components": [
         {
           "name": "odh-automl",
           "imageName": "odh-automl-rhel9",
           "image": "quay.io/rhoai/odh-automl-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/pipelines-components/.tekton/odh-automl-v3-4-push.yaml"
         },
         {
           "name": "odh-dashboard",
           "imageName": "odh-dashboard-rhel9",
           "image": "quay.io/rhoai/odh-dashboard-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-dashboard/.tekton/odh-dashboard-v3-4-push.yaml"
         },
         {
           "name": "odh-data-science-pipelines-operator-controller",
           "imageName": "odh-data-science-pipelines-operator-controller-rhel9",
           "image": "quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "exception", "issueKey": "RHOAIENG-34100", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-34100", "reason": "ppc64le build dependency missing" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-34101", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-34101", "reason": "s390x build dependency missing" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-34100",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-34100",
+              "reason": "ppc64le build dependency missing"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-34101",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-34101",
+              "reason": "s390x build dependency missing"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines-operator/.tekton/odh-data-science-pipelines-operator-controller-v3-4-push.yaml"
         },
         {
           "name": "odh-kserve-controller",
           "imageName": "odh-kserve-controller-rhel9",
           "image": "quay.io/rhoai/odh-kserve-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kserve/.tekton/odh-kserve-controller-v3-4-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-api-server-v2",
           "imageName": "odh-ml-pipelines-api-server-v2-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-api-server-v2-v3-4-push.yaml"
         },
         {
           "name": "odh-ml-pipelines-driver",
           "imageName": "odh-ml-pipelines-driver-rhel9",
           "image": "quay.io/rhoai/odh-ml-pipelines-driver-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/data-science-pipelines/.tekton/odh-ml-pipelines-driver-v3-4-push.yaml"
         },
         {
           "name": "odh-mlmd-grpc-server",
           "imageName": "odh-mlmd-grpc-server-rhel9",
           "image": "quay.io/rhoai/odh-mlmd-grpc-server-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "exception", "issueKey": "RHOAIENG-38728", "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728", "reason": "Not yet implemented" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "exception",
+              "issueKey": "RHOAIENG-38728",
+              "issueUrl": "https://issues.redhat.com/browse/RHOAIENG-38728",
+              "reason": "Not yet implemented"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/ml-metadata/.tekton/odh-mlmd-grpc-server-v3-4-push.yaml"
         },
         {
           "name": "odh-model-controller",
           "imageName": "odh-model-controller-rhel9",
           "image": "quay.io/rhoai/odh-model-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/odh-model-controller/.tekton/odh-model-controller-v3-4-push.yaml"
         },
         {
           "name": "odh-notebook-controller",
           "imageName": "odh-notebook-controller-rhel9",
           "image": "quay.io/rhoai/odh-notebook-controller-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/kubeflow/.tekton/odh-notebook-controller-v3-4-push.yaml"
         },
         {
           "name": "odh-rhel9-operator",
           "imageName": "odh-rhel9-operator",
           "image": "quay.io/rhoai/odh-rhel9-operator",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "supported" },
-            "s390x": { "status": "supported" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "supported"
+            },
+            "s390x": {
+              "status": "supported"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/rhods-operator/.tekton/odh-rhel9-operator-v3-4-push.yaml"
         },
         {
           "name": "odh-trustyai-service",
           "imageName": "odh-trustyai-service-rhel9",
           "image": "quay.io/rhoai/odh-trustyai-service-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "not_built" },
-            "s390x": { "status": "not_built" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "not_built"
+            },
+            "s390x": {
+              "status": "not_built"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/trustyai-service/.tekton/odh-trustyai-service-v3-4-push.yaml"
         },
         {
           "name": "odh-vllm-gaudi",
           "imageName": "odh-vllm-gaudi-rhel9",
           "image": "quay.io/rhoai/odh-vllm-gaudi-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "gaudi" },
-            "ppc64le": { "status": "incompatible", "accelerator": "gaudi" },
-            "s390x": { "status": "incompatible", "accelerator": "gaudi" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "gaudi"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-gaudi-v3-4-push.yaml"
         },
         {
           "name": "odh-vllm-rocm",
           "imageName": "odh-vllm-rocm-rhel9",
           "image": "quay.io/rhoai/odh-vllm-rocm-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "incompatible", "accelerator": "rocm" },
-            "ppc64le": { "status": "incompatible", "accelerator": "rocm" },
-            "s390x": { "status": "incompatible", "accelerator": "rocm" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "rocm"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/vllm/.tekton/odh-vllm-rocm-v3-4-push.yaml"
         },
         {
           "name": "odh-workbench-cuda",
           "imageName": "odh-workbench-cuda-rhel9",
           "image": "quay.io/rhoai/odh-workbench-cuda-rhel9",
           "architectures": {
-            "amd64": { "status": "supported" },
-            "arm64": { "status": "supported" },
-            "ppc64le": { "status": "incompatible", "accelerator": "cuda" },
-            "s390x": { "status": "incompatible", "accelerator": "cuda" }
-          }
+            "amd64": {
+              "status": "supported"
+            },
+            "arm64": {
+              "status": "supported"
+            },
+            "ppc64le": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            },
+            "s390x": {
+              "status": "incompatible",
+              "accelerator": "cuda"
+            }
+          },
+          "pipelineRunFile": "pipelineruns/notebooks/.tekton/odh-workbench-cuda-v3-4-push.yaml"
         }
       ],
       "summary": {
@@ -669,7 +1299,18 @@
         "withExceptions": 2,
         "withIncompatible": 3,
         "withNotBuilt": 4
-      }
+      },
+      "reportAvailable": true
+    },
+    "rhoai-3.3": {
+      "reportAvailable": false,
+      "components": [],
+      "summary": null
+    },
+    "rhoai-2.25": {
+      "reportAvailable": false,
+      "components": [],
+      "summary": null
     }
   }
 }

--- a/modules/releases/client/reports/ComponentArchitecturesReport.vue
+++ b/modules/releases/client/reports/ComponentArchitecturesReport.vue
@@ -105,8 +105,17 @@
         </p>
       </div>
 
+      <!-- No report for this branch -->
+      <div v-if="currentBranchData && currentBranchData.reportAvailable === false" class="text-center py-16">
+        <Cpu :size="40" class="mx-auto text-gray-300 dark:text-gray-600 mb-3" />
+        <h3 class="text-base font-medium text-gray-700 dark:text-gray-300 mb-1">No multi-arch report for {{ selectedBranch }}</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          The <code class="text-xs bg-gray-100 dark:bg-gray-700 px-1 py-0.5 rounded">multi-arch-report.yaml</code> file has not been generated for this branch yet.
+        </p>
+      </div>
+
       <!-- Summary cards -->
-      <div v-if="summary" class="grid grid-cols-2 lg:grid-cols-5 gap-3">
+      <div v-else-if="summary" class="grid grid-cols-2 lg:grid-cols-5 gap-3">
         <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center flex flex-col justify-between">
           <p class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 h-8 flex items-center justify-center">Total</p>
           <p class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ summary.totalComponents }}</p>
@@ -130,7 +139,7 @@
       </div>
 
       <!-- Architecture matrix table -->
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div v-if="currentBranchData?.reportAvailable !== false" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
@@ -159,8 +168,8 @@
                       <Package :size="14" />
                     </a>
                     <a
-                      v-if="comp.imageName"
-                      :href="pipelineRunUrl(comp.imageName)"
+                      v-if="comp.pipelineRunFile"
+                      :href="pipelineRunUrl(comp)"
                       target="_blank"
                       rel="noopener noreferrer"
                       class="text-gray-400 hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400 transition-colors"
@@ -286,9 +295,12 @@ function quayUrl(image) {
   return `https://quay.io/repository/${name}?tab=tags`
 }
 
-function pipelineRunUrl(imageName) {
-  if (!imageName || !selectedBranch.value) return '#'
-  return `https://github.com/red-hat-data-services/konflux-central/tree/${selectedBranch.value}/pipelineruns/${imageName}`
+function pipelineRunUrl(comp) {
+  if (!selectedBranch.value) return '#'
+  if (comp.pipelineRunFile) {
+    return `https://github.com/red-hat-data-services/konflux-central/blob/${selectedBranch.value}/${comp.pipelineRunFile}`
+  }
+  return '#'
 }
 
 function formatDate(iso) {

--- a/modules/releases/server/component-architectures/fetcher.js
+++ b/modules/releases/server/component-architectures/fetcher.js
@@ -16,7 +16,7 @@ function stripRhelSuffix(name) {
   return name.replace(/-rhel\d+$/, '')
 }
 
-async function discoverReleaseBranches(octokit, { maxBranches = 3 } = {}) {
+async function discoverReleaseBranches(octokit) {
   const branches = await octokit.paginate(octokit.rest.repos.listBranches, {
     owner: OWNER,
     repo: REPO,
@@ -38,34 +38,42 @@ async function discoverReleaseBranches(octokit, { maxBranches = 3 } = {}) {
     return 0
   })
 
-  return rhoaiBranches.slice(0, maxBranches)
+  return rhoaiBranches
 }
 
 async function fetchBranchReport(octokit, branch) {
-  const { data } = await octokit.rest.repos.getContent({
-    owner: OWNER,
-    repo: REPO,
-    path: REPORT_PATH,
-    ref: branch
-  })
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner: OWNER,
+      repo: REPO,
+      path: REPORT_PATH,
+      ref: branch
+    })
 
-  const content = Buffer.from(data.content, 'base64').toString('utf8')
-  const report = yaml.load(content)
+    const content = Buffer.from(data.content, 'base64').toString('utf8')
+    const report = yaml.load(content)
 
-  report.components = (report.components || []).map(comp => {
-    if (comp.imageName) {
-      return comp
+    report.components = (report.components || []).map(comp => {
+      if (comp.imageName) {
+        return comp
+      }
+      const originalName = comp.name
+      return {
+        ...comp,
+        name: stripRhelSuffix(originalName),
+        imageName: originalName,
+        image: `quay.io/rhoai/${originalName}`
+      }
+    })
+
+    report.reportAvailable = true
+    return report
+  } catch (err) {
+    if (err.status === 404) {
+      return { reportAvailable: false, components: [], summary: null }
     }
-    const originalName = comp.name
-    return {
-      ...comp,
-      name: stripRhelSuffix(originalName),
-      imageName: originalName,
-      image: `quay.io/rhoai/${originalName}`
-    }
-  })
-
-  return report
+    throw err
+  }
 }
 
 function registerComponentArchitecturesFetcher(router, context) {
@@ -84,7 +92,7 @@ function registerComponentArchitecturesFetcher(router, context) {
 
     const octokit = new Octokit({ auth: token, request: { timeout: 30000 } })
 
-    const branches = await discoverReleaseBranches(octokit, { maxBranches: 3 })
+    const branches = await discoverReleaseBranches(octokit)
     if (!branches.length) {
       return { status: 'error', message: 'No rhoai-* release branches found' }
     }
@@ -97,12 +105,9 @@ function registerComponentArchitecturesFetcher(router, context) {
         branchData[branch] = await fetchBranchReport(octokit, branch)
       } catch (err) {
         console.warn(`[component-architectures] No report on ${branch}: ${err.message}`)
+        branchData[branch] = { reportAvailable: false, components: [], summary: null }
       }
       if (i < branches.length - 1) await delay(200)
-    }
-
-    if (!Object.keys(branchData).length) {
-      return { status: 'error', message: 'No multi-arch-report.yaml found on any release branch' }
     }
 
     const fetchedAt = new Date().toISOString()


### PR DESCRIPTION
## Summary
- **Fix pipeline definition links**: Use `pipelineRunFile` field from the report YAML (actual file path in konflux-central) instead of guessing from image name. The `pipelineruns/` directories are named after source repos, not component/image names.
- **Show all release branches**: Removed the 3-branch cap — all `rhoai-*` branches from konflux-central are now fetched. Branches without a `multi-arch-report.yaml` show an informative empty state instead of being silently skipped.
- **Updated fixture**: Added `pipelineRunFile` paths to all components and empty-branch entries (`rhoai-3.3`, `rhoai-2.25`) for demo mode.

Companion PR in konflux-central: adds `pipelineRunFile` to `generate-table.py` JSON/YAML output.

Jira: RHOAIENG-84746

## Test plan
- [ ] Verify pipeline definition links (FileCode icon) point to the correct `.tekton/` YAML file in konflux-central
- [ ] Verify all `rhoai-*` branches appear in the branch dropdown, not just the latest 3
- [ ] Verify branches without a report show "No multi-arch report" message instead of an empty table
- [ ] Verify demo mode works with updated fixture (`DEMO_MODE=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)