### PR TITLE
fix(releases): derive branches from release registry, relax refresh auth

### DIFF
--- a/fixtures/releases/component-architectures/latest.json
+++ b/fixtures/releases/component-architectures/latest.json
@@ -1302,12 +1302,22 @@
       },
       "reportAvailable": true
     },
-    "rhoai-3.3": {
+    "rhoai-3.5-ea.1": {
       "reportAvailable": false,
       "components": [],
       "summary": null
     },
-    "rhoai-2.25": {
+    "rhoai-3.5-ea.2": {
+      "reportAvailable": false,
+      "components": [],
+      "summary": null
+    },
+    "rhoai-3.6": {
+      "reportAvailable": false,
+      "components": [],
+      "summary": null
+    },
+    "rhoai-3.6-ea.2": {
       "reportAvailable": false,
       "components": [],
       "summary": null

--- a/modules/releases/server/component-architectures/fetcher.js
+++ b/modules/releases/server/component-architectures/fetcher.js
@@ -141,7 +141,7 @@ function registerComponentArchitecturesFetcher(router, context) {
    * @openapi
    * /api/modules/releases/component-architectures/refresh:
    *   post:
-   *     summary: Trigger component architecture data refresh from GitHub (admin only)
+   *     summary: Trigger component architecture data refresh from GitHub
    *     tags: [Releases - Component Architectures]
    *     responses:
    *       200:

--- a/modules/releases/server/component-architectures/fetcher.js
+++ b/modules/releases/server/component-architectures/fetcher.js
@@ -4,6 +4,7 @@ const { Octokit } = require('@octokit/rest')
 const yaml = require('js-yaml')
 
 const STORAGE_KEY = 'releases/component-architectures/latest.json'
+const REGISTRY_KEY = 'releases/registry.json'
 const OWNER = 'red-hat-data-services'
 const REPO = 'konflux-central'
 const REPORT_PATH = 'multi-arch-report.yaml'
@@ -16,18 +17,18 @@ function stripRhelSuffix(name) {
   return name.replace(/-rhel\d+$/, '')
 }
 
-async function discoverReleaseBranches(octokit) {
-  const branches = await octokit.paginate(octokit.rest.repos.listBranches, {
-    owner: OWNER,
-    repo: REPO,
-    per_page: 100
-  })
+function registryIdToBranch(id) {
+  const match = id.match(/^rhai-(\d+\.\d+)-?(ea\d+|ga)?$/)
+  if (!match) return null
+  const version = match[1]
+  const phase = match[2]
+  if (!phase || phase === 'ga') return `rhoai-${version}`
+  const eaNum = phase.replace('ea', '')
+  return `rhoai-${version}-ea.${eaNum}`
+}
 
-  const rhoaiBranches = branches
-    .map(b => b.name)
-    .filter(name => /^rhoai-\d/.test(name))
-
-  rhoaiBranches.sort((a, b) => {
+function sortBranchesDesc(branches) {
+  return [...branches].sort((a, b) => {
     const partsA = a.replace(/^rhoai-/, '').split(/[.-]/).map(Number)
     const partsB = b.replace(/^rhoai-/, '').split(/[.-]/).map(Number)
     for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
@@ -37,8 +38,17 @@ async function discoverReleaseBranches(octokit) {
     }
     return 0
   })
+}
 
-  return rhoaiBranches
+function branchesFromRegistry(registry) {
+  if (!registry || !Array.isArray(registry.releases)) return []
+  const seen = new Set()
+  for (const release of registry.releases) {
+    if (release.state !== 'active') continue
+    const branch = registryIdToBranch(release.id)
+    if (branch) seen.add(branch)
+  }
+  return sortBranchesDesc([...seen])
 }
 
 async function fetchBranchReport(octokit, branch) {
@@ -77,8 +87,8 @@ async function fetchBranchReport(octokit, branch) {
 }
 
 function registerComponentArchitecturesFetcher(router, context) {
-  const { storage, requireAdmin, requireScope, secrets } = context
-  const { writeToStorage } = storage
+  const { storage, requireAuth, requireScope, secrets } = context
+  const { readFromStorage, writeToStorage } = storage
 
   async function runFetch() {
     if (process.env.DEMO_MODE === 'true') {
@@ -92,9 +102,10 @@ function registerComponentArchitecturesFetcher(router, context) {
 
     const octokit = new Octokit({ auth: token, request: { timeout: 30000 } })
 
-    const branches = await discoverReleaseBranches(octokit)
+    const registry = await readFromStorage(REGISTRY_KEY)
+    const branches = branchesFromRegistry(registry)
     if (!branches.length) {
-      return { status: 'error', message: 'No rhoai-* release branches found' }
+      return { status: 'error', message: 'No active releases found in the registry' }
     }
 
     const branchData = {}
@@ -136,7 +147,7 @@ function registerComponentArchitecturesFetcher(router, context) {
    *       200:
    *         description: Refresh results
    */
-  router.post('/refresh', requireAdmin, requireScope('releases:write'), async function (req, res) {
+  router.post('/refresh', requireAuth, requireScope('releases:write'), async function (req, res) {
     if (context.isRefreshRunning && context.isRefreshRunning()) {
       return res.json({ status: 'already_running', message: 'A refresh is already in progress' })
     }
@@ -168,7 +179,8 @@ function registerComponentArchitecturesFetcher(router, context) {
 module.exports = {
   registerComponentArchitecturesFetcher,
   STORAGE_KEY,
-  discoverReleaseBranches,
+  registryIdToBranch,
+  branchesFromRegistry,
   fetchBranchReport,
   stripRhelSuffix
 }


### PR DESCRIPTION
## Summary
- **Branch list from registry**: Branches are now derived from the release registry (active releases) instead of listing all `rhoai-*` branches from konflux-central. Only currently supported versions appear in the dropdown. Mapping: `rhai-3.5-ea1` → `rhoai-3.5-ea.1`, `rhai-3.5-ga` → `rhoai-3.5`, etc.
- **Relax refresh auth**: Changed from `requireAdmin` to `requireAuth` — matches the pattern used by release-readiness, ai-adoption, cve-sustaining, and other report refresh routes. Any authenticated user can now trigger a data refresh.
- **Fixture updated**: Branch entries now match the registry-derived set.

Jira: RHOAIENG-84746

## Test plan
- [ ] Verify branch dropdown shows all active releases from the registry, not just branches with reports
- [ ] Verify non-admin users can click Refresh without getting "admin access required"
- [ ] Verify branches without a `multi-arch-report.yaml` show the empty state message
- [ ] Verify demo mode fixture loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)