### PR TITLE
fix(releases): merge registry branches into GET response

### DIFF
--- a/modules/releases/server/component-architectures/fetcher.js
+++ b/modules/releases/server/component-architectures/fetcher.js
@@ -179,6 +179,7 @@ function registerComponentArchitecturesFetcher(router, context) {
 module.exports = {
   registerComponentArchitecturesFetcher,
   STORAGE_KEY,
+  REGISTRY_KEY,
   registryIdToBranch,
   branchesFromRegistry,
   fetchBranchReport,

--- a/modules/releases/server/component-architectures/routes.js
+++ b/modules/releases/server/component-architectures/routes.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const { registerComponentArchitecturesFetcher, STORAGE_KEY, branchesFromRegistry } = require('./fetcher')
-
-const REGISTRY_KEY = 'releases/registry.json'
+const { registerComponentArchitecturesFetcher, STORAGE_KEY, REGISTRY_KEY, branchesFromRegistry } = require('./fetcher')
 
 /**
  * @param {import('express').Router} router

--- a/modules/releases/server/component-architectures/routes.js
+++ b/modules/releases/server/component-architectures/routes.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const { registerComponentArchitecturesFetcher, STORAGE_KEY } = require('./fetcher')
+const { registerComponentArchitecturesFetcher, STORAGE_KEY, branchesFromRegistry } = require('./fetcher')
+
+const REGISTRY_KEY = 'releases/registry.json'
 
 /**
  * @param {import('express').Router} router
@@ -32,11 +34,30 @@ function registerComponentArchitecturesRoutes(router, context) {
   router.get('/', requireAuth, requireScope('releases:read'), async function (req, res) {
     try {
       const data = await readFromStorage(STORAGE_KEY)
+
+      const registry = await readFromStorage(REGISTRY_KEY)
+      const registryBranches = branchesFromRegistry(registry)
+
       if (!data) {
-        return res.status(404).json({ error: 'No cached data. Trigger a refresh first.' })
+        const shell = {
+          fetchedAt: null,
+          source: { owner: 'red-hat-data-services', repo: 'konflux-central' },
+          branches: {}
+        }
+        for (const branch of registryBranches) {
+          shell.branches[branch] = { reportAvailable: false, components: [], summary: null }
+        }
+        return res.json(shell)
       }
 
-      if (req.query.branch && data.branches) {
+      if (!data.branches) data.branches = {}
+      for (const branch of registryBranches) {
+        if (!data.branches[branch]) {
+          data.branches[branch] = { reportAvailable: false, components: [], summary: null }
+        }
+      }
+
+      if (req.query.branch) {
         const branch = data.branches[req.query.branch]
         if (!branch) {
           return res.status(404).json({ error: `Branch ${req.query.branch} not found` })


### PR DESCRIPTION
## Summary
- The GET endpoint now reads the release registry and merges any missing branches into the cached data **on every request**. This ensures all active release branches appear in the dropdown immediately — no manual refresh needed, even after a fresh deploy with empty cache.
- If no cached data exists at all, returns a shell response with all registry branches marked `reportAvailable: false`, so the UI always shows the correct branch list.

Jira: RHOAIENG-84746

## Test plan
- [ ] Deploy with empty/stale cache — verify all registry branches appear immediately without clicking Refresh
- [ ] Verify new registry entries (e.g., a new EA release) appear in the dropdown on next page load
- [ ] Verify demo mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)