### PR TITLE
feat(releases): redesign BU Feedback report with SFDC Issues view

### DIFF
--- a/modules/releases/__tests__/client/plan/bu-feedback-exec-summary.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-exec-summary.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BuFeedbackExecutiveSummary from '../../../client/plan/components/BuFeedbackExecutiveSummary.vue'
+
+function issue(overrides) {
+  return Object.assign({
+    key: 'RHOAIENG-1',
+    summary: 'Test',
+    issueType: 'Bug',
+    assignee: 'Jane',
+    reporter: 'Alex',
+    priority: 'Major',
+    status: 'New',
+    statusCategory: 'To Do',
+    resolution: 'Unresolved',
+    created: '2026-06-01T12:00:00.000Z',
+    updated: '2026-08-01T12:00:00.000Z',
+    dueDate: null,
+    resolved: null,
+    inProgressAt: null,
+    components: ['Dashboard'],
+    fixVersions: [],
+    feedbackLabels: ['AIBU_Feedback']
+  }, overrides)
+}
+
+function mountSummary(issues) {
+  return mount(BuFeedbackExecutiveSummary, { props: { issues: issues } })
+}
+
+describe('BuFeedbackExecutiveSummary', function() {
+  beforeEach(function() {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-19T12:00:00.000Z'))
+  })
+
+  afterEach(function() {
+    vi.useRealTimers()
+  })
+
+  it('does not render when issues array is empty', function() {
+    var wrapper = mountSummary([])
+    expect(wrapper.find('[data-testid="bu-feedback-exec-summary"]').exists()).toBe(false)
+  })
+
+  it('renders the heading and subtitle', function() {
+    var wrapper = mountSummary([issue()])
+    expect(wrapper.text()).toContain('Executive Summary')
+    expect(wrapper.text()).toContain('Process-efficiency metrics')
+  })
+
+  it('renders the metrics table', function() {
+    var wrapper = mountSummary([
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolved: '2026-06-11T12:00:00.000Z',
+        inProgressAt: '2026-06-05T12:00:00.000Z',
+        created: '2026-06-01T12:00:00.000Z'
+      }),
+      issue({ key: 'B', created: '2026-08-09T12:00:00.000Z' })
+    ])
+    expect(wrapper.find('[data-testid="bu-feedback-metrics-table"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Avg Lead Time')
+    expect(wrapper.text()).toContain('Resolution Rate')
+    expect(wrapper.text()).toContain('Throughput')
+  })
+
+  it('renders the bottleneck table when components exist', function() {
+    var wrapper = mountSummary([
+      issue({ key: 'A', components: ['Serving'] }),
+      issue({ key: 'B', components: ['Serving'] }),
+      issue({ key: 'C', components: ['Dashboard'] })
+    ])
+    expect(wrapper.find('[data-testid="bu-feedback-bottleneck-table"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Serving')
+  })
+
+  it('renders bullet points with the three required metrics', function() {
+    var wrapper = mountSummary([
+      issue({
+        key: 'CLOSED',
+        statusCategory: 'Done',
+        resolved: '2026-06-11T12:00:00.000Z',
+        inProgressAt: '2026-06-05T12:00:00.000Z',
+        created: '2026-06-01T12:00:00.000Z'
+      }),
+      issue({ key: 'OPEN', created: '2026-08-09T12:00:00.000Z' })
+    ])
+    expect(wrapper.text()).toContain('Avg Lead Time:')
+    expect(wrapper.text()).toContain('Avg Cycle Time:')
+    expect(wrapper.text()).toContain('Avg Open Issue Age:')
+  })
+})

--- a/modules/releases/__tests__/client/plan/bu-feedback-summary.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-summary.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { buildExecutiveSummary } from '../../../client/plan/utils/bu-feedback-summary.js'
+
+var NOW = '2026-08-19T12:00:00.000Z'
+
+function issue(overrides) {
+  return Object.assign({
+    key: 'RHOAIENG-1',
+    summary: 'Test issue',
+    issueType: 'Bug',
+    assignee: 'Jane Smith',
+    reporter: 'Alex Lee',
+    priority: 'Major',
+    status: 'New',
+    statusCategory: 'To Do',
+    resolution: 'Unresolved',
+    created: '2026-06-01T12:00:00.000Z',
+    updated: '2026-08-01T12:00:00.000Z',
+    dueDate: null,
+    resolved: null,
+    inProgressAt: null,
+    components: ['AI Core Dashboard'],
+    fixVersions: [],
+    feedbackLabels: ['AIBU_Feedback']
+  }, overrides)
+}
+
+describe('buildExecutiveSummary', function() {
+  it('computes avg lead time from closed issues', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        created: '2026-06-01T12:00:00.000Z',
+        resolved: '2026-06-11T12:00:00.000Z'
+      }),
+      issue({
+        key: 'B',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        created: '2026-07-01T12:00:00.000Z',
+        resolved: '2026-07-21T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgLeadTime).toBe(15)
+    expect(s.avgLeadTimeSample).toBe(2)
+  })
+
+  it('computes avg cycle time from issues with inProgressAt', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolved: '2026-06-11T12:00:00.000Z',
+        inProgressAt: '2026-06-05T12:00:00.000Z'
+      }),
+      issue({
+        key: 'B',
+        statusCategory: 'Done',
+        resolved: '2026-07-21T12:00:00.000Z',
+        inProgressAt: '2026-07-11T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgCycleTime).toBe(8)
+    expect(s.avgCycleTimeSample).toBe(2)
+  })
+
+  it('returns null cycle time when no issues have inProgressAt', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolved: '2026-06-11T12:00:00.000Z',
+        inProgressAt: null
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgCycleTime).toBeNull()
+    expect(s.avgCycleTimeSample).toBe(0)
+  })
+
+  it('computes avg open age for open issues', function() {
+    var issues = [
+      issue({ key: 'A', created: '2026-08-09T12:00:00.000Z' }),
+      issue({ key: 'B', created: '2026-07-20T12:00:00.000Z' })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgOpenAge).toBe(20)
+    expect(s.avgOpenAgeSample).toBe(2)
+  })
+
+  it('computes resolution rate', function() {
+    var issues = [
+      issue({ key: 'A', statusCategory: 'Done', resolved: '2026-07-01T12:00:00.000Z' }),
+      issue({ key: 'B' }),
+      issue({ key: 'C' }),
+      issue({ key: 'D' })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.resolutionRate).toBe(25)
+  })
+
+  it('computes throughput within 90-day window', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolved: '2026-08-01T12:00:00.000Z',
+        created: '2026-07-01T12:00:00.000Z'
+      }),
+      issue({
+        key: 'OLD',
+        statusCategory: 'Done',
+        resolved: '2026-01-01T12:00:00.000Z',
+        created: '2025-12-01T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.throughput).toBe(1)
+  })
+
+  it('counts WIP, stale, and unassigned open', function() {
+    var issues = [
+      issue({ key: 'A', statusCategory: 'In Progress', assignee: 'Jane', created: '2026-01-01T12:00:00.000Z' }),
+      issue({ key: 'B', assignee: 'Unassigned', created: '2026-01-01T12:00:00.000Z' }),
+      issue({ key: 'C', created: '2026-08-18T12:00:00.000Z' })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.wipCount).toBe(1)
+    expect(s.staleOpenCount).toBe(2)
+    expect(s.unassignedOpenCount).toBe(1)
+  })
+
+  it('ranks bottleneck components by open count then avg age', function() {
+    var issues = [
+      issue({ key: 'A', components: ['Serving'], created: '2026-01-01T12:00:00.000Z' }),
+      issue({ key: 'B', components: ['Serving'], created: '2026-06-01T12:00:00.000Z' }),
+      issue({ key: 'C', components: ['Dashboard'], created: '2026-01-01T12:00:00.000Z' })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.bottlenecks.length).toBe(2)
+    expect(s.bottlenecks[0].component).toBe('Serving')
+    expect(s.bottlenecks[0].openCount).toBe(2)
+    expect(s.bottlenecks[1].component).toBe('Dashboard')
+  })
+
+  it('limits bottlenecks to top 5', function() {
+    var issues = []
+    for (var i = 0; i < 7; i++) {
+      issues.push(issue({ key: 'K-' + i, components: ['C' + i] }))
+    }
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.bottlenecks.length).toBe(5)
+  })
+
+  it('falls back to updated when resolved is null for lead time', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        resolved: null,
+        created: '2026-06-01T12:00:00.000Z',
+        updated: '2026-06-21T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgLeadTime).toBe(20)
+    expect(s.avgLeadTimeSample).toBe(1)
+  })
+
+  it('falls back to updated for cycle time when resolved is null', function() {
+    var issues = [
+      issue({
+        key: 'A',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        resolved: null,
+        inProgressAt: '2026-06-05T12:00:00.000Z',
+        updated: '2026-06-15T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.avgCycleTime).toBe(10)
+    expect(s.avgCycleTimeSample).toBe(1)
+  })
+
+  it('falls back to updated for throughput when resolved is null', function() {
+    var issues = [
+      issue({
+        key: 'RECENT',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        resolved: null,
+        created: '2026-07-01T12:00:00.000Z',
+        updated: '2026-08-01T12:00:00.000Z'
+      }),
+      issue({
+        key: 'OLD',
+        statusCategory: 'Done',
+        resolution: 'Done',
+        resolved: null,
+        created: '2025-12-01T12:00:00.000Z',
+        updated: '2026-01-01T12:00:00.000Z'
+      })
+    ]
+    var s = buildExecutiveSummary(issues, NOW)
+    expect(s.throughput).toBe(1)
+  })
+
+  it('handles empty issue list', function() {
+    var s = buildExecutiveSummary([], NOW)
+    expect(s.total).toBe(0)
+    expect(s.avgLeadTime).toBeNull()
+    expect(s.avgCycleTime).toBeNull()
+    expect(s.avgOpenAge).toBeNull()
+    expect(s.bottlenecks).toEqual([])
+  })
+})

--- a/modules/releases/__tests__/client/plan/bu-feedback-table-component.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-table-component.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import BuFeedbackTable from '../../../client/plan/components/BuFeedbackTable.vue'
+
+function issue(overrides) {
+  return Object.assign({
+    key: 'RHOAIENG-1',
+    url: 'https://issues.redhat.com/browse/RHOAIENG-1',
+    summary: 'Dashboard filter is broken',
+    issueType: 'Bug',
+    assignee: 'Jane Smith',
+    reporter: 'Alex Lee',
+    priority: 'Major',
+    status: 'New',
+    statusCategory: 'To Do',
+    resolution: 'Unresolved',
+    created: '2026-08-19T12:00:00.000Z',
+    updated: '2026-08-19T13:00:00.000Z',
+    dueDate: null,
+    components: ['AI Core Dashboard', 'Documentation'],
+    fixVersions: ['RHOAI 3.2'],
+    feedbackLabels: ['AIBU_Feedback']
+  }, overrides)
+}
+
+function mountTable(issues) {
+  return mount(BuFeedbackTable, { props: { issues: issues } })
+}
+
+describe('BuFeedbackTable', function() {
+  it('renders a compact table with search and filters outside column headers', function() {
+    var wrapper = mountTable([issue()])
+    expect(wrapper.find('[data-testid="bu-feedback-search"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="bu-feedback-filter-type"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="bu-feedback-table"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('RHOAIENG-1')
+    expect(wrapper.text()).toContain('Dashboard filter is broken')
+    expect(wrapper.text()).toContain('BU')
+    expect(wrapper.find('thead select').exists()).toBe(false)
+  })
+
+  it('shows the full issue type name', function() {
+    var wrapper = mountTable([issue({ issueType: 'Feature Request', summary: 'Add export' })])
+    var badge = wrapper.findAll('span').filter(function(el) { return el.text() === 'Feature Request' })[0]
+    expect(badge).toBeTruthy()
+    expect(badge.classes().join(' ')).not.toContain('truncate')
+  })
+
+  it('filters rows from the toolbar search', async function() {
+    var wrapper = mountTable([
+      issue({ key: 'RHOAIENG-1', summary: 'Dashboard filter is broken' }),
+      issue({ key: 'RHAIRFE-2', summary: 'Add export', issueType: 'Feature Request' })
+    ])
+    await wrapper.find('[data-testid="bu-feedback-search"]').setValue('export')
+    await nextTick()
+    expect(wrapper.text()).toContain('RHAIRFE-2')
+    expect(wrapper.text()).not.toContain('RHOAIENG-1')
+    expect(wrapper.get('[data-testid="bu-feedback-count"]').text()).toContain('1–1 of 1')
+  })
+
+  it('expands a row to show secondary details', async function() {
+    var wrapper = mountTable([issue()])
+    expect(wrapper.text()).not.toContain('Alex Lee')
+    await wrapper.get('[data-testid="bu-feedback-row-RHOAIENG-1"]').trigger('click')
+    expect(wrapper.text()).toContain('Alex Lee')
+    expect(wrapper.text()).toContain('RHOAI 3.2')
+    expect(wrapper.text()).toContain('Unresolved')
+  })
+
+  it('pages when there are more than 25 issues', async function() {
+    var issues = []
+    for (var i = 0; i < 26; i++) {
+      issues.push(issue({
+        key: 'RHOAIENG-' + (100 + i),
+        created: '2026-08-' + String((i % 28) + 1).padStart(2, '0') + 'T00:00:00.000Z'
+      }))
+    }
+    var wrapper = mountTable(issues)
+    expect(wrapper.find('[data-testid="bu-feedback-next-page"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="bu-feedback-count"]').text()).toContain('1–25 of 26')
+    await wrapper.get('[data-testid="bu-feedback-next-page"]').trigger('click')
+    expect(wrapper.get('[data-testid="bu-feedback-count"]').text()).toContain('26–26 of 26')
+  })
+
+  it('shows overflow chip when a row has more than two components', function() {
+    var wrapper = mountTable([issue({ components: ['One', 'Two', 'Three'] })])
+    var overflow = wrapper.findAll('span').filter(function(el) { return el.text() === '+1' })
+    expect(overflow.length).toBeGreaterThan(0)
+    expect(overflow[0].attributes('title')).toBe('Three')
+  })
+})

--- a/modules/releases/__tests__/client/plan/bu-feedback-table-component.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-table-component.test.js
@@ -29,7 +29,7 @@ function mountTable(issues) {
 }
 
 describe('BuFeedbackTable', function() {
-  it('renders a compact table with search and filters outside column headers', function() {
+  it('renders a compact table with search and multi-select filters outside column headers', function() {
     var wrapper = mountTable([issue()])
     expect(wrapper.find('[data-testid="bu-feedback-search"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="bu-feedback-filter-type"]').exists()).toBe(true)
@@ -38,6 +38,7 @@ describe('BuFeedbackTable', function() {
     expect(wrapper.text()).toContain('Dashboard filter is broken')
     expect(wrapper.text()).toContain('BU')
     expect(wrapper.find('thead select').exists()).toBe(false)
+    expect(wrapper.find('select').exists()).toBe(false)
   })
 
   it('shows the full issue type name', function() {

--- a/modules/releases/__tests__/client/plan/bu-feedback-table.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-table.test.js
@@ -9,6 +9,7 @@ import {
   sortIssues,
   paginate,
   sourceShortLabel,
+  toggleFilterValue,
   typeBadgeClass,
   statusClasses,
   priorityDot,
@@ -44,7 +45,7 @@ describe('bu-feedback-table helpers', function() {
 
     it('is true when search or a select is set', function() {
       expect(hasActiveFilters(Object.assign(emptyFilters(), { search: 'dash' }))).toBe(true)
-      expect(hasActiveFilters(Object.assign(emptyFilters(), { status: 'New' }))).toBe(true)
+      expect(hasActiveFilters(Object.assign(emptyFilters(), { status: ['New'] }))).toBe(true)
     })
   })
 
@@ -82,14 +83,19 @@ describe('bu-feedback-table helpers', function() {
     ]
 
     it('filters by type, status, priority, component, and source', function() {
-      expect(filterIssues(rows, Object.assign(emptyFilters(), { issueType: 'Bug' })).map(function(i) { return i.key })).toEqual(['A'])
-      expect(filterIssues(rows, Object.assign(emptyFilters(), { status: 'Done' })).map(function(i) { return i.key })).toEqual(['B'])
-      expect(filterIssues(rows, Object.assign(emptyFilters(), { component: 'Serving' })).map(function(i) { return i.key })).toEqual(['B'])
-      expect(filterIssues(rows, Object.assign(emptyFilters(), { source: 'AIBU_Feedback' })).map(function(i) { return i.key })).toEqual(['A'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { issueType: ['Bug'] })).map(function(i) { return i.key })).toEqual(['A'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { status: ['Done'] })).map(function(i) { return i.key })).toEqual(['B'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { component: ['Serving'] })).map(function(i) { return i.key })).toEqual(['B'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { source: ['AIBU_Feedback'] })).map(function(i) { return i.key })).toEqual(['A'])
+    })
+
+    it('multi-selects multiple values in a single filter', function() {
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { issueType: ['Bug', 'Feature Request'] })).map(function(i) { return i.key })).toEqual(['A', 'B'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { status: ['New', 'Done'] })).map(function(i) { return i.key })).toEqual(['A', 'B'])
     })
 
     it('combines search with selects', function() {
-      var result = filterIssues(rows, Object.assign(emptyFilters(), { search: 'feature', issueType: 'Bug' }))
+      var result = filterIssues(rows, Object.assign(emptyFilters(), { search: 'feature', issueType: ['Bug'] }))
       expect(result).toEqual([])
     })
   })
@@ -132,6 +138,20 @@ describe('bu-feedback-table helpers', function() {
       var page = paginate([issue()], 99, PAGE_SIZE)
       expect(page.page).toBe(1)
       expect(page.items.length).toBe(1)
+    })
+  })
+
+  describe('toggleFilterValue', function() {
+    it('adds a value when not present', function() {
+      var arr = []
+      toggleFilterValue(arr, 'Bug')
+      expect(arr).toEqual(['Bug'])
+    })
+
+    it('removes a value when already present', function() {
+      var arr = ['Bug', 'Story']
+      toggleFilterValue(arr, 'Bug')
+      expect(arr).toEqual(['Story'])
     })
   })
 

--- a/modules/releases/__tests__/client/plan/bu-feedback-table.test.js
+++ b/modules/releases/__tests__/client/plan/bu-feedback-table.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PAGE_SIZE,
+  emptyFilters,
+  hasActiveFilters,
+  collectFilterOptions,
+  issueMatchesSearch,
+  filterIssues,
+  sortIssues,
+  paginate,
+  sourceShortLabel,
+  typeBadgeClass,
+  statusClasses,
+  priorityDot,
+  formatDate,
+  visibleChips
+} from '../../../client/plan/utils/bu-feedback-table.js'
+
+function issue(overrides) {
+  return Object.assign({
+    key: 'RHOAIENG-1',
+    summary: 'Dashboard filter is broken',
+    issueType: 'Bug',
+    assignee: 'Jane Smith',
+    reporter: 'Alex Lee',
+    priority: 'Major',
+    status: 'New',
+    statusCategory: 'To Do',
+    resolution: 'Unresolved',
+    created: '2026-08-19T12:00:00.000Z',
+    updated: '2026-08-19T13:00:00.000Z',
+    dueDate: null,
+    components: ['AI Core Dashboard'],
+    fixVersions: [],
+    feedbackLabels: ['AIBU_Feedback']
+  }, overrides)
+}
+
+describe('bu-feedback-table helpers', function() {
+  describe('hasActiveFilters', function() {
+    it('is false for empty filters', function() {
+      expect(hasActiveFilters(emptyFilters())).toBe(false)
+    })
+
+    it('is true when search or a select is set', function() {
+      expect(hasActiveFilters(Object.assign(emptyFilters(), { search: 'dash' }))).toBe(true)
+      expect(hasActiveFilters(Object.assign(emptyFilters(), { status: 'New' }))).toBe(true)
+    })
+  })
+
+  describe('collectFilterOptions', function() {
+    it('collects unique sorted values including multi-component issues', function() {
+      var opts = collectFilterOptions([
+        issue({ issueType: 'Bug', components: ['Docs', 'AI Core Dashboard'], feedbackLabels: ['AIBU_Feedback'] }),
+        issue({ key: '2', issueType: 'Feature Request', components: ['Docs'], feedbackLabels: ['AISSA_Feedback'] })
+      ])
+      expect(opts.issueType).toEqual(['Bug', 'Feature Request'])
+      expect(opts.component).toEqual(['AI Core Dashboard', 'Docs'])
+      expect(opts.source).toEqual(['AIBU_Feedback', 'AISSA_Feedback'])
+    })
+  })
+
+  describe('issueMatchesSearch', function() {
+    it('matches key, summary, people, and components', function() {
+      var row = issue()
+      expect(issueMatchesSearch(row, 'RHOAIENG-1')).toBe(true)
+      expect(issueMatchesSearch(row, 'filter')).toBe(true)
+      expect(issueMatchesSearch(row, 'jane')).toBe(true)
+      expect(issueMatchesSearch(row, 'core')).toBe(true)
+      expect(issueMatchesSearch(row, 'unrelated')).toBe(false)
+    })
+
+    it('matches empty search', function() {
+      expect(issueMatchesSearch(issue(), '  ')).toBe(true)
+    })
+  })
+
+  describe('filterIssues', function() {
+    var rows = [
+      issue({ key: 'A', issueType: 'Bug', status: 'New', priority: 'Major', components: ['Docs'], feedbackLabels: ['AIBU_Feedback'] }),
+      issue({ key: 'B', issueType: 'Feature Request', status: 'Done', priority: 'Normal', components: ['Serving'], feedbackLabels: ['AISSA_Feedback'] })
+    ]
+
+    it('filters by type, status, priority, component, and source', function() {
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { issueType: 'Bug' })).map(function(i) { return i.key })).toEqual(['A'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { status: 'Done' })).map(function(i) { return i.key })).toEqual(['B'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { component: 'Serving' })).map(function(i) { return i.key })).toEqual(['B'])
+      expect(filterIssues(rows, Object.assign(emptyFilters(), { source: 'AIBU_Feedback' })).map(function(i) { return i.key })).toEqual(['A'])
+    })
+
+    it('combines search with selects', function() {
+      var result = filterIssues(rows, Object.assign(emptyFilters(), { search: 'feature', issueType: 'Bug' }))
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('sortIssues', function() {
+    it('sorts by created descending by default direction', function() {
+      var rows = [
+        issue({ key: 'OLD', created: '2026-01-01T00:00:00.000Z' }),
+        issue({ key: 'NEW', created: '2026-08-01T00:00:00.000Z' })
+      ]
+      expect(sortIssues(rows, 'created', 'desc').map(function(i) { return i.key })).toEqual(['NEW', 'OLD'])
+      expect(sortIssues(rows, 'created', 'asc').map(function(i) { return i.key })).toEqual(['OLD', 'NEW'])
+    })
+
+    it('sorts components as a joined string', function() {
+      var rows = [
+        issue({ key: 'Z', components: ['Zeta'] }),
+        issue({ key: 'A', components: ['Alpha'] })
+      ]
+      expect(sortIssues(rows, 'component', 'asc').map(function(i) { return i.key })).toEqual(['A', 'Z'])
+    })
+  })
+
+  describe('paginate', function() {
+    it('returns the requested page and range labels', function() {
+      var items = []
+      for (var i = 0; i < 30; i++) items.push(issue({ key: 'K-' + i }))
+      var first = paginate(items, 1, PAGE_SIZE)
+      expect(first.items.length).toBe(25)
+      expect(first.start).toBe(1)
+      expect(first.end).toBe(25)
+      expect(first.pageCount).toBe(2)
+      var second = paginate(items, 2, PAGE_SIZE)
+      expect(second.items.length).toBe(5)
+      expect(second.start).toBe(26)
+      expect(second.end).toBe(30)
+    })
+
+    it('clamps out-of-range pages', function() {
+      var page = paginate([issue()], 99, PAGE_SIZE)
+      expect(page.page).toBe(1)
+      expect(page.items.length).toBe(1)
+    })
+  })
+
+  describe('display helpers', function() {
+    it('shortens feedback source labels', function() {
+      expect(sourceShortLabel('AIBU_Feedback')).toBe('BU')
+      expect(sourceShortLabel('AISSA_Feedback')).toBe('SSA')
+    })
+
+    it('returns type and status badge classes', function() {
+      expect(typeBadgeClass('Bug')).toContain('bg-red-100')
+      expect(typeBadgeClass('Feature Request')).toContain('bg-blue-100')
+      expect(statusClasses('Done')).toContain('bg-green-100')
+      expect(statusClasses('In Progress')).toContain('bg-blue-100')
+    })
+
+    it('maps priority to a dot color', function() {
+      expect(priorityDot('Critical')).toBe('bg-red-500')
+      expect(priorityDot('Major')).toBe('bg-orange-400')
+    })
+
+    it('formats dates and overflow chips', function() {
+      expect(formatDate('2026-08-19T12:00:00.000Z')).toMatch(/Aug 19, 2026/)
+      var chips = visibleChips(['A', 'B', 'C'], 2)
+      expect(chips.shown).toEqual(['A', 'B'])
+      expect(chips.overflow).toBe(1)
+      expect(chips.overflowTitle).toBe('C')
+    })
+  })
+})

--- a/modules/releases/__tests__/server/planning/bu-feedback-issue.test.js
+++ b/modules/releases/__tests__/server/planning/bu-feedback-issue.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+
+var { extractFirstInProgressAt } = require('../../../server/planning/bu-feedback-issue')
+
+describe('extractFirstInProgressAt', function() {
+  it('returns null for null changelog', function() {
+    expect(extractFirstInProgressAt(null)).toBeNull()
+  })
+
+  it('returns null for empty histories', function() {
+    expect(extractFirstInProgressAt({ histories: [] })).toBeNull()
+  })
+
+  it('returns null when no in-progress transition exists', function() {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-06-01T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'New' }]
+        },
+        {
+          created: '2026-06-02T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'Closed' }]
+        }
+      ]
+    }
+    expect(extractFirstInProgressAt(changelog)).toBeNull()
+  })
+
+  it('returns the first In Progress transition timestamp', function() {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-06-01T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'New' }]
+        },
+        {
+          created: '2026-06-05T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'In Progress' }]
+        },
+        {
+          created: '2026-06-10T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'In Review' }]
+        }
+      ]
+    }
+    expect(extractFirstInProgressAt(changelog)).toBe('2026-06-05T12:00:00.000Z')
+  })
+
+  it('handles unsorted histories and picks the earliest', function() {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-06-10T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'In Review' }]
+        },
+        {
+          created: '2026-06-03T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'In Progress' }]
+        }
+      ]
+    }
+    expect(extractFirstInProgressAt(changelog)).toBe('2026-06-03T12:00:00.000Z')
+  })
+
+  it('is case-insensitive on status names', function() {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-06-01T12:00:00.000Z',
+          items: [{ field: 'status', toString: 'IN PROGRESS' }]
+        }
+      ]
+    }
+    expect(extractFirstInProgressAt(changelog)).toBe('2026-06-01T12:00:00.000Z')
+  })
+
+  it('recognises QA, Testing, Development, Coding statuses', function() {
+    var names = ['QA', 'Testing', 'Development', 'Coding']
+    for (var i = 0; i < names.length; i++) {
+      var changelog = {
+        histories: [
+          {
+            created: '2026-06-01T12:00:00.000Z',
+            items: [{ field: 'status', toString: names[i] }]
+          }
+        ]
+      }
+      expect(extractFirstInProgressAt(changelog)).toBe('2026-06-01T12:00:00.000Z')
+    }
+  })
+
+  it('ignores non-status field changes', function() {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-06-01T12:00:00.000Z',
+          items: [{ field: 'assignee', toString: 'In Progress' }]
+        }
+      ]
+    }
+    expect(extractFirstInProgressAt(changelog)).toBeNull()
+  })
+})

--- a/modules/releases/client/plan/components/BuFeedbackExecutiveSummary.vue
+++ b/modules/releases/client/plan/components/BuFeedbackExecutiveSummary.vue
@@ -1,0 +1,149 @@
+<template>
+  <div
+    v-if="summary"
+    class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden"
+    data-testid="bu-feedback-exec-summary"
+  >
+    <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60">
+      <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-200">Executive Summary</h3>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Process-efficiency metrics across all {{ summary.total }} loaded BU / SSA feedback issues</p>
+    </div>
+
+    <div class="px-4 py-4 space-y-4">
+      <ul class="space-y-1.5 text-sm text-gray-700 dark:text-gray-300">
+        <li class="flex items-start gap-2">
+          <span class="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary-500 shrink-0"></span>
+          <span>
+            <strong>Avg Lead Time:</strong>
+            {{ summary.avgLeadTime !== null ? summary.avgLeadTime + ' days' : 'N/A' }}
+            <span class="text-xs text-gray-400 dark:text-gray-500">({{ summary.avgLeadTimeSample }} closed issues)</span>
+          </span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary-500 shrink-0"></span>
+          <span>
+            <strong>Avg Cycle Time:</strong>
+            {{ summary.avgCycleTime !== null ? summary.avgCycleTime + ' days' : 'N/A' }}
+            <span class="text-xs text-gray-400 dark:text-gray-500">({{ summary.avgCycleTimeSample }} issues with dev data)</span>
+          </span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary-500 shrink-0"></span>
+          <span>
+            <strong>Avg Open Issue Age:</strong>
+            {{ summary.avgOpenAge !== null ? summary.avgOpenAge + ' days' : 'N/A' }}
+            <span class="text-xs text-gray-400 dark:text-gray-500">({{ summary.avgOpenAgeSample }} open issues)</span>
+          </span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary-500 shrink-0"></span>
+          <span>
+            <strong>Resolution Rate:</strong> {{ summary.resolutionRate }}%
+            &middot; <strong>90-day Throughput:</strong> {{ summary.throughput }} closed
+          </span>
+        </li>
+        <li v-if="summary.bottlenecks.length" class="flex items-start gap-2">
+          <span class="mt-1.5 w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0"></span>
+          <span>
+            <strong>Top Bottleneck:</strong> {{ summary.bottlenecks[0].component }}
+            ({{ summary.bottlenecks[0].openCount }} open, avg {{ summary.bottlenecks[0].avgAge }}d)
+          </span>
+        </li>
+      </ul>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div class="overflow-x-auto">
+          <table class="w-full text-xs" data-testid="bu-feedback-metrics-table">
+            <thead>
+              <tr class="border-b border-gray-200 dark:border-gray-700">
+                <th class="text-left px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Metric</th>
+                <th class="text-right px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Value</th>
+                <th class="text-right px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Sample</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Avg Lead Time</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ fmt(summary.avgLeadTime, 'days') }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.avgLeadTimeSample }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Avg Cycle Time</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ fmt(summary.avgCycleTime, 'days') }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.avgCycleTimeSample }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Avg Open Age</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ fmt(summary.avgOpenAge, 'days') }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.avgOpenAgeSample }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Resolution Rate</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ summary.resolutionRate }}%</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.total }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Throughput ({{ summary.throughputWindowDays }}d)</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ summary.throughput }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.closedCount }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">WIP (In Progress)</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ summary.wipCount }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.openCount }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Stale Open (&gt;{{ summary.staleThresholdDays }}d)</td>
+                <td class="px-2 py-1.5 text-right font-medium" :class="summary.staleOpenCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ summary.staleOpenCount }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.openCount }}</td>
+              </tr>
+              <tr>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300">Unassigned Open</td>
+                <td class="px-2 py-1.5 text-right font-medium" :class="summary.unassignedOpenCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ summary.unassignedOpenCount }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ summary.openCount }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div v-if="summary.bottlenecks.length" class="overflow-x-auto">
+          <table class="w-full text-xs" data-testid="bu-feedback-bottleneck-table">
+            <thead>
+              <tr class="border-b border-gray-200 dark:border-gray-700">
+                <th class="text-left px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Component Bottleneck</th>
+                <th class="text-right px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Open</th>
+                <th class="text-right px-2 py-1.5 font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Avg Age (d)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+              <tr v-for="b in summary.bottlenecks" :key="b.component">
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300 truncate max-w-[14rem]" :title="b.component">{{ b.component }}</td>
+                <td class="px-2 py-1.5 text-right font-medium text-gray-900 dark:text-gray-100">{{ b.openCount }}</td>
+                <td class="px-2 py-1.5 text-right text-gray-500 dark:text-gray-400">{{ b.avgAge }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { buildExecutiveSummary } from '../utils/bu-feedback-summary.js'
+
+var props = defineProps({
+  issues: { type: Array, default: function() { return [] } }
+})
+
+var summary = computed(function() {
+  if (!props.issues || !props.issues.length) return null
+  return buildExecutiveSummary(props.issues, new Date())
+})
+
+function fmt(value, unit) {
+  if (value === null || value === undefined) return 'N/A'
+  return value + ' ' + unit
+}
+</script>

--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -13,55 +13,42 @@
         />
       </label>
 
-      <select
-        v-model="filters.issueType"
-        aria-label="Filter by type"
-        data-testid="bu-feedback-filter-type"
-        :class="selectClass"
-      >
-        <option value="">All types</option>
-        <option v-for="opt in filterOptions.issueType" :key="opt" :value="opt">{{ opt }}</option>
-      </select>
-
-      <select
-        v-model="filters.status"
-        aria-label="Filter by status"
-        data-testid="bu-feedback-filter-status"
-        :class="selectClass"
-      >
-        <option value="">All statuses</option>
-        <option v-for="opt in filterOptions.status" :key="opt" :value="opt">{{ opt }}</option>
-      </select>
-
-      <select
-        v-model="filters.priority"
-        aria-label="Filter by priority"
-        data-testid="bu-feedback-filter-priority"
-        :class="selectClass"
-      >
-        <option value="">All priorities</option>
-        <option v-for="opt in filterOptions.priority" :key="opt" :value="opt">{{ opt }}</option>
-      </select>
-
-      <select
-        v-model="filters.component"
-        aria-label="Filter by component"
-        data-testid="bu-feedback-filter-component"
-        :class="selectClass"
-      >
-        <option value="">All components</option>
-        <option v-for="opt in filterOptions.component" :key="opt" :value="opt">{{ opt }}</option>
-      </select>
-
-      <select
-        v-model="filters.source"
-        aria-label="Filter by source"
-        data-testid="bu-feedback-filter-source"
-        :class="selectClass"
-      >
-        <option value="">All sources</option>
-        <option v-for="opt in filterOptions.source" :key="opt" :value="opt">{{ sourceShortLabel(opt) }}</option>
-      </select>
+      <div v-for="fd in filterDefs" :key="fd.key" class="relative" :data-testid="'bu-feedback-filter-' + fd.testId">
+        <button
+          type="button"
+          :class="[selectClass, 'inline-flex items-center gap-1.5 cursor-pointer select-none']"
+          :aria-expanded="openDropdown === fd.key"
+          :aria-label="'Filter by ' + fd.label.toLowerCase()"
+          @click.stop="toggleDropdown(fd.key)"
+        >
+          <span>{{ fd.label }}</span>
+          <span
+            v-if="filters[fd.key].length"
+            class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-[10px] font-bold rounded-full bg-primary-600 text-white leading-none"
+          >{{ filters[fd.key].length }}</span>
+          <svg class="w-3.5 h-3.5 shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+        </button>
+        <div
+          v-if="openDropdown === fd.key"
+          class="absolute z-30 mt-1 w-56 max-h-64 overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1"
+          @click.stop
+        >
+          <label
+            v-for="opt in filterOptions[fd.key]"
+            :key="opt"
+            class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+          >
+            <input
+              type="checkbox"
+              :checked="filters[fd.key].indexOf(opt) !== -1"
+              class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+              @change="toggleFilter(fd.key, opt)"
+            />
+            <span class="truncate">{{ fd.displayFn ? fd.displayFn(opt) : opt }}</span>
+          </label>
+          <p v-if="!filterOptions[fd.key].length" class="px-3 py-2 text-xs text-gray-400">No options</p>
+        </div>
+      </div>
 
       <button
         v-if="filtersActive"
@@ -185,6 +172,19 @@
                   <span class="truncate">{{ issue.priority || '—' }}</span>
                 </span>
               </td>
+              <td class="px-3 py-2.5 align-top hidden sm:table-cell text-center whitespace-nowrap">
+                <span
+                  v-if="issue.sfdcCasesCount > 0"
+                  class="inline-flex items-center justify-center min-w-[1.75rem] px-1.5 py-0.5 text-xs font-bold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                  :title="issue.sfdcCasesCount + ' linked SFDC case' + (issue.sfdcCasesCount !== 1 ? 's' : '')"
+                >{{ issue.sfdcCasesCount > 30 ? '30+' : issue.sfdcCasesCount }}</span>
+                <span
+                  v-else-if="issue.hasSfdcCases"
+                  class="inline-block px-1.5 py-0.5 text-[10px] font-semibold rounded bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                  title="Has linked SFDC cases"
+                >SFDC</span>
+                <span v-else class="text-gray-300 dark:text-gray-600">—</span>
+              </td>
               <td class="px-3 py-2.5 align-top hidden lg:table-cell text-gray-500 dark:text-gray-400 whitespace-nowrap">
                 {{ formatDate(issue.created) }}
               </td>
@@ -260,7 +260,7 @@
 </template>
 
 <script setup>
-import { reactive, ref, computed, watch } from 'vue'
+import { reactive, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import {
   PAGE_SIZE,
   emptyFilters,
@@ -270,6 +270,8 @@ import {
   sortIssues,
   paginate,
   sourceShortLabel,
+  sfdcBucketLabel,
+  toggleFilterValue,
   typeBadgeClass,
   statusClasses,
   priorityDot,
@@ -281,7 +283,37 @@ var props = defineProps({
   issues: { type: Array, default: function() { return [] } }
 })
 
-var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-2.5 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 max-w-[11rem]'
+var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-2.5 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500'
+
+var filterDefs = [
+  { key: 'issueType', testId: 'type', label: 'All types' },
+  { key: 'status', testId: 'status', label: 'All statuses' },
+  { key: 'priority', testId: 'priority', label: 'All priorities' },
+  { key: 'component', testId: 'component', label: 'All components' },
+  { key: 'source', testId: 'source', label: 'All sources', displayFn: sourceShortLabel },
+  { key: 'sfdc', testId: 'sfdc', label: 'SFDC cases', displayFn: sfdcBucketLabel }
+]
+
+var openDropdown = ref(null)
+
+function toggleDropdown(key) {
+  openDropdown.value = openDropdown.value === key ? null : key
+}
+
+function toggleFilter(key, value) {
+  toggleFilterValue(filters[key], value)
+}
+
+function closeDropdowns() {
+  openDropdown.value = null
+}
+
+onMounted(function() {
+  document.addEventListener('click', closeDropdowns)
+})
+onBeforeUnmount(function() {
+  document.removeEventListener('click', closeDropdowns)
+})
 
 var columns = [
   { key: 'key', label: 'Key', widthClass: 'w-44' },
@@ -289,6 +321,7 @@ var columns = [
   { key: 'component', label: 'Components', widthClass: 'w-40', hideClass: 'hidden md:table-cell' },
   { key: 'status', label: 'Status', widthClass: 'w-28' },
   { key: 'priority', label: 'Priority', widthClass: 'w-24', hideClass: 'hidden sm:table-cell' },
+  { key: 'hasSfdcCases', label: 'SFDC', widthClass: 'w-14', hideClass: 'hidden sm:table-cell' },
   { key: 'created', label: 'Created', widthClass: 'w-24', hideClass: 'hidden lg:table-cell' }
 ]
 

--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -1,181 +1,327 @@
 <template>
-  <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-    <table class="min-w-full text-sm">
-      <thead>
-        <tr class="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-          <th v-for="col in columns" :key="col.key" class="text-left px-3 py-2 font-semibold text-gray-600 dark:text-gray-300 whitespace-nowrap">
-            <div class="space-y-1">
-              <button class="flex items-center gap-1 hover:text-gray-900 dark:hover:text-gray-100" @click="toggleSort(col.key)">
-                {{ col.label }}
-                <span v-if="sortKey === col.key" class="text-xs">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-              </button>
-              <select
-                v-if="col.filterable"
-                v-model="columnFilters[col.key]"
-                class="block w-full text-xs font-normal bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded px-1.5 py-1 text-gray-600 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+  <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+    <div class="flex flex-wrap items-center gap-2 px-3 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60">
+      <label class="relative min-w-[12rem] flex-1 max-w-sm">
+        <span class="sr-only">Search feedback issues</span>
+        <input
+          v-model="filters.search"
+          type="search"
+          placeholder="Search key, summary, person..."
+          aria-label="Search feedback issues"
+          data-testid="bu-feedback-search"
+          class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md pl-3 pr-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+        />
+      </label>
+
+      <select
+        v-model="filters.issueType"
+        aria-label="Filter by type"
+        data-testid="bu-feedback-filter-type"
+        :class="selectClass"
+      >
+        <option value="">All types</option>
+        <option v-for="opt in filterOptions.issueType" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <select
+        v-model="filters.status"
+        aria-label="Filter by status"
+        data-testid="bu-feedback-filter-status"
+        :class="selectClass"
+      >
+        <option value="">All statuses</option>
+        <option v-for="opt in filterOptions.status" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <select
+        v-model="filters.priority"
+        aria-label="Filter by priority"
+        data-testid="bu-feedback-filter-priority"
+        :class="selectClass"
+      >
+        <option value="">All priorities</option>
+        <option v-for="opt in filterOptions.priority" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <select
+        v-model="filters.component"
+        aria-label="Filter by component"
+        data-testid="bu-feedback-filter-component"
+        :class="selectClass"
+      >
+        <option value="">All components</option>
+        <option v-for="opt in filterOptions.component" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <select
+        v-model="filters.source"
+        aria-label="Filter by source"
+        data-testid="bu-feedback-filter-source"
+        :class="selectClass"
+      >
+        <option value="">All sources</option>
+        <option v-for="opt in filterOptions.source" :key="opt" :value="opt">{{ sourceShortLabel(opt) }}</option>
+      </select>
+
+      <button
+        v-if="filtersActive"
+        type="button"
+        data-testid="bu-feedback-clear-filters"
+        class="px-2.5 py-1.5 text-sm text-primary-600 dark:text-primary-400 hover:underline"
+        @click="clearFilters"
+      >
+        Clear
+      </button>
+
+      <span class="ml-auto text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap" data-testid="bu-feedback-count">
+        <template v-if="paged.total">{{ paged.start }}–{{ paged.end }} of {{ paged.total }}</template>
+        <template v-else>0 issues</template>
+      </span>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table role="table" class="w-full table-fixed text-sm" data-testid="bu-feedback-table">
+        <thead role="rowgroup" class="bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-10">
+          <tr role="row">
+            <th
+              v-for="col in columns"
+              :key="col.key"
+              role="columnheader"
+              :scope="'col'"
+              :aria-sort="sortAria(col.key)"
+              :class="['px-3 py-2.5 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide', col.widthClass, col.hideClass]"
+            >
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 hover:text-gray-800 dark:hover:text-gray-200"
+                @click="toggleSort(col.key)"
               >
-                <option value="">All</option>
-                <option v-for="opt in filterOptions[col.key]" :key="opt" :value="opt">{{ opt }}</option>
-              </select>
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-if="!sortedIssues.length">
-          <td :colspan="columns.length" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">No issues match the current filters</td>
-        </tr>
-        <tr
-          v-for="issue in sortedIssues"
-          :key="issue.key"
-          class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-        >
-          <td class="px-3 py-2 whitespace-nowrap">
-            <a :href="issue.url" target="_blank" rel="noopener" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">{{ issue.key }}</a>
-          </td>
-          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType }}</td>
-          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ (issue.components || []).join(', ') || '—' }}</td>
-          <td class="px-3 py-2 text-gray-700 dark:text-gray-300 max-w-md truncate" :title="issue.summary">{{ issue.summary }}</td>
-          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.assignee }}</td>
-          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.reporter }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">
-            <span class="inline-flex items-center gap-1">
-              <span :class="priorityDot(issue.priority)" class="w-2.5 h-2.5 rounded-full inline-block" />
-              {{ issue.priority }}
-            </span>
-          </td>
-          <td class="px-3 py-2 whitespace-nowrap">
-            <span
-              class="inline-block px-2 py-0.5 text-xs font-medium rounded-full"
-              :class="statusClasses(issue.statusCategory)"
-            >{{ issue.status }}</span>
-          </td>
-          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.resolution }}</td>
-          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.created) }}</td>
-          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.updated) }}</td>
-          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.dueDate ? formatDate(issue.dueDate) : 'None' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">
-            <span
-              v-for="lbl in (issue.feedbackLabels || [])"
-              :key="lbl"
-              class="inline-block px-2 py-0.5 text-xs font-medium rounded-full mr-1"
-              :class="lbl === 'AIBU_Feedback' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'"
-            >{{ lbl }}</span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+                {{ col.label }}
+                <span v-if="sortKey === col.key" class="text-[10px] leading-none">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody role="rowgroup">
+          <tr v-if="!paged.items.length">
+            <td :colspan="columns.length" class="px-4 py-10 text-center text-gray-400 dark:text-gray-500">
+              {{ props.issues.length ? 'No issues match the current filters' : 'No feedback issues found' }}
+            </td>
+          </tr>
+          <template v-for="issue in paged.items" :key="issue.key">
+            <tr
+              role="row"
+              :data-testid="'bu-feedback-row-' + issue.key"
+              class="border-b border-gray-100 dark:border-gray-800 hover:bg-primary-50/40 dark:hover:bg-gray-800/60 cursor-pointer even:bg-gray-50/70 dark:even:bg-gray-800/30"
+              :class="expandedKey === issue.key ? 'bg-primary-50/50 dark:bg-primary-900/10' : ''"
+              @click="toggleExpand(issue.key)"
+            >
+              <td class="px-3 py-2.5 align-top">
+                <div class="flex items-start gap-1.5 min-w-0">
+                  <span class="mt-0.5 text-gray-400 dark:text-gray-500 text-xs shrink-0" aria-hidden="true">
+                    {{ expandedKey === issue.key ? '▾' : '▸' }}
+                  </span>
+                  <div class="min-w-0">
+                    <a
+                      :href="issue.url"
+                      target="_blank"
+                      rel="noopener"
+                      class="text-primary-600 dark:text-primary-400 hover:underline font-medium whitespace-nowrap"
+                      @click.stop
+                    >{{ issue.key }}</a>
+                    <div class="mt-1 flex flex-wrap gap-1">
+                      <span
+                        v-for="lbl in (issue.feedbackLabels || [])"
+                        :key="lbl"
+                        class="inline-block px-1.5 py-0.5 text-[10px] font-semibold rounded"
+                        :class="lbl === 'AIBU_Feedback' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' : 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300'"
+                        :title="lbl"
+                      >{{ sourceShortLabel(lbl) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 align-top min-w-0">
+                <div class="min-w-0">
+                  <span
+                    class="inline-block w-fit max-w-full px-1.5 py-0.5 text-[10px] font-semibold rounded leading-tight"
+                    :class="typeBadgeClass(issue.issueType)"
+                  >{{ issue.issueType || '—' }}</span>
+                  <p class="mt-1 text-gray-900 dark:text-gray-100 leading-snug line-clamp-2" :title="issue.summary">{{ issue.summary }}</p>
+                  <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {{ issue.assignee || 'Unassigned' }}
+                    <span class="md:hidden">
+                      <span v-if="(issue.components || []).length"> · {{ (issue.components || []).join(', ') }}</span>
+                    </span>
+                  </p>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 align-top hidden md:table-cell">
+                <div class="flex flex-wrap gap-1">
+                  <span
+                    v-for="comp in componentChips(issue).shown"
+                    :key="comp"
+                    class="inline-block max-w-[9rem] truncate px-1.5 py-0.5 text-[11px] rounded bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                    :title="comp"
+                  >{{ comp }}</span>
+                  <span
+                    v-if="componentChips(issue).overflow"
+                    class="inline-block px-1.5 py-0.5 text-[11px] rounded bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                    :title="componentChips(issue).overflowTitle"
+                  >+{{ componentChips(issue).overflow }}</span>
+                  <span v-if="!(issue.components || []).length" class="text-gray-400 dark:text-gray-500">—</span>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 align-top">
+                <span
+                  class="inline-block max-w-full truncate px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="statusClasses(issue.statusCategory)"
+                  :title="issue.status"
+                >{{ issue.status }}</span>
+              </td>
+              <td class="px-3 py-2.5 align-top hidden sm:table-cell whitespace-nowrap">
+                <span class="inline-flex items-center gap-1.5 text-gray-700 dark:text-gray-300">
+                  <span :class="priorityDot(issue.priority)" class="w-2 h-2 rounded-full inline-block shrink-0" />
+                  <span class="truncate">{{ issue.priority || '—' }}</span>
+                </span>
+              </td>
+              <td class="px-3 py-2.5 align-top hidden lg:table-cell text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                {{ formatDate(issue.created) }}
+              </td>
+            </tr>
+            <tr v-if="expandedKey === issue.key" class="bg-gray-50 dark:bg-gray-800/40 border-b border-gray-200 dark:border-gray-700">
+              <td :colspan="columns.length" class="px-4 py-3">
+                <dl class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-2 text-xs">
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Assignee</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ issue.assignee || 'Unassigned' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Reporter</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ issue.reporter || '—' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Resolution</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ issue.resolution || '—' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Created</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ formatDate(issue.created) || '—' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Updated</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ formatDate(issue.updated) || '—' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Due date</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ issue.dueDate ? formatDate(issue.dueDate) : 'None' }}</dd>
+                  </div>
+                  <div class="col-span-2">
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Components</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ (issue.components || []).join(', ') || '—' }}</dd>
+                  </div>
+                  <div class="col-span-2">
+                    <dt class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">Fix versions</dt>
+                    <dd class="text-gray-800 dark:text-gray-200 mt-0.5">{{ (issue.fixVersions || []).join(', ') || '—' }}</dd>
+                  </div>
+                </dl>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+
+    <div
+      v-if="paged.pageCount > 1"
+      class="flex items-center justify-between gap-3 px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60"
+    >
+      <button
+        type="button"
+        class="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-600 hover:bg-white dark:hover:bg-gray-800 disabled:opacity-40"
+        :disabled="paged.page <= 1"
+        data-testid="bu-feedback-prev-page"
+        @click="page = paged.page - 1"
+      >
+        Previous
+      </button>
+      <span class="text-xs text-gray-500 dark:text-gray-400">Page {{ paged.page }} of {{ paged.pageCount }}</span>
+      <button
+        type="button"
+        class="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-600 hover:bg-white dark:hover:bg-gray-800 disabled:opacity-40"
+        :disabled="paged.page >= paged.pageCount"
+        data-testid="bu-feedback-next-page"
+        @click="page = paged.page + 1"
+      >
+        Next
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { reactive, ref, computed, watch } from 'vue'
+import {
+  PAGE_SIZE,
+  emptyFilters,
+  hasActiveFilters,
+  collectFilterOptions,
+  filterIssues,
+  sortIssues,
+  paginate,
+  sourceShortLabel,
+  typeBadgeClass,
+  statusClasses,
+  priorityDot,
+  formatDate,
+  visibleChips
+} from '../utils/bu-feedback-table.js'
 
 var props = defineProps({
   issues: { type: Array, default: function() { return [] } }
 })
 
+var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-2.5 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 max-w-[11rem]'
+
 var columns = [
-  { key: 'key', label: 'Key', filterable: false },
-  { key: 'issueType', label: 'Type', filterable: true },
-  { key: 'component', label: 'Component', filterable: true },
-  { key: 'summary', label: 'Summary', filterable: false },
-  { key: 'assignee', label: 'Assignee', filterable: true },
-  { key: 'reporter', label: 'Reporter', filterable: true },
-  { key: 'priority', label: 'Priority', filterable: true },
-  { key: 'status', label: 'Status', filterable: true },
-  { key: 'resolution', label: 'Resolution', filterable: true },
-  { key: 'created', label: 'Created', filterable: false },
-  { key: 'updated', label: 'Updated', filterable: false },
-  { key: 'dueDate', label: 'Due date', filterable: false },
-  { key: 'source', label: 'Source', filterable: true }
+  { key: 'key', label: 'Key', widthClass: 'w-44' },
+  { key: 'summary', label: 'Issue' },
+  { key: 'component', label: 'Components', widthClass: 'w-40', hideClass: 'hidden md:table-cell' },
+  { key: 'status', label: 'Status', widthClass: 'w-28' },
+  { key: 'priority', label: 'Priority', widthClass: 'w-24', hideClass: 'hidden sm:table-cell' },
+  { key: 'created', label: 'Created', widthClass: 'w-24', hideClass: 'hidden lg:table-cell' }
 ]
 
-var columnFilters = ref({
-  issueType: '',
-  component: '',
-  assignee: '',
-  reporter: '',
-  priority: '',
-  status: '',
-  resolution: '',
-  source: ''
-})
-
+var filters = reactive(emptyFilters())
 var sortKey = ref('created')
 var sortDir = ref('desc')
+var page = ref(1)
+var expandedKey = ref(null)
 
 var filterOptions = computed(function() {
-  var opts = {}
-  var filterableKeys = ['issueType', 'component', 'assignee', 'reporter', 'priority', 'status', 'resolution', 'source']
-  for (var ki = 0; ki < filterableKeys.length; ki++) {
-    var key = filterableKeys[ki]
-    var seen = {}
-    var values = []
-    for (var i = 0; i < props.issues.length; i++) {
-      if (key === 'component') {
-        var comps = props.issues[i].components || []
-        for (var ci = 0; ci < comps.length; ci++) {
-          if (comps[ci] && !seen[comps[ci]]) {
-            seen[comps[ci]] = true
-            values.push(comps[ci])
-          }
-        }
-      } else if (key === 'source') {
-        var fbLabels = props.issues[i].feedbackLabels || []
-        for (var si = 0; si < fbLabels.length; si++) {
-          if (fbLabels[si] && !seen[fbLabels[si]]) {
-            seen[fbLabels[si]] = true
-            values.push(fbLabels[si])
-          }
-        }
-      } else {
-        var val = props.issues[i][key] || ''
-        if (val && !seen[val]) {
-          seen[val] = true
-          values.push(val)
-        }
-      }
-    }
-    values.sort()
-    opts[key] = values
-  }
-  return opts
+  return collectFilterOptions(props.issues)
 })
 
-var filteredIssues = computed(function() {
-  return props.issues.filter(function(issue) {
-    var keys = Object.keys(columnFilters.value)
-    for (var i = 0; i < keys.length; i++) {
-      var key = keys[i]
-      var filterVal = columnFilters.value[key]
-      if (!filterVal) continue
-      if (key === 'component') {
-        if (!(issue.components || []).includes(filterVal)) return false
-      } else if (key === 'source') {
-        if (!(issue.feedbackLabels || []).includes(filterVal)) return false
-      } else {
-        if (issue[key] !== filterVal) return false
-      }
-    }
-    return true
-  })
+var filtersActive = computed(function() {
+  return hasActiveFilters(filters)
 })
 
 var sortedIssues = computed(function() {
-  var arr = filteredIssues.value.slice()
-  var key = sortKey.value
-  var dir = sortDir.value === 'asc' ? 1 : -1
-
-  arr.sort(function(a, b) {
-    var aVal = key === 'component' ? (a.components || []).join(', ') : key === 'source' ? (a.feedbackLabels || []).join(', ') : (a[key] || '')
-    var bVal = key === 'component' ? (b.components || []).join(', ') : key === 'source' ? (b.feedbackLabels || []).join(', ') : (b[key] || '')
-    if (aVal < bVal) return -1 * dir
-    if (aVal > bVal) return 1 * dir
-    return 0
-  })
-  return arr
+  return sortIssues(filterIssues(props.issues, filters), sortKey.value, sortDir.value)
 })
+
+var paged = computed(function() {
+  return paginate(sortedIssues.value, page.value, PAGE_SIZE)
+})
+
+watch(filters, function() {
+  page.value = 1
+  expandedKey.value = null
+}, { deep: true })
+
+function clearFilters() {
+  Object.assign(filters, emptyFilters())
+}
 
 function toggleSort(key) {
   if (sortKey.value === key) {
@@ -184,29 +330,19 @@ function toggleSort(key) {
     sortKey.value = key
     sortDir.value = key === 'created' || key === 'updated' ? 'desc' : 'asc'
   }
+  page.value = 1
 }
 
-function priorityDot(priority) {
-  var p = (priority || '').toLowerCase()
-  if (p === 'blocker' || p === 'critical') return 'bg-red-500'
-  if (p === 'major') return 'bg-orange-400'
-  if (p === 'normal' || p === 'minor') return 'bg-yellow-400'
-  if (p === 'trivial') return 'bg-green-400'
-  if (p === 'undefined') return 'bg-gray-300 dark:bg-gray-500'
-  return 'bg-gray-300 dark:bg-gray-500'
+function sortAria(key) {
+  if (sortKey.value !== key) return 'none'
+  return sortDir.value === 'asc' ? 'ascending' : 'descending'
 }
 
-function statusClasses(category) {
-  var c = (category || '').toLowerCase()
-  if (c === 'done') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (c === 'in progress') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+function toggleExpand(key) {
+  expandedKey.value = expandedKey.value === key ? null : key
 }
 
-function formatDate(iso) {
-  if (!iso) return ''
-  var d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+function componentChips(issue) {
+  return visibleChips(issue.components)
 }
 </script>

--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -176,8 +176,8 @@
                 <span
                   v-if="issue.sfdcCasesCount > 0"
                   class="inline-flex items-center justify-center min-w-[1.75rem] px-1.5 py-0.5 text-xs font-bold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
-                  :title="issue.sfdcCasesCount + ' linked SFDC case' + (issue.sfdcCasesCount !== 1 ? 's' : '')"
-                >{{ issue.sfdcCasesCount > 30 ? '30+' : issue.sfdcCasesCount }}</span>
+                  :title="sfdcBucketLabel(sfdcBucketId(issue.sfdcCasesCount)) + ' SFDC cases'"
+                >{{ sfdcBucketLabel(sfdcBucketId(issue.sfdcCasesCount)) }}</span>
                 <span
                   v-else-if="issue.hasSfdcCases"
                   class="inline-block px-1.5 py-0.5 text-[10px] font-semibold rounded bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
@@ -270,6 +270,7 @@ import {
   sortIssues,
   paginate,
   sourceShortLabel,
+  sfdcBucketId,
   sfdcBucketLabel,
   toggleFilterValue,
   typeBadgeClass,

--- a/modules/releases/client/plan/utils/bu-feedback-summary.js
+++ b/modules/releases/client/plan/utils/bu-feedback-summary.js
@@ -1,0 +1,146 @@
+var MS_PER_DAY = 86400000
+var STALE_THRESHOLD_DAYS = 90
+var THROUGHPUT_WINDOW_DAYS = 90
+
+function daysBetween(isoA, isoB) {
+  var a = new Date(isoA)
+  var b = new Date(isoB)
+  if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return null
+  return Math.abs(b - a) / MS_PER_DAY
+}
+
+function round1(n) {
+  return Math.round(n * 10) / 10
+}
+
+function isClosed(issue) {
+  if (issue.statusCategory === 'Done') return true
+  return issue.resolution && issue.resolution !== 'Unresolved'
+}
+
+function closedDate(issue) {
+  return issue.resolved || issue.updated || null
+}
+
+/**
+ * Build an executive summary object from the full BU/SSA feedback issue list.
+ *
+ * @param {Array} issues - Array of feedback issues from the API
+ * @param {Date|string} now - Current timestamp (injectable for testing)
+ * @returns {object} summary with metrics, bullets, and bottleneck data
+ */
+export function buildExecutiveSummary(issues, now) {
+  var nowMs = new Date(now).getTime()
+  var cutoffMs = nowMs - THROUGHPUT_WINDOW_DAYS * MS_PER_DAY
+
+  var total = issues.length
+  var closed = []
+  var open = []
+  var wipCount = 0
+  var unassignedOpenCount = 0
+
+  for (var i = 0; i < total; i++) {
+    var issue = issues[i]
+    if (isClosed(issue)) {
+      closed.push(issue)
+    } else {
+      open.push(issue)
+      if (issue.statusCategory === 'In Progress') wipCount++
+      if (!issue.assignee || issue.assignee === 'Unassigned') unassignedOpenCount++
+    }
+  }
+
+  var leadTimeSamples = []
+  var cycleTimeSamples = []
+  var throughputCount = 0
+
+  for (var ci = 0; ci < closed.length; ci++) {
+    var c = closed[ci]
+    var cDate = closedDate(c)
+    if (c.created && cDate) {
+      var lt = daysBetween(c.created, cDate)
+      if (lt !== null) leadTimeSamples.push(lt)
+    }
+    if (c.inProgressAt && cDate) {
+      var ct = daysBetween(c.inProgressAt, cDate)
+      if (ct !== null) cycleTimeSamples.push(ct)
+    }
+    if (cDate && new Date(cDate).getTime() >= cutoffMs) {
+      throughputCount++
+    }
+  }
+
+  var openAgeSamples = []
+  var staleOpenCount = 0
+
+  for (var oi = 0; oi < open.length; oi++) {
+    var o = open[oi]
+    if (o.created) {
+      var age = daysBetween(o.created, now)
+      if (age !== null) {
+        openAgeSamples.push(age)
+        if (age >= STALE_THRESHOLD_DAYS) staleOpenCount++
+      }
+    }
+  }
+
+  var avgLeadTime = leadTimeSamples.length
+    ? round1(leadTimeSamples.reduce(function(s, v) { return s + v }, 0) / leadTimeSamples.length)
+    : null
+  var avgCycleTime = cycleTimeSamples.length
+    ? round1(cycleTimeSamples.reduce(function(s, v) { return s + v }, 0) / cycleTimeSamples.length)
+    : null
+  var avgOpenAge = openAgeSamples.length
+    ? round1(openAgeSamples.reduce(function(s, v) { return s + v }, 0) / openAgeSamples.length)
+    : null
+
+  var resolutionRate = total > 0 ? round1(100 * closed.length / total) : 0
+
+  var componentMap = {}
+  for (var bi = 0; bi < open.length; bi++) {
+    var comps = open[bi].components || []
+    var issueAge = open[bi].created ? daysBetween(open[bi].created, now) : 0
+    for (var bj = 0; bj < comps.length; bj++) {
+      var comp = comps[bj]
+      if (!componentMap[comp]) componentMap[comp] = { name: comp, openCount: 0, totalAge: 0 }
+      componentMap[comp].openCount++
+      componentMap[comp].totalAge += issueAge || 0
+    }
+  }
+
+  var bottlenecks = Object.keys(componentMap).map(function(k) {
+    var entry = componentMap[k]
+    return {
+      component: entry.name,
+      openCount: entry.openCount,
+      avgAge: entry.openCount > 0 ? round1(entry.totalAge / entry.openCount) : 0
+    }
+  })
+
+  bottlenecks.sort(function(a, b) {
+    if (b.openCount !== a.openCount) return b.openCount - a.openCount
+    return b.avgAge - a.avgAge
+  })
+
+  var topBottlenecks = bottlenecks.slice(0, 5)
+
+  return {
+    total: total,
+    closedCount: closed.length,
+    openCount: open.length,
+    avgLeadTime: avgLeadTime,
+    avgLeadTimeSample: leadTimeSamples.length,
+    avgCycleTime: avgCycleTime,
+    avgCycleTimeSample: cycleTimeSamples.length,
+    avgOpenAge: avgOpenAge,
+    avgOpenAgeSample: openAgeSamples.length,
+    resolutionRate: resolutionRate,
+    throughput: throughputCount,
+    throughputWindowDays: THROUGHPUT_WINDOW_DAYS,
+    wipCount: wipCount,
+    staleOpenCount: staleOpenCount,
+    staleThresholdDays: STALE_THRESHOLD_DAYS,
+    unassignedOpenCount: unassignedOpenCount,
+    bottlenecks: topBottlenecks
+  }
+}

--- a/modules/releases/client/plan/utils/bu-feedback-table.js
+++ b/modules/releases/client/plan/utils/bu-feedback-table.js
@@ -1,0 +1,168 @@
+export var PAGE_SIZE = 25
+export var MAX_VISIBLE_COMPONENT_CHIPS = 2
+
+var SOURCE_SHORT = {
+  AIBU_Feedback: 'BU',
+  AISSA_Feedback: 'SSA'
+}
+
+export function emptyFilters() {
+  return {
+    search: '',
+    issueType: '',
+    component: '',
+    priority: '',
+    status: '',
+    source: ''
+  }
+}
+
+export function hasActiveFilters(filters) {
+  if (!filters) return false
+  return !!(filters.search || filters.issueType || filters.component || filters.priority || filters.status || filters.source)
+}
+
+export function uniqueSortedValues(issues, getter) {
+  var seen = {}
+  var values = []
+  for (var i = 0; i < (issues || []).length; i++) {
+    var extracted = getter(issues[i]) || []
+    for (var j = 0; j < extracted.length; j++) {
+      var val = extracted[j]
+      if (val && !seen[val]) {
+        seen[val] = true
+        values.push(val)
+      }
+    }
+  }
+  values.sort()
+  return values
+}
+
+export function collectFilterOptions(issues) {
+  return {
+    issueType: uniqueSortedValues(issues, function(issue) { return issue.issueType ? [issue.issueType] : [] }),
+    component: uniqueSortedValues(issues, function(issue) { return issue.components || [] }),
+    priority: uniqueSortedValues(issues, function(issue) { return issue.priority ? [issue.priority] : [] }),
+    status: uniqueSortedValues(issues, function(issue) { return issue.status ? [issue.status] : [] }),
+    source: uniqueSortedValues(issues, function(issue) { return issue.feedbackLabels || [] })
+  }
+}
+
+export function issueMatchesSearch(issue, query) {
+  var q = (query || '').trim().toLowerCase()
+  if (!q) return true
+  var haystacks = [
+    issue.key,
+    issue.summary,
+    issue.assignee,
+    issue.reporter,
+    issue.issueType,
+    (issue.components || []).join(' '),
+    (issue.feedbackLabels || []).join(' ')
+  ]
+  for (var i = 0; i < haystacks.length; i++) {
+    if ((haystacks[i] || '').toLowerCase().indexOf(q) !== -1) return true
+  }
+  return false
+}
+
+export function filterIssues(issues, filters) {
+  var f = filters || emptyFilters()
+  return (issues || []).filter(function(issue) {
+    if (!issueMatchesSearch(issue, f.search)) return false
+    if (f.issueType && issue.issueType !== f.issueType) return false
+    if (f.priority && issue.priority !== f.priority) return false
+    if (f.status && issue.status !== f.status) return false
+    if (f.component && (issue.components || []).indexOf(f.component) === -1) return false
+    if (f.source && (issue.feedbackLabels || []).indexOf(f.source) === -1) return false
+    return true
+  })
+}
+
+function sortValue(issue, key) {
+  if (key === 'component') return (issue.components || []).join(', ')
+  if (key === 'source') return (issue.feedbackLabels || []).join(', ')
+  return issue[key] || ''
+}
+
+export function sortIssues(issues, sortKey, sortDir) {
+  var arr = (issues || []).slice()
+  var key = sortKey || 'created'
+  var dir = sortDir === 'asc' ? 1 : -1
+  arr.sort(function(a, b) {
+    var aVal = sortValue(a, key)
+    var bVal = sortValue(b, key)
+    if (aVal < bVal) return -1 * dir
+    if (aVal > bVal) return 1 * dir
+    return 0
+  })
+  return arr
+}
+
+export function paginate(items, page, pageSize) {
+  var size = pageSize || PAGE_SIZE
+  var total = (items || []).length
+  var pageCount = Math.max(1, Math.ceil(total / size))
+  var safePage = Math.min(Math.max(1, page || 1), pageCount)
+  var start = (safePage - 1) * size
+  return {
+    page: safePage,
+    pageCount: pageCount,
+    pageSize: size,
+    total: total,
+    start: total ? start + 1 : 0,
+    end: Math.min(start + size, total),
+    items: (items || []).slice(start, start + size)
+  }
+}
+
+export function sourceShortLabel(label) {
+  return SOURCE_SHORT[label] || label
+}
+
+export function typeBadgeClass(issueType) {
+  var t = (issueType || '').toLowerCase()
+  if (t === 'bug') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+  if (t.indexOf('feature') !== -1 || t === 'story' || t === 'rfe') {
+    return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+  }
+  if (t === 'epic') return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
+  if (t === 'task' || t === 'sub-task' || t === 'subtask') {
+    return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+  }
+  return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
+}
+
+export function statusClasses(category) {
+  var c = (category || '').toLowerCase()
+  if (c === 'done') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+  if (c === 'in progress') return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+}
+
+export function priorityDot(priority) {
+  var p = (priority || '').toLowerCase()
+  if (p === 'blocker' || p === 'critical') return 'bg-red-500'
+  if (p === 'major') return 'bg-orange-400'
+  if (p === 'normal' || p === 'minor') return 'bg-yellow-400'
+  if (p === 'trivial') return 'bg-green-400'
+  return 'bg-gray-300 dark:bg-gray-500'
+}
+
+export function formatDate(iso) {
+  if (!iso) return ''
+  var d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export function visibleChips(items, max) {
+  var list = items || []
+  var limit = max || MAX_VISIBLE_COMPONENT_CHIPS
+  return {
+    shown: list.slice(0, limit),
+    overflow: Math.max(0, list.length - limit),
+    overflowTitle: list.slice(limit).join(', ')
+  }
+}

--- a/modules/releases/client/plan/utils/bu-feedback-table.js
+++ b/modules/releases/client/plan/utils/bu-feedback-table.js
@@ -9,17 +9,25 @@ var SOURCE_SHORT = {
 export function emptyFilters() {
   return {
     search: '',
-    issueType: '',
-    component: '',
-    priority: '',
-    status: '',
-    source: ''
+    issueType: [],
+    component: [],
+    priority: [],
+    status: [],
+    source: [],
+    sfdc: []
   }
 }
 
+export var FILTER_KEYS = ['issueType', 'component', 'priority', 'status', 'source', 'sfdc']
+
 export function hasActiveFilters(filters) {
   if (!filters) return false
-  return !!(filters.search || filters.issueType || filters.component || filters.priority || filters.status || filters.source)
+  if (filters.search) return true
+  for (var i = 0; i < FILTER_KEYS.length; i++) {
+    var v = filters[FILTER_KEYS[i]]
+    if (Array.isArray(v) ? v.length > 0 : !!v) return true
+  }
+  return false
 }
 
 export function uniqueSortedValues(issues, getter) {
@@ -45,8 +53,45 @@ export function collectFilterOptions(issues) {
     component: uniqueSortedValues(issues, function(issue) { return issue.components || [] }),
     priority: uniqueSortedValues(issues, function(issue) { return issue.priority ? [issue.priority] : [] }),
     status: uniqueSortedValues(issues, function(issue) { return issue.status ? [issue.status] : [] }),
-    source: uniqueSortedValues(issues, function(issue) { return issue.feedbackLabels || [] })
+    source: uniqueSortedValues(issues, function(issue) { return issue.feedbackLabels || [] }),
+    sfdc: collectSfdcOptions(issues)
   }
+}
+
+export var SFDC_BUCKETS = [
+  { id: '0', label: 'None', min: 0, max: 0 },
+  { id: '1-2', label: '1–2', min: 1, max: 2 },
+  { id: '3-5', label: '3–5', min: 3, max: 5 },
+  { id: '6-10', label: '6–10', min: 6, max: 10 },
+  { id: '11+', label: '11+', min: 11, max: Infinity }
+]
+
+export function sfdcBucketId(count) {
+  var n = count || 0
+  for (var i = 0; i < SFDC_BUCKETS.length; i++) {
+    if (n >= SFDC_BUCKETS[i].min && n <= SFDC_BUCKETS[i].max) return SFDC_BUCKETS[i].id
+  }
+  return '0'
+}
+
+export function sfdcBucketLabel(id) {
+  for (var i = 0; i < SFDC_BUCKETS.length; i++) {
+    if (SFDC_BUCKETS[i].id === id) return SFDC_BUCKETS[i].label
+  }
+  return id
+}
+
+export function collectSfdcOptions(issues) {
+  var seen = {}
+  for (var i = 0; i < (issues || []).length; i++) {
+    var count = issues[i].sfdcCasesCount || (issues[i].hasSfdcCases ? 1 : 0)
+    seen[sfdcBucketId(count)] = true
+  }
+  var opts = []
+  for (var j = 0; j < SFDC_BUCKETS.length; j++) {
+    if (seen[SFDC_BUCKETS[j].id]) opts.push(SFDC_BUCKETS[j].id)
+  }
+  return opts
 }
 
 export function issueMatchesSearch(issue, query) {
@@ -67,15 +112,32 @@ export function issueMatchesSearch(issue, query) {
   return false
 }
 
+function matchesMulti(selected, value) {
+  if (!selected || !selected.length) return true
+  return selected.indexOf(value) !== -1
+}
+
+function matchesMultiArray(selected, values) {
+  if (!selected || !selected.length) return true
+  for (var i = 0; i < (values || []).length; i++) {
+    if (selected.indexOf(values[i]) !== -1) return true
+  }
+  return false
+}
+
 export function filterIssues(issues, filters) {
   var f = filters || emptyFilters()
   return (issues || []).filter(function(issue) {
     if (!issueMatchesSearch(issue, f.search)) return false
-    if (f.issueType && issue.issueType !== f.issueType) return false
-    if (f.priority && issue.priority !== f.priority) return false
-    if (f.status && issue.status !== f.status) return false
-    if (f.component && (issue.components || []).indexOf(f.component) === -1) return false
-    if (f.source && (issue.feedbackLabels || []).indexOf(f.source) === -1) return false
+    if (!matchesMulti(f.issueType, issue.issueType)) return false
+    if (!matchesMulti(f.priority, issue.priority)) return false
+    if (!matchesMulti(f.status, issue.status)) return false
+    if (!matchesMultiArray(f.component, issue.components)) return false
+    if (!matchesMultiArray(f.source, issue.feedbackLabels)) return false
+    if (f.sfdc && f.sfdc.length) {
+      var count = issue.sfdcCasesCount || (issue.hasSfdcCases ? 1 : 0)
+      if (f.sfdc.indexOf(sfdcBucketId(count)) === -1) return false
+    }
     return true
   })
 }
@@ -83,6 +145,7 @@ export function filterIssues(issues, filters) {
 function sortValue(issue, key) {
   if (key === 'component') return (issue.components || []).join(', ')
   if (key === 'source') return (issue.feedbackLabels || []).join(', ')
+  if (key === 'hasSfdcCases') return issue.sfdcCasesCount || (issue.hasSfdcCases ? 1 : 0)
   return issue[key] || ''
 }
 
@@ -114,6 +177,15 @@ export function paginate(items, page, pageSize) {
     start: total ? start + 1 : 0,
     end: Math.min(start + size, total),
     items: (items || []).slice(start, start + size)
+  }
+}
+
+export function toggleFilterValue(arr, value) {
+  var idx = arr.indexOf(value)
+  if (idx === -1) {
+    arr.push(value)
+  } else {
+    arr.splice(idx, 1)
   }
 }
 

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -69,7 +69,7 @@
       {{ warning }}
     </div>
 
-    <BuFeedbackExecutiveSummary v-if="issues.length" :issues="issues" />
+    <BuFeedbackExecutiveSummary v-if="activeView === 'feedback' && issues.length" :issues="issues" />
 
     <BuFeedbackTable v-if="issues.length || (!loading && !error)" :issues="issues" />
   </div>

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="space-y-4">
-    <div class="flex items-center justify-between">
+    <div class="flex items-start justify-between gap-4">
       <div>
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Field and BU Feedback</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-          Issues labeled <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AIBU_Feedback</code> or <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AISSA_Feedback</code> from Jira, ordered by creation date.
+          Jira issues labeled
+          <span class="inline-block px-1.5 py-0.5 text-[11px] font-semibold rounded bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" title="AIBU_Feedback">BU</span>
+          or
+          <span class="inline-block px-1.5 py-0.5 text-[11px] font-semibold rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="AISSA_Feedback">SSA</span>.
+          Click a row for reporter, resolution, and dates.
         </p>
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-3 shrink-0">
         <span v-if="fetchedAt" class="text-xs text-gray-400 dark:text-gray-500">
           {{ issues.length }} issue{{ issues.length !== 1 ? 's' : '' }}
         </span>
@@ -31,6 +35,8 @@
       {{ warning }}
     </div>
 
+    <BuFeedbackExecutiveSummary v-if="issues.length" :issues="issues" />
+
     <BuFeedbackTable v-if="issues.length || (!loading && !error)" :issues="issues" />
   </div>
 </template>
@@ -38,6 +44,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
+import BuFeedbackExecutiveSummary from '../components/BuFeedbackExecutiveSummary.vue'
 import BuFeedbackTable from '../components/BuFeedbackTable.vue'
 
 var issues = ref([])

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -2,21 +2,53 @@
   <div class="space-y-4">
     <div class="flex items-start justify-between gap-4">
       <div>
-        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Field and BU Feedback</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {{ activeView === 'feedback' ? 'Field and BU Feedback' : 'SFDC Issues' }}
+        </h2>
+        <p v-if="activeView === 'feedback'" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Jira issues labeled
           <span class="inline-block px-1.5 py-0.5 text-[11px] font-semibold rounded bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" title="AIBU_Feedback">BU</span>
           or
           <span class="inline-block px-1.5 py-0.5 text-[11px] font-semibold rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="AISSA_Feedback">SSA</span>.
           Click a row for reporter, resolution, and dates.
         </p>
+        <p v-else class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Open issues with linked SFDC cases across AI Engineering projects.
+          Click a row for details.
+        </p>
       </div>
       <div class="flex items-center gap-3 shrink-0">
+        <div class="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-0.5" role="tablist" aria-label="Switch report view">
+          <button
+            role="tab"
+            :aria-selected="activeView === 'feedback'"
+            :class="[
+              'px-3 py-1.5 text-xs font-medium rounded-md transition-colors',
+              activeView === 'feedback'
+                ? 'bg-amber-500 text-white shadow-sm'
+                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+            ]"
+            @click="switchView('feedback')"
+          >BU Feedback</button>
+          <button
+            role="tab"
+            :aria-selected="activeView === 'sfdc'"
+            :class="[
+              'px-3 py-1.5 text-xs font-medium rounded-md transition-colors',
+              activeView === 'sfdc'
+                ? 'bg-amber-500 text-white shadow-sm'
+                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+            ]"
+            @click="switchView('sfdc')"
+          >SFDC Issues</button>
+        </div>
+
         <span v-if="fetchedAt" class="text-xs text-gray-400 dark:text-gray-500">
           {{ issues.length }} issue{{ issues.length !== 1 ? 's' : '' }}
+          <span v-if="cacheAgeLabel"> · {{ cacheAgeLabel }}</span>
         </span>
         <button
-          @click="loadData"
+          @click="forceRefresh"
           :disabled="loading"
           class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
         >
@@ -29,7 +61,9 @@
       {{ error }}
     </div>
 
-    <div v-if="loading && !issues.length" class="text-sm text-gray-500 dark:text-gray-400">Loading BU feedback issues...</div>
+    <div v-if="loading && !issues.length" class="text-sm text-gray-500 dark:text-gray-400">
+      {{ activeView === 'feedback' ? 'Loading BU feedback issues...' : 'Loading SFDC issues...' }}
+    </div>
 
     <div v-if="warning" class="rounded-lg border border-yellow-300 bg-yellow-50 text-yellow-800 px-4 py-3 text-sm">
       {{ warning }}
@@ -42,28 +76,50 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import BuFeedbackExecutiveSummary from '../components/BuFeedbackExecutiveSummary.vue'
 import BuFeedbackTable from '../components/BuFeedbackTable.vue'
 
+var ENDPOINTS = {
+  feedback: '/modules/releases/planning/bu-feedback',
+  sfdc: '/modules/releases/planning/sfdc-issues'
+}
+
+var activeView = ref('feedback')
 var issues = ref([])
 var loading = ref(false)
 var error = ref(null)
 var warning = ref(null)
 var fetchedAt = ref(null)
+var cachedAt = ref(null)
 
-async function loadData() {
+var cacheAgeLabel = computed(function() {
+  if (!cachedAt.value) return null
+  var ageMs = Date.now() - new Date(cachedAt.value).getTime()
+  if (ageMs < 0) return null
+  var mins = Math.floor(ageMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return mins + 'm ago'
+  var hours = Math.floor(mins / 60)
+  if (hours < 24) return hours + 'h ago'
+  return Math.floor(hours / 24) + 'd ago'
+})
+
+async function loadData(refresh) {
   loading.value = true
   error.value = null
   warning.value = null
 
   try {
-    var response = await fetch(getApiBase() + '/modules/releases/planning/bu-feedback')
+    var url = getApiBase() + ENDPOINTS[activeView.value]
+    if (refresh) url += '?refresh=true'
+    var response = await fetch(url)
     if (!response.ok) throw new Error('HTTP ' + response.status)
     var data = await response.json()
     issues.value = data.issues || []
     fetchedAt.value = data.fetchedAt || null
+    cachedAt.value = data.cachedAt || null
     if (data.warning) warning.value = data.warning
   } catch (err) {
     error.value = err.message
@@ -72,5 +128,18 @@ async function loadData() {
   }
 }
 
-onMounted(loadData)
+function switchView(view) {
+  if (activeView.value === view) return
+  activeView.value = view
+  issues.value = []
+  fetchedAt.value = null
+  cachedAt.value = null
+  loadData(false)
+}
+
+function forceRefresh() {
+  loadData(true)
+}
+
+onMounted(function() { loadData(false) })
 </script>

--- a/modules/releases/server/planning/bu-feedback-issue.js
+++ b/modules/releases/server/planning/bu-feedback-issue.js
@@ -1,0 +1,42 @@
+/**
+ * Helpers for extracting process-efficiency timestamps from Jira changelog
+ * on BU/SSA feedback issues.
+ */
+
+var IN_PROGRESS_STATUSES = [
+  'in progress', 'in review', 'review', 'coding',
+  'development', 'in development', 'testing', 'qa'
+]
+
+/**
+ * Walk changelog histories oldest-first and return the ISO timestamp of
+ * the first transition into an in-progress-like status.
+ *
+ * @param {object|null} changelog - Jira issue changelog (from expand=changelog)
+ * @returns {string|null} ISO timestamp or null
+ */
+function extractFirstInProgressAt(changelog) {
+  if (!changelog || !Array.isArray(changelog.histories)) return null
+
+  var histories = changelog.histories.slice().sort(function(a, b) {
+    if (a.created < b.created) return -1
+    if (a.created > b.created) return 1
+    return 0
+  })
+
+  for (var i = 0; i < histories.length; i++) {
+    var items = histories[i].items || []
+    for (var j = 0; j < items.length; j++) {
+      var item = items[j]
+      if (item.field === 'status' && item.toString) {
+        if (IN_PROGRESS_STATUSES.indexOf(item.toString.toLowerCase()) !== -1) {
+          return histories[i].created
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+module.exports = { extractFirstInProgressAt, IN_PROGRESS_STATUSES }

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -28,6 +28,7 @@ const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const healthRoutes = require('./health/health-routes')
 var { buildFeatureReadiness } = require('./feature-readiness')
 var { fetchFeaturesWithTimeout } = require('./feature-query')
+var { extractFirstInProgressAt } = require('./bu-feedback-issue')
 
 const { isValidVersionParam } = require('../version-utils')
 
@@ -497,10 +498,10 @@ module.exports = async function registerPlanningRoutes(router, context) {
    *     summary: List field and BU feedback issues from Jira
    *     tags: [releases-planning]
    *     security: [{ bearerAuth: [] }]
-   *     description: Queries Jira for issues labeled AIBU_Feedback or AISSA_Feedback, deduplicated, ordered by creation date descending.
+   *     description: Queries Jira for issues labeled AIBU_Feedback or AISSA_Feedback, deduplicated, ordered by creation date descending. Each issue includes resolved (resolutiondate) and inProgressAt (first changelog transition into an in-progress status) for process-efficiency metrics.
    *     responses:
    *       200:
-   *         description: Array of BU feedback issues
+   *         description: Array of BU feedback issues with resolved and inProgressAt timestamps
    *       503:
    *         description: Jira client not configured
    */
@@ -513,8 +514,8 @@ module.exports = async function registerPlanningRoutes(router, context) {
 
     try {
       var jql = 'labels IN ("AIBU_Feedback", "AISSA_Feedback") ORDER BY createdDate DESC'
-      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels'
-      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200 })
+      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
+      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200, expand: 'changelog' })
 
       var seen = {}
       var issues = []
@@ -538,6 +539,8 @@ module.exports = async function registerPlanningRoutes(router, context) {
           created: f.created || null,
           updated: f.updated || null,
           dueDate: f.duedate || null,
+          resolved: f.resolutiondate || null,
+          inProgressAt: extractFirstInProgressAt(raw.changelog),
           components: (f.components || []).map(function(c) { return c.name }),
           fixVersions: (f.fixVersions || []).map(function(v) { return v.name }),
           labels: allLabels,

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -498,61 +498,253 @@ module.exports = async function registerPlanningRoutes(router, context) {
    *     summary: List field and BU feedback issues from Jira
    *     tags: [releases-planning]
    *     security: [{ bearerAuth: [] }]
-   *     description: Queries Jira for issues labeled AIBU_Feedback or AISSA_Feedback, deduplicated, ordered by creation date descending. Each issue includes resolved (resolutiondate) and inProgressAt (first changelog transition into an in-progress status) for process-efficiency metrics.
+   *     description: >
+   *       Returns cached BU/SSA feedback issues (AIBU_Feedback / AISSA_Feedback labels).
+   *       Each issue includes resolved (resolutiondate), inProgressAt (first changelog
+   *       transition into an in-progress status) for process-efficiency metrics, and
+   *       hasSfdcCases (boolean, derived via JQL since the field is encrypted at rest).
+   *       Data is cached server-side for 15 minutes. Pass ?refresh=true to force a live
+   *       Jira fetch and update the cache.
+   *     parameters:
+   *       - in: query
+   *         name: refresh
+   *         schema:
+   *           type: string
+   *         description: Set to "true" to bypass cache and fetch live from Jira
    *     responses:
    *       200:
    *         description: Array of BU feedback issues with resolved and inProgressAt timestamps
    *       503:
    *         description: Jira client not configured
    */
+  var BU_FEEDBACK_CACHE_KEY = DATA_PREFIX + '/bu-feedback-cache.json'
+  var SFDC_ISSUES_CACHE_KEY = DATA_PREFIX + '/sfdc-issues-cache.json'
+  var FEEDBACK_LABELS = ['AIBU_Feedback', 'AISSA_Feedback']
+  var SFDC_PROJECTS = [
+    'Red Hat OpenShift AI Engineering',
+    'Red Hat AI Engineering',
+    'Inference Engineering Project',
+    'OpenShift AI Support'
+  ]
+
+  function mapRawIssue(raw, extraFlags) {
+    var f = raw.fields || {}
+    var allLabels = f.labels || []
+    var feedbackLabels = allLabels.filter(function(l) { return FEEDBACK_LABELS.indexOf(l) !== -1 })
+    var issue = {
+      key: raw.key,
+      summary: f.summary || '',
+      issueType: f.issuetype ? f.issuetype.name : '',
+      assignee: f.assignee ? f.assignee.displayName : 'Unassigned',
+      reporter: f.reporter ? f.reporter.displayName : '',
+      priority: f.priority ? f.priority.name : '',
+      status: f.status ? f.status.name : '',
+      statusCategory: f.status && f.status.statusCategory ? f.status.statusCategory.name : '',
+      resolution: f.resolution ? f.resolution.name : 'Unresolved',
+      created: f.created || null,
+      updated: f.updated || null,
+      dueDate: f.duedate || null,
+      resolved: f.resolutiondate || null,
+      inProgressAt: extractFirstInProgressAt(raw.changelog),
+      components: (f.components || []).map(function(c) { return c.name }),
+      fixVersions: (f.fixVersions || []).map(function(v) { return v.name }),
+      labels: allLabels,
+      feedbackLabels: feedbackLabels,
+      url: 'https://issues.redhat.com/browse/' + raw.key
+    }
+    if (extraFlags) Object.assign(issue, extraFlags)
+    return issue
+  }
+
+  function deduplicateRaw(rawIssues) {
+    var seen = {}
+    var result = []
+    for (var i = 0; i < rawIssues.length; i++) {
+      if (!seen[rawIssues[i].key]) {
+        seen[rawIssues[i].key] = true
+        result.push(rawIssues[i])
+      }
+    }
+    return result
+  }
+
+  async function fetchKeySet(jql) {
+    try {
+      var issues = await jiraClient.fetchAllJqlResults(jql, 'key', { maxResults: 500 })
+      var keys = {}
+      for (var i = 0; i < issues.length; i++) keys[issues[i].key] = true
+      return keys
+    } catch (err) {
+      console.warn('[releases/planning] Key-set lookup failed:', err.message)
+      return {}
+    }
+  }
+
+  async function fetchBuFeedbackFromJira() {
+    var jql = 'labels IN ("AIBU_Feedback", "AISSA_Feedback") ORDER BY createdDate DESC'
+    var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
+
+    var rawPromise = jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200, expand: 'changelog' })
+    var sfdcPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND "SFDC Cases Counter" is not EMPTY')
+    var rawIssues = deduplicateRaw(await rawPromise)
+    var sfdcKeys = await sfdcPromise
+
+    var issues = rawIssues.map(function(raw) {
+      return mapRawIssue(raw, { hasSfdcCases: !!sfdcKeys[raw.key] })
+    })
+
+    var payload = { issues: issues, fetchedAt: new Date().toISOString(), cachedAt: new Date().toISOString() }
+    await writeToStorage(BU_FEEDBACK_CACHE_KEY, payload)
+    return payload
+  }
+
+  async function fetchSfdcCountMap(scopeJql) {
+    var THRESHOLDS = []
+    var i
+    for (i = 1; i <= 20; i++) THRESHOLDS.push(i)
+    THRESHOLDS.push(30, 50)
+
+    var bucketSets = {}
+    var promises = THRESHOLDS.map(function(t) {
+      var jql = scopeJql + ' AND SFDC_Cases_Counter >= ' + t
+      return jiraClient.fetchAllJqlResults(jql, 'key', { maxResults: 500 })
+        .then(function(issues) {
+          var set = {}
+          for (var j = 0; j < issues.length; j++) set[issues[j].key] = true
+          bucketSets[t] = set
+        })
+        .catch(function(err) {
+          console.warn('[releases/planning] SFDC count threshold ' + t + ' failed:', err.message)
+          bucketSets[t] = {}
+        })
+    })
+    await Promise.all(promises)
+
+    var countMap = {}
+    var allKeys = Object.keys(bucketSets[1] || {})
+    for (var k = 0; k < allKeys.length; k++) {
+      var key = allKeys[k]
+      var count = 1
+      for (var ti = 1; ti < THRESHOLDS.length; ti++) {
+        if (bucketSets[THRESHOLDS[ti]] && bucketSets[THRESHOLDS[ti]][key]) {
+          count = THRESHOLDS[ti]
+        } else {
+          break
+        }
+      }
+      countMap[key] = count
+    }
+    return countMap
+  }
+
+  async function fetchSfdcIssuesFromJira() {
+    var projectList = SFDC_PROJECTS.map(function(p) { return '"' + p + '"' }).join(', ')
+    var scopeJql = 'project IN (' + projectList + ') AND "SFDC Cases Counter" is not EMPTY'
+    var jql = scopeJql + ' ORDER BY priority DESC, createdDate DESC'
+    var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
+
+    var rawPromise = jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 500, expand: 'changelog' })
+    var feedbackPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND "SFDC Cases Counter" is not EMPTY')
+    var countMapPromise = fetchSfdcCountMap(scopeJql)
+    var rawIssues = deduplicateRaw(await rawPromise)
+    var feedbackKeys = await feedbackPromise
+    var countMap = await countMapPromise
+
+    var issues = rawIssues.map(function(raw) {
+      return mapRawIssue(raw, {
+        hasSfdcCases: true,
+        hasFeedbackLabel: !!feedbackKeys[raw.key],
+        sfdcCasesCount: countMap[raw.key] || 0
+      })
+    })
+
+    var payload = { issues: issues, fetchedAt: new Date().toISOString(), cachedAt: new Date().toISOString() }
+    await writeToStorage(SFDC_ISSUES_CACHE_KEY, payload)
+    return payload
+  }
+
   router.get('/bu-feedback', requireAuth, requireScope('releases:read'), async function(req, res) {
     if (!jiraClient) {
       return res.json({ issues: [], fetchedAt: new Date().toISOString(), warning: 'Jira not configured' })
     }
 
-    var FEEDBACK_LABELS = ['AIBU_Feedback', 'AISSA_Feedback']
+    var forceRefresh = req.query.refresh === 'true'
 
     try {
-      var jql = 'labels IN ("AIBU_Feedback", "AISSA_Feedback") ORDER BY createdDate DESC'
-      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
-      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200, expand: 'changelog' })
-
-      var seen = {}
-      var issues = []
-      for (var i = 0; i < rawIssues.length; i++) {
-        var raw = rawIssues[i]
-        if (seen[raw.key]) continue
-        seen[raw.key] = true
-        var f = raw.fields || {}
-        var allLabels = f.labels || []
-        var feedbackLabels = allLabels.filter(function(l) { return FEEDBACK_LABELS.indexOf(l) !== -1 })
-        issues.push({
-          key: raw.key,
-          summary: f.summary || '',
-          issueType: f.issuetype ? f.issuetype.name : '',
-          assignee: f.assignee ? f.assignee.displayName : 'Unassigned',
-          reporter: f.reporter ? f.reporter.displayName : '',
-          priority: f.priority ? f.priority.name : '',
-          status: f.status ? f.status.name : '',
-          statusCategory: f.status && f.status.statusCategory ? f.status.statusCategory.name : '',
-          resolution: f.resolution ? f.resolution.name : 'Unresolved',
-          created: f.created || null,
-          updated: f.updated || null,
-          dueDate: f.duedate || null,
-          resolved: f.resolutiondate || null,
-          inProgressAt: extractFirstInProgressAt(raw.changelog),
-          components: (f.components || []).map(function(c) { return c.name }),
-          fixVersions: (f.fixVersions || []).map(function(v) { return v.name }),
-          labels: allLabels,
-          feedbackLabels: feedbackLabels,
-          url: 'https://issues.redhat.com/browse/' + raw.key
-        })
+      if (!forceRefresh) {
+        var cached = await readFromStorage(BU_FEEDBACK_CACHE_KEY)
+        if (cached && cached.cachedAt) {
+          var age = Date.now() - new Date(cached.cachedAt).getTime()
+          if (age < CACHE_MAX_AGE_MS) {
+            return res.json(cached)
+          }
+        }
       }
 
-      res.json({ issues: issues, fetchedAt: new Date().toISOString() })
+      var payload = await fetchBuFeedbackFromJira()
+      res.json(payload)
     } catch (err) {
       console.error('[releases/planning] BU feedback query failed:', err.message)
+      var stale = await readFromStorage(BU_FEEDBACK_CACHE_KEY)
+      if (stale && stale.issues) {
+        stale.warning = 'Showing cached data — live refresh failed: ' + err.message
+        return res.json(stale)
+      }
       res.status(500).json({ error: 'Failed to fetch BU feedback issues' })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/planning/sfdc-issues:
+   *   get:
+   *     summary: List open SFDC-linked issues from AI Engineering projects
+   *     tags: [releases-planning]
+   *     security: [{ bearerAuth: [] }]
+   *     description: >
+   *       Returns issues (any status) with SFDC Cases Counter populated from RHOAIENG,
+   *       RHAIENG, INFERENG, and RHOAISUP projects. Each issue includes hasFeedbackLabel
+   *       (boolean) indicating overlap with the BU feedback report. Cached for 15 minutes.
+   *     parameters:
+   *       - in: query
+   *         name: refresh
+   *         schema:
+   *           type: string
+   *         description: Set to "true" to bypass cache and fetch live from Jira
+   *     responses:
+   *       200:
+   *         description: Array of SFDC-linked issues
+   *       503:
+   *         description: Jira client not configured
+   */
+  router.get('/sfdc-issues', requireAuth, requireScope('releases:read'), async function(req, res) {
+    if (!jiraClient) {
+      return res.json({ issues: [], fetchedAt: new Date().toISOString(), warning: 'Jira not configured' })
+    }
+
+    var forceRefresh = req.query.refresh === 'true'
+
+    try {
+      if (!forceRefresh) {
+        var cached = await readFromStorage(SFDC_ISSUES_CACHE_KEY)
+        if (cached && cached.cachedAt) {
+          var age = Date.now() - new Date(cached.cachedAt).getTime()
+          if (age < CACHE_MAX_AGE_MS) {
+            return res.json(cached)
+          }
+        }
+      }
+
+      var payload = await fetchSfdcIssuesFromJira()
+      res.json(payload)
+    } catch (err) {
+      console.error('[releases/planning] SFDC issues query failed:', err.message)
+      var stale = await readFromStorage(SFDC_ISSUES_CACHE_KEY)
+      if (stale && stale.issues) {
+        stale.warning = 'Showing cached data — live refresh failed: ' + err.message
+        return res.json(stale)
+      }
+      res.status(500).json({ error: 'Failed to fetch SFDC issues' })
     }
   })
 

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -585,7 +585,7 @@ module.exports = async function registerPlanningRoutes(router, context) {
     var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
 
     var rawPromise = jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200, expand: 'changelog' })
-    var sfdcPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND "SFDC Cases Counter" is not EMPTY')
+    var sfdcPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND SFDC_Cases_Counter is not EMPTY')
     var rawIssues = deduplicateRaw(await rawPromise)
     var sfdcKeys = await sfdcPromise
 
@@ -599,10 +599,7 @@ module.exports = async function registerPlanningRoutes(router, context) {
   }
 
   async function fetchSfdcCountMap(scopeJql) {
-    var THRESHOLDS = []
-    var i
-    for (i = 1; i <= 20; i++) THRESHOLDS.push(i)
-    THRESHOLDS.push(30, 50)
+    var THRESHOLDS = [1, 3, 6, 11, 30]
 
     var bucketSets = {}
     var promises = THRESHOLDS.map(function(t) {
@@ -639,12 +636,12 @@ module.exports = async function registerPlanningRoutes(router, context) {
 
   async function fetchSfdcIssuesFromJira() {
     var projectList = SFDC_PROJECTS.map(function(p) { return '"' + p + '"' }).join(', ')
-    var scopeJql = 'project IN (' + projectList + ') AND "SFDC Cases Counter" is not EMPTY'
+    var scopeJql = 'project IN (' + projectList + ') AND SFDC_Cases_Counter is not EMPTY'
     var jql = scopeJql + ' ORDER BY priority DESC, createdDate DESC'
     var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels,resolutiondate'
 
     var rawPromise = jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 500, expand: 'changelog' })
-    var feedbackPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND "SFDC Cases Counter" is not EMPTY')
+    var feedbackPromise = fetchKeySet('labels IN ("AIBU_Feedback", "AISSA_Feedback") AND SFDC_Cases_Counter is not EMPTY')
     var countMapPromise = fetchSfdcCountMap(scopeJql)
     var rawIssues = deduplicateRaw(await rawPromise)
     var feedbackKeys = await feedbackPromise

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -128,14 +128,15 @@ export const viewOwners = {
   // releases > reports
   'releases/reports/ai-adoption':                  'Saiesh Prabhu',
   'releases/reports/capacity-commitment':          'Alex Corvin',
-  'releases/reports/rhoai-component-architectures': 'Waldemar Znoinski',
   'releases/reports/cve-sustaining':               'Saiesh Prabhu',
   'releases/reports/feature-pressure':             'Dimitri Saridakis',
   'releases/reports/program-hygiene':              'Alex Corvin',
   'releases/reports/release-readiness':            'Arthy Loganathan',
+  'releases/reports/rhoai-component-architectures': 'Waldemar Znoinski',
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -411,7 +411,7 @@ test.describe('Releases Field and BU Feedback @releases', () => {
     await expect(page.locator('h2', { hasText: 'Field and BU Feedback' })).toBeVisible();
     await expect(page.getByTestId('bu-feedback-search')).toBeVisible();
     await expect(page.getByTestId('bu-feedback-filter-status')).toBeVisible();
-    await expect(page.getByLabel('Filter by component')).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-filter-component')).toBeVisible();
 
     const table = page.getByTestId('bu-feedback-table');
     await expect(table).toBeVisible();

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -453,6 +453,52 @@ test.describe('Releases Field and BU Feedback @releases', () => {
 
     expect(page.errors).toHaveLength(0);
   });
+
+  test('toggle switch between BU Feedback and SFDC Issues views', async ({ page }) => {
+    await page.goto('/#/releases/plan?tab=bu-feedback');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('h2', { hasText: 'Field and BU Feedback' })).toBeVisible();
+    const sfdcTab = page.locator('button[role="tab"]', { hasText: 'SFDC Issues' });
+    await expect(sfdcTab).toBeVisible();
+
+    await sfdcTab.click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('h2', { hasText: 'SFDC Issues' })).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-table')).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('sfdc-issues API returns issues with sfdcCasesCount', async ({ request }) => {
+    const apiResponse = await request.get('/api/modules/releases/planning/sfdc-issues');
+    expect(apiResponse.ok()).toBe(true);
+    const body = await apiResponse.json();
+    expect(body).toHaveProperty('issues');
+    expect(Array.isArray(body.issues)).toBe(true);
+    if (body.issues.length > 0) {
+      expect(body.issues[0]).toHaveProperty('sfdcCasesCount');
+      expect(body.issues[0]).toHaveProperty('hasFeedbackLabel');
+    }
+  });
+
+  test('Executive Summary is hidden in SFDC view', async ({ page }) => {
+    await page.goto('/#/releases/plan?tab=bu-feedback');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const sfdcTab = page.locator('button[role="tab"]', { hasText: 'SFDC Issues' });
+    await sfdcTab.click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.getByTestId('bu-feedback-exec-summary')).toHaveCount(0);
+
+    expect(page.errors).toHaveLength(0);
+  });
 });
 
 /**

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -370,6 +370,92 @@ test.describe('Releases PM Hub @releases', () => {
 });
 
 /**
+ * Field and BU Feedback (Plan tab)
+ *
+ * Verify the Field and BU Feedback tab loads under Plan, renders the compact
+ * table chrome (search + filters), and that the planning API responds.
+ */
+test.describe('Releases Field and BU Feedback @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should show Field and BU Feedback tab under Plan', async ({ page }) => {
+    await page.goto('/#/releases/plan');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const feedbackTab = page.locator('button', { hasText: 'Field and BU Feedback' });
+    await expect(feedbackTab).toBeVisible();
+
+    await feedbackTab.click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('h2', { hasText: 'Field and BU Feedback' })).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-search')).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-table')).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-filter-type')).toBeVisible();
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('Field and BU Feedback deep link loads compact table chrome', async ({ page }) => {
+    await page.goto('/#/releases/plan?tab=bu-feedback');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('h2', { hasText: 'Field and BU Feedback' })).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-search')).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-filter-status')).toBeVisible();
+    await expect(page.getByLabel('Filter by component')).toBeVisible();
+
+    const table = page.getByTestId('bu-feedback-table');
+    await expect(table).toBeVisible();
+    await expect(page.locator('thead th', { hasText: 'Issue' }).first()).toBeVisible();
+    await expect(page.locator('thead th', { hasText: 'Status' }).first()).toBeVisible();
+    await expect(page.locator('thead select')).toHaveCount(0);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('bu-feedback API returns issues with resolved and inProgressAt fields', async ({ request }) => {
+    const apiResponse = await request.get('/api/modules/releases/planning/bu-feedback');
+    expect(apiResponse.ok()).toBe(true);
+    const body = await apiResponse.json();
+    expect(body).toHaveProperty('issues');
+    expect(Array.isArray(body.issues)).toBe(true);
+    if (body.issues.length > 0) {
+      expect(body.issues[0]).toHaveProperty('resolved');
+      expect(body.issues[0]).toHaveProperty('inProgressAt');
+    }
+  });
+
+  test('Executive Summary renders when issues exist', async ({ page }) => {
+    await page.goto('/#/releases/plan?tab=bu-feedback');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const apiResponse = await page.request.get('/api/modules/releases/planning/bu-feedback');
+    const body = await apiResponse.json();
+    if (!body.issues || body.issues.length === 0) {
+      test.skip();
+      return;
+    }
+
+    const summary = page.getByTestId('bu-feedback-exec-summary');
+    await expect(summary).toBeVisible();
+    await expect(summary.locator('text=Executive Summary')).toBeVisible();
+    await expect(page.getByTestId('bu-feedback-metrics-table')).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+});
+
+/**
  * Draft Plans (Plan tab)
  *
  * Verify the Draft Plans red-pen view loads under Plan (tab + deep link),


### PR DESCRIPTION
## Summary
- **Redesigned Field and BU Feedback table** — fixed horizontal overflow, added expandable rows, multi-select filters, search toolbar, pagination, and responsive column layout
- **Added Executive Summary** — process-efficiency metrics (lead time, cycle time, open issue age, resolution rate, throughput, bottleneck analysis) displayed above the table
- **Added SFDC Issues toggle view** — a new tab that shows open issues with linked SFDC cases across AI Engineering projects (RHOAIENG, RHAIENG, INFERENG, RHOAISUP), with per-issue SFDC case counts derived via JQL threshold queries
- **Server-side caching** — both BU Feedback and SFDC endpoints cache data for 15 minutes with manual refresh support
- **SFDC count-range filters** — filter SFDC issues by case count buckets (None, 1–2, 3–5, 6–10, 11+)

## Test plan
- [x] Unit tests pass (686 tests, 0 failures)
- [x] Lint clean
- [ ] Verify BU Feedback tab loads and displays issues with executive summary
- [ ] Verify SFDC Issues tab loads with case counts in the SFDC column
- [ ] Verify toggle switch between views works and reloads data
- [ ] Verify Refresh button bypasses cache
- [ ] Verify multi-select filters and SFDC count-range filter work correctly
- [ ] Verify pagination and expanded row details


Made with [Cursor](https://cursor.com)