### PR TITLE
fix(releases): make Schedule timeline countdown-card test robust

### DIFF
--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -52,6 +52,7 @@
         <div
           v-for="card in upcomingMilestoneCards"
           :key="card.releaseName + '-' + card.type"
+          data-testid="milestone-countdown-card"
           class="flex-1 min-w-[140px] bg-white dark:bg-gray-800 border rounded-lg text-center py-5 px-4 transition-all hover:shadow-md"
           :class="card.days <= 7
             ? 'border-blue-300 dark:border-blue-600'

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -136,7 +136,6 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
-  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }

--- a/tests/integration/release-timeline.spec.js
+++ b/tests/integration/release-timeline.spec.js
@@ -46,8 +46,11 @@ test.describe('Release Timeline @release-timeline @releases', () => {
     var canvas = page.locator('canvas');
     await expect(canvas).toBeVisible();
 
-    // The milestone countdown cards should be visible above the timeline
-    var countdownCards = page.locator('text=/\\d+ DAYS|Today/');
+    // The milestone countdown cards should be visible above the timeline.
+    // Match the card element directly — the day count and the "DAYS" label are
+    // separate nodes (and "DAYS" is CSS-uppercased "days"), so a text regex like
+    // /\d+ DAYS/ never matches a single element.
+    var countdownCards = page.locator('[data-testid="milestone-countdown-card"]');
     var cardCount = await countdownCards.count();
     expect(cardCount).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

The `release-timeline.spec.js` test **"timeline renders milestone cards above and below axis"** fails intermittently — it failed on 2026-08-21 with `cardCount = 0`, blocking releases integration runs.

## Root cause

The test located the milestone countdown cards with:

```js
page.locator('text=/\\d+ DAYS|Today/')
```

But in the Schedule view each card renders the **day count** and the **"DAYS" label** as *separate* elements, and "DAYS" is CSS-uppercased "days" (so the DOM `textContent` is `"5days…"`, lowercase, no space). No single element's text is ever `"5 DAYS"`, so the regex matches nothing. The test only passed *coincidentally* on days when a demo milestone fell exactly on "Today" (matching the `Today` alternative). Once that stopped being true, it failed — even though the cards render correctly (verified live: 4 cards render for the upcoming RHAI 3.6 milestones).

This is a flaky/brittle test locator, not a data problem.

## Fix

- Add a stable `data-testid="milestone-countdown-card"` to the countdown card in `ScheduleView.vue`.
- Match that testid in the test instead of the fragile text regex, so the assertion reflects the rendered cards regardless of the current date.

## Testing

- Ran the full `release-timeline.spec.js` suite locally against a demo server: **9 passed, 1 skipped** (previously the milestone-cards test failed).
- `npm run lint` clean.

Note: `platform/view-owners/owners.js` was auto-regenerated by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)