### PR TITLE
feat(releases): polish timeline dim lines, captions, and Y layout

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -2,10 +2,112 @@
   "schemaVersion": 1,
   "releases": [
     {
-      "id": "rhai-3.5-ea1",
-      "displayName": "RHAI 3.5 EA1",
-      "fixVersions": ["RHAI-3.5-EA1", "rhai-3.5-ea1"],
-      "productPagesShortname": "rhai",
+      "id": "rhoai-3.5-ea1",
+      "displayName": "3.5 EA1 RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.5-EA1"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-04-10",
+        "featureFreeze": null,
+        "codeFreeze": "2026-05-05",
+        "ga": "2026-06-10"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-03-01T00:00:00Z",
+      "updatedAt": "2026-06-10T00:00:00Z"
+    },
+    {
+      "id": "rhoai-3.5-ea2",
+      "displayName": "3.5 EA2 RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.5-EA2"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-05-15",
+        "featureFreeze": null,
+        "codeFreeze": "2026-06-09",
+        "ga": "2026-07-14"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-04-20T00:00:00Z",
+      "updatedAt": "2026-07-14T00:00:00Z"
+    },
+    {
+      "id": "rhoai-3.5-ga",
+      "displayName": "3.5 GA RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.5-GA", "RHOAI-3.5"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-06-20",
+        "featureFreeze": "2026-07-10",
+        "codeFreeze": "2026-07-17",
+        "ga": "2026-08-18"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-05-28T00:00:00Z",
+      "updatedAt": "2026-07-17T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.5-ea1",
+      "displayName": "3.5 EA1 RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.5-EA1"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-04-14",
+        "featureFreeze": null,
+        "codeFreeze": "2026-05-08",
+        "ga": "2026-06-12"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-03-05T00:00:00Z",
+      "updatedAt": "2026-06-12T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.5-ea2",
+      "displayName": "3.5 EA2 RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.5-EA2"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-05-19",
+        "featureFreeze": null,
+        "codeFreeze": "2026-06-12",
+        "ga": "2026-07-17"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-04-25T00:00:00Z",
+      "updatedAt": "2026-07-17T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.5-ga",
+      "displayName": "3.5 GA RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.5-GA", "RHELAI-3.5"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-06-24",
+        "featureFreeze": "2026-07-14",
+        "codeFreeze": "2026-07-20",
+        "ga": "2026-08-20"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-01T00:00:00Z",
+      "updatedAt": "2026-07-20T00:00:00Z"
+    },
+    {
+      "id": "rhaii-3.5-ea1",
+      "displayName": "3.5 EA1 RHAII RELEASE",
+      "fixVersions": ["RHAII-3.5-EA1"],
+      "productPagesShortname": "rhaii",
       "productPagesVersion": "3.5",
       "milestones": {
         "planningFreeze": "2026-04-17",
@@ -19,89 +121,344 @@
       "updatedAt": "2026-06-17T00:00:00Z"
     },
     {
-      "id": "rhai-3.5-ea2",
-      "displayName": "RHAI 3.5 EA2",
-      "fixVersions": ["RHAI-3.5-EA2", "rhai-3.5-ea2"],
-      "productPagesShortname": "rhai",
+      "id": "rhaii-3.5-ea2",
+      "displayName": "3.5 EA2 RHAII RELEASE",
+      "fixVersions": ["RHAII-3.5-EA2"],
+      "productPagesShortname": "rhaii",
       "productPagesVersion": "3.5",
       "milestones": {
-        "planningFreeze": "2026-05-15",
+        "planningFreeze": "2026-05-22",
         "featureFreeze": null,
-        "codeFreeze": "2026-06-09",
-        "ga": "2026-07-15"
+        "codeFreeze": "2026-06-15",
+        "ga": "2026-07-20"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-04-30T00:00:00Z",
-      "updatedAt": "2026-07-15T00:00:00Z"
+      "createdAt": "2026-04-28T00:00:00Z",
+      "updatedAt": "2026-07-20T00:00:00Z"
     },
     {
-      "id": "rhai-3.5-ga",
-      "displayName": "RHAI 3.5 GA",
-      "fixVersions": ["RHAI-3.5-GA", "rhai-3.5-ga", "RHAI-3.5"],
-      "productPagesShortname": "rhai",
+      "id": "rhaii-3.5-ga",
+      "displayName": "3.5 GA RHAII RELEASE",
+      "fixVersions": ["RHAII-3.5-GA", "RHAII-3.5"],
+      "productPagesShortname": "rhaii",
       "productPagesVersion": "3.5",
       "milestones": {
-        "planningFreeze": "2026-06-24",
+        "planningFreeze": "2026-06-27",
         "featureFreeze": "2026-07-17",
-        "codeFreeze": "2026-07-20",
-        "ga": "2026-08-19"
+        "codeFreeze": "2026-07-23",
+        "ga": "2026-08-22"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-06-04T00:00:00Z",
-      "updatedAt": "2026-07-19T00:00:00Z"
+      "createdAt": "2026-06-05T00:00:00Z",
+      "updatedAt": "2026-07-23T00:00:00Z"
     },
     {
-      "id": "rhai-3.6-ea1",
-      "displayName": "RHAI 3.6 EA1",
-      "fixVersions": ["RHAI-3.6-EA1", "rhai-3.6-ea1"],
-      "productPagesShortname": "rhai",
+      "id": "rhoai-3.6-ea1",
+      "displayName": "3.6 EA1 RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.6-EA1"],
+      "productPagesShortname": "rhoai",
       "productPagesVersion": "3.6",
       "milestones": {
-        "planningFreeze": "2026-07-29",
+        "planningFreeze": "2026-07-28",
         "featureFreeze": null,
-        "codeFreeze": "2026-08-20",
-        "ga": "2026-09-17"
+        "codeFreeze": "2026-08-18",
+        "ga": "2026-09-15"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-06-11T00:00:00Z",
-      "updatedAt": "2026-07-19T00:00:00Z"
+      "createdAt": "2026-06-15T00:00:00Z",
+      "updatedAt": "2026-08-18T00:00:00Z"
     },
     {
-      "id": "rhai-3.6-ea2",
-      "displayName": "RHAI 3.6 EA2",
-      "fixVersions": ["RHAI-3.6-EA2", "rhai-3.6-ea2"],
-      "productPagesShortname": "rhai",
+      "id": "rhoai-3.6-ea2",
+      "displayName": "3.6 EA2 RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.6-EA2"],
+      "productPagesShortname": "rhoai",
       "productPagesVersion": "3.6",
       "milestones": {
-        "planningFreeze": "2026-08-26",
+        "planningFreeze": "2026-08-25",
+        "featureFreeze": null,
+        "codeFreeze": "2026-09-12",
+        "ga": "2026-10-13"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-10T00:00:00Z",
+      "updatedAt": "2026-09-12T00:00:00Z"
+    },
+    {
+      "id": "rhoai-3.6-ga",
+      "displayName": "3.6 GA RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.6-GA", "RHOAI-3.6"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-09-22",
+        "featureFreeze": "2026-10-12",
+        "codeFreeze": "2026-10-16",
+        "ga": "2026-11-17"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-10T00:00:00Z",
+      "updatedAt": "2026-10-16T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.6-ea1",
+      "displayName": "3.6 EA1 RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.6-EA1"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-08-01",
+        "featureFreeze": null,
+        "codeFreeze": "2026-08-22",
+        "ga": "2026-09-18"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-20T00:00:00Z",
+      "updatedAt": "2026-08-22T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.6-ea2",
+      "displayName": "3.6 EA2 RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.6-EA2"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-08-28",
         "featureFreeze": null,
         "codeFreeze": "2026-09-15",
-        "ga": "2026-10-15"
+        "ga": "2026-10-16"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-06-11T00:00:00Z",
-      "updatedAt": "2026-07-19T00:00:00Z"
+      "createdAt": "2026-07-15T00:00:00Z",
+      "updatedAt": "2026-09-15T00:00:00Z"
     },
     {
-      "id": "rhai-3.6-ga",
-      "displayName": "RHAI 3.6 GA",
-      "fixVersions": ["RHAI-3.6-GA", "rhai-3.6-ga", "RHAI-3.6"],
-      "productPagesShortname": "rhai",
+      "id": "rhelai-3.6-ga",
+      "displayName": "3.6 GA RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.6-GA", "RHELAI-3.6"],
+      "productPagesShortname": "rhelai",
       "productPagesVersion": "3.6",
       "milestones": {
-        "planningFreeze": "2026-09-23",
-        "featureFreeze": "2026-10-16",
+        "planningFreeze": "2026-09-25",
+        "featureFreeze": "2026-10-15",
         "codeFreeze": "2026-10-19",
         "ga": "2026-11-19"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-06-11T00:00:00Z",
-      "updatedAt": "2026-07-19T00:00:00Z"
+      "createdAt": "2026-07-15T00:00:00Z",
+      "updatedAt": "2026-10-19T00:00:00Z"
+    },
+    {
+      "id": "rhaii-3.6-ea1",
+      "displayName": "3.6 EA1 RHAII RELEASE",
+      "fixVersions": ["RHAII-3.6-EA1"],
+      "productPagesShortname": "rhaii",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-08-04",
+        "featureFreeze": null,
+        "codeFreeze": "2026-08-25",
+        "ga": "2026-09-22"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-25T00:00:00Z",
+      "updatedAt": "2026-08-25T00:00:00Z"
+    },
+    {
+      "id": "rhaii-3.6-ea2",
+      "displayName": "3.6 EA2 RHAII RELEASE",
+      "fixVersions": ["RHAII-3.6-EA2"],
+      "productPagesShortname": "rhaii",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-09-01",
+        "featureFreeze": null,
+        "codeFreeze": "2026-09-18",
+        "ga": "2026-10-19"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-20T00:00:00Z",
+      "updatedAt": "2026-09-18T00:00:00Z"
+    },
+    {
+      "id": "rhaii-3.6-ga",
+      "displayName": "3.6 GA RHAII RELEASE",
+      "fixVersions": ["RHAII-3.6-GA", "RHAII-3.6"],
+      "productPagesShortname": "rhaii",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-09-28",
+        "featureFreeze": "2026-10-18",
+        "codeFreeze": "2026-10-22",
+        "ga": "2026-11-22"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-20T00:00:00Z",
+      "updatedAt": "2026-10-22T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.5-ea1",
+      "displayName": "3.5 EA1 RHAI RELEASE",
+      "fixVersions": ["RHAI-3.5-EA1"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-04-20",
+        "featureFreeze": null,
+        "codeFreeze": "2026-05-15",
+        "ga": "2026-06-20"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-03-15T00:00:00Z",
+      "updatedAt": "2026-06-20T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.5-ga",
+      "displayName": "3.5 GA RHAI RELEASE",
+      "fixVersions": ["RHAI-3.5-GA", "RHAI-3.5"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.5",
+      "milestones": {
+        "planningFreeze": "2026-07-01",
+        "featureFreeze": "2026-07-20",
+        "codeFreeze": "2026-07-28",
+        "ga": "2026-08-25"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-10T00:00:00Z",
+      "updatedAt": "2026-07-28T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.6-ea1",
+      "displayName": "3.6 EA1 RHAI RELEASE",
+      "fixVersions": ["RHAI-3.6-EA1"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-08-10",
+        "featureFreeze": null,
+        "codeFreeze": "2026-08-28",
+        "ga": "2026-09-25"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-01T00:00:00Z",
+      "updatedAt": "2026-08-28T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.6-ga",
+      "displayName": "3.6 GA RHAI RELEASE",
+      "fixVersions": ["RHAI-3.6-GA", "RHAI-3.6"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-10-01",
+        "featureFreeze": "2026-10-20",
+        "codeFreeze": "2026-10-25",
+        "ga": "2026-11-25"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-07-25T00:00:00Z",
+      "updatedAt": "2026-10-25T00:00:00Z"
+    },
+    {
+      "id": "rhoai-3.7-ea1",
+      "displayName": "3.7 EA1 RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.7-EA1"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.7",
+      "milestones": {
+        "planningFreeze": "2026-11-10",
+        "featureFreeze": null,
+        "codeFreeze": "2026-12-01",
+        "ga": "2027-01-12"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-09-15T00:00:00Z",
+      "updatedAt": "2026-11-10T00:00:00Z"
+    },
+    {
+      "id": "rhoai-3.4-ga",
+      "displayName": "3.4 GA RHOAI RELEASE",
+      "fixVersions": ["RHOAI-3.4-GA", "RHOAI-3.4"],
+      "productPagesShortname": "rhoai",
+      "productPagesVersion": "3.4",
+      "milestones": {
+        "planningFreeze": "2026-01-15",
+        "featureFreeze": "2026-02-10",
+        "codeFreeze": "2026-02-20",
+        "ga": "2026-03-17"
+      },
+      "state": "archived",
+      "source": "product-pages",
+      "createdAt": "2025-11-01T00:00:00Z",
+      "updatedAt": "2026-03-17T00:00:00Z"
+    },
+    {
+      "id": "rhelai-3.7-ea1",
+      "displayName": "3.7 EA1 RHELAI RELEASE",
+      "fixVersions": ["RHELAI-3.7-EA1"],
+      "productPagesShortname": "rhelai",
+      "productPagesVersion": "3.7",
+      "milestones": {
+        "planningFreeze": null,
+        "featureFreeze": null,
+        "codeFreeze": null,
+        "ga": "2027-01-19"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-10-01T00:00:00Z",
+      "updatedAt": "2026-10-01T00:00:00Z"
+    },
+    {
+      "id": "infra-refresh",
+      "displayName": "Infrastructure Refresh",
+      "fixVersions": [],
+      "productPagesShortname": null,
+      "productPagesVersion": null,
+      "milestones": {
+        "planningFreeze": "2026-09-01",
+        "featureFreeze": null,
+        "codeFreeze": "2026-10-01",
+        "ga": null
+      },
+      "state": "active",
+      "source": "manual",
+      "createdAt": "2026-08-01T00:00:00Z",
+      "updatedAt": "2026-08-15T00:00:00Z"
+    },
+    {
+      "id": "infra-security-hardening",
+      "displayName": "Security Hardening",
+      "fixVersions": [],
+      "productPagesShortname": null,
+      "productPagesVersion": null,
+      "milestones": {
+        "planningFreeze": "2026-10-15",
+        "featureFreeze": "2026-11-01",
+        "codeFreeze": "2026-11-15",
+        "ga": null
+      },
+      "state": "active",
+      "source": "manual",
+      "createdAt": "2026-09-15T00:00:00Z",
+      "updatedAt": "2026-10-01T00:00:00Z"
     }
   ]
 }

--- a/modules/releases/__tests__/client/release-timeline.test.js
+++ b/modules/releases/__tests__/client/release-timeline.test.js
@@ -6,6 +6,7 @@ vi.mock('@shared/client/services/api.js', () => ({
 }))
 
 import ReleaseTimeline from '../../client/components/ReleaseTimeline.vue'
+import { productLabel } from '../../client/composables/useReleaseFamily.js'
 
 // Timezone-safe date formatting: uses local components, not toISOString (which is UTC).
 function localIso(y, m, d) {
@@ -63,12 +64,12 @@ describe('ReleaseTimeline', () => {
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var nodes = wrapper.vm.nodes
 
-    expect(nodes).toHaveLength(2)
+    expect(nodes).toHaveLength(4)
 
-    var gaNode = nodes.find(function (n) { return n.isGa })
-    expect(gaNode).toBeTruthy()
-    expect(gaNode.productList).toContain('rhoai')
-    expect(gaNode.productList).toContain('rhelai')
+    var gaNodes = nodes.filter(function (n) { return n.isGa })
+    expect(gaNodes).toHaveLength(2)
+    expect(gaNodes[0].productList).toHaveLength(1)
+    expect(gaNodes[1].productList).toHaveLength(1)
   })
 
   it('skips null milestones', () => {
@@ -119,9 +120,11 @@ describe('ReleaseTimeline', () => {
       makeRelease('newprod-3.5.EA1', { displayName: 'newprod-3.5.EA1', shortname: 'newprod', ga: '2026-06-17' })
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
-    var gaNode = wrapper.vm.nodes.find(function (n) { return n.isGa })
-    expect(gaNode.productList).toContain('rhoai')
-    expect(gaNode.productList).toContain('newprod')
+    var gaNodes = wrapper.vm.nodes.filter(function (n) { return n.isGa })
+    expect(gaNodes).toHaveLength(2)
+    var products = gaNodes.map(function (n) { return n.productList[0] })
+    expect(products).toContain('rhoai')
+    expect(products).toContain('newprod')
   })
 
   it('uses CSS overlay for today marker instead of dataset', () => {
@@ -162,7 +165,7 @@ describe('ReleaseTimeline', () => {
     expect(ds.pointBorderWidth).toBe(0)
   })
 
-  it('shows product badges only on GA nodes', () => {
+  it('all nodes include productList for label rendering', () => {
     var releases = [
       makeRelease('rhoai-3.5', {
         displayName: 'RHAI 3.5 GA',
@@ -483,9 +486,9 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
-    // Both sides use laneBaseStem (65) for equal stem lengths
-    // belowSpace for 1 row = laneBaseStem + 70 = 135
-    expect(m.belowSpace).toBeGreaterThanOrEqual(135)
+    // Both sides use laneBaseStem (28) for equal stem lengths
+    // belowSpace for 1 row = laneBaseStem + 70 = 98
+    expect(m.belowSpace).toBeGreaterThanOrEqual(98)
     // infraSpace = 60, belowSpace must always exceed it when below tiles exist
     expect(m.belowSpace).toBeGreaterThan(60)
   })
@@ -501,13 +504,13 @@ describe('ReleaseTimeline', () => {
     var m = wrapper.vm.layoutMetrics
     // aboveSpace formula: laneBaseStem + (rows-1)*offset + 70
     // belowSpace formula: laneBaseStem + (rows-1)*offset + 70
-    // Both use laneBaseStem (65) so first-row stem length is identical
-    // For 1 row each: above = 65 + 70 = 135, below = 65 + 70 = 135
+    // Both use laneBaseStem (28) so first-row stem length is identical
+    // For 1 row each: above = 28 + 70 = 98, below = 28 + 70 = 98
     var aboveBase = m.aboveSpace - 70
     var belowBase = m.belowSpace - 70
-    // Both bases should be multiples of laneBaseStem (65) + row offsets
-    expect(aboveBase).toBeGreaterThanOrEqual(65)
-    expect(belowBase).toBeGreaterThanOrEqual(65)
+    // Both bases should be multiples of laneBaseStem (28) + row offsets
+    expect(aboveBase).toBeGreaterThanOrEqual(28)
+    expect(belowBase).toBeGreaterThanOrEqual(28)
   })
 
   it('visibleDays reflects the current zoom range', () => {
@@ -556,12 +559,12 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
-    // A box with 5 lines at 16px + 4px padding * 2 = 88px estimated max
-    // safeOff = max(80, 88 + 4 + 6) = max(80, 98) = 98
+    // A box with 3 lines at 16px + 4px padding * 2 = 56px estimated max
+    // safeOff = max(80, 56 + 4 + 6) = max(80, 66) = 80
     // Both aboveSpace and belowSpace must accommodate this
     var lineH = 16
     var pad = 4
-    var estMaxBoxH = 5 * lineH + pad * 2
+    var estMaxBoxH = 3 * lineH + pad * 2
     expect(m.aboveSpace).toBeGreaterThanOrEqual(estMaxBoxH)
     expect(m.belowSpace).toBeGreaterThanOrEqual(estMaxBoxH)
   })
@@ -631,8 +634,8 @@ describe('ReleaseTimeline', () => {
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
     // With 4 nodes very close together, they need multiple rows
-    // aboveSpace must grow to accommodate them
-    expect(m.aboveSpace).toBeGreaterThan(100)
+    // aboveSpace must grow to accommodate them (laneBaseStem=28 + 70 = 98 min)
+    expect(m.aboveSpace).toBeGreaterThanOrEqual(98)
   })
 
   it('overlapping boxes in same cycle trigger stacking', () => {
@@ -657,7 +660,7 @@ describe('ReleaseTimeline', () => {
     expect(wrapper.find('.mb-6').exists()).toBe(true)
   })
 
-  it('GA nodes include product list for side label rendering', () => {
+  it('GA nodes include product list', () => {
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-08-20' }),
       makeRelease('rhelai-3.5', { displayName: 'rhelai-3.5', shortname: 'rhelai', ga: '2026-08-21' })
@@ -696,7 +699,7 @@ describe('ReleaseTimeline', () => {
     expect(m.safeOff).toBeGreaterThan(0)
   })
 
-  it('upcoming cycle is always placed above the axis', () => {
+  it('groupLabels interleave above and below by GA date', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-14T12:00:00'))
     var releases = [
@@ -709,12 +712,13 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var sides = wrapper.vm.cycleSides
-    // 3.6 has the most future milestones (4 vs 1), should be above
-    expect(sides['3.6']).toBe(true)
+    expect(sides['3.5 GA']).toBe(true)
+    expect(sides['3.6 EA1']).toBe(false)
+    expect(sides['3.6 EA2']).toBe(true)
     vi.useRealTimers()
   })
 
-  it('upcoming cycle stays above regardless of hide-past toggle', () => {
+  it('cycleSides is stable across hidePast toggle', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-14T12:00:00'))
     var releases = [
@@ -728,6 +732,17 @@ describe('ReleaseTimeline', () => {
     // cycleSides should be identical regardless of hidePast
     expect(wrapperA.vm.cycleSides).toEqual(wrapperB.vm.cycleSides)
     vi.useRealTimers()
+  })
+
+  it('non-versioned releases are always below', () => {
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' }),
+      makeRelease('infra-refresh', { displayName: 'Infrastructure Refresh', codeFreeze: '2026-10-01' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var sides = wrapper.vm.cycleSides
+    expect(sides['Infrastructure Refresh']).toBe(false)
+    expect(sides['3.6 GA']).toBe(true)
   })
 
   it('overlapping same-cycle nodes have distinct stack levels for peek rendering', () => {
@@ -762,19 +777,18 @@ describe('ReleaseTimeline', () => {
     expect(Math.abs(d1 - d0)).toBeGreaterThan(20 * 86400000)
   })
 
-  it('peek triggers when same-cycle milestones share the same date', () => {
-    // Two releases with GA on the same day: boxes fully overlap → peek
+  it('different release types on same date produce separate nodes', () => {
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai',
         ga: '2026-08-19' }),
-      makeRelease('rhelai-3.5', { displayName: 'rhelai-3.5', shortname: 'rhelai',
+      makeRelease('rhoai-3.5.EA1', { displayName: 'rhoai-3.5.EA1', shortname: 'rhoai',
         ga: '2026-08-19' })
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var gaNodes = wrapper.vm.nodes.filter(function (n) { return n.isGa })
-    // Same date means their boxes fully overlap at any zoom level
-    expect(gaNodes.length).toBe(1)
+    expect(gaNodes.length).toBe(2)
     expect(gaNodes[0].date).toBe('2026-08-19')
+    expect(gaNodes[1].date).toBe('2026-08-19')
   })
 
   it('cards from spaced-apart milestones each get their own full rendering', () => {
@@ -795,10 +809,9 @@ describe('ReleaseTimeline', () => {
     }
   })
 
-  it('cycle with most future milestones goes above even if not nearest', () => {
+  it('interleaving alternates above/below by GA date order', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-01T12:00:00'))
-    // 3.5 has 1 future milestone (GA Aug 5), 3.6 has 3 future milestones
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai',
         planningFreeze: '2026-07-01', ga: '2026-08-05' }),
@@ -809,16 +822,15 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var sides = wrapper.vm.cycleSides
-    // 3.6 has 3 future milestones vs 3.5's 1 — 3.6 goes above
-    expect(sides['3.6']).toBe(true)
-    expect(sides['3.5']).toBe(false)
+    expect(sides['3.5 GA']).toBe(true)
+    expect(sides['3.6 EA1']).toBe(false)
+    expect(sides['3.6 GA']).toBe(true)
     vi.useRealTimers()
   })
 
-  it('ties in future milestone count broken by nearest milestone', () => {
+  it('two releases interleave: earlier GA above, later GA below', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-01T12:00:00'))
-    // Both cycles have 1 future milestone each, but 3.5 is nearer
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai',
         ga: '2026-08-10' }),
@@ -827,8 +839,8 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var sides = wrapper.vm.cycleSides
-    // Equal future count → nearest wins → 3.5 above
-    expect(sides['3.5']).toBe(true)
+    expect(sides['3.5 GA']).toBe(true)
+    expect(sides['3.6 EA1']).toBe(false)
     vi.useRealTimers()
   })
 
@@ -884,8 +896,7 @@ describe('ReleaseTimeline', () => {
     expect(labels).toContain('3.6 EA1')
   })
 
-  it('same-date milestones within a cycle produce single merged node', () => {
-    // Two releases with identical GA dates in the same cycle → merged into one node
+  it('same-date milestones from different products produce separate nodes', () => {
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai',
         ga: '2026-08-19' }),
@@ -894,9 +905,11 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var gaNodes = wrapper.vm.allNodes.filter(function (n) { return n.isGa })
-    expect(gaNodes).toHaveLength(1)
-    expect(gaNodes[0].productList).toContain('rhoai')
-    expect(gaNodes[0].productList).toContain('rhelai')
+    expect(gaNodes).toHaveLength(2)
+    expect(gaNodes[0].productList).toHaveLength(1)
+    expect(gaNodes[1].productList).toHaveLength(1)
+    var products = gaNodes.map(function (n) { return n.productList[0] }).sort()
+    expect(products).toEqual(['rhelai', 'rhoai'])
   })
 
   it('render order: farther-from-today cards appear earlier in sorted date order', () => {
@@ -1001,8 +1014,7 @@ describe('ReleaseTimeline', () => {
     vi.useRealTimers()
   })
 
-  it('same-date milestones from same cycle merge into a single node', () => {
-    // Same-date GA milestones from the same cycle (3.6) merge → 1 node, not 3
+  it('different release types on same date produce separate nodes per groupLabel', () => {
     var releases = [
       makeRelease('rhoai-3.6.EA1', { displayName: 'rhoai-3.6.EA1', shortname: 'rhoai',
         ga: '2026-10-15' }),
@@ -1014,8 +1026,9 @@ describe('ReleaseTimeline', () => {
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var nodes = wrapper.vm.allNodes
     var oct15 = nodes.filter(function (n) { return n.date === '2026-10-15' })
-    expect(oct15.length).toBe(1)
-    expect(oct15[0].groupLabel).toMatch(/3\.6/)
+    expect(oct15.length).toBe(3)
+    var labels = oct15.map(function (n) { return n.groupLabel }).sort()
+    expect(labels).toEqual(['3.6 EA1', '3.6 EA2', '3.6 GA'])
   })
 
   it('penetration-based stacking: cards only stack when dot is inside front card area', () => {
@@ -1158,8 +1171,8 @@ describe('ReleaseTimeline', () => {
           ]
           var wrapper = mount(ReleaseTimeline, { props: { releases } })
           var sides = wrapper.vm.cycleSides
-          // 3.6 has more future milestones — always above
-          expect(sides['3.6']).toBe(true)
+          // 3.5 has nearest future GA (Aug 19) — always above
+          expect(sides['3.5 GA']).toBe(true)
           // Same result with hidePast toggled
           var wrapper2 = mount(ReleaseTimeline, { props: { releases, hidePast: true } })
           expect(wrapper2.vm.cycleSides).toEqual(sides)
@@ -1217,8 +1230,7 @@ describe('ReleaseTimeline', () => {
   })
 
   describe('stacking and peek invariants', () => {
-    it('same-date milestones from same cycle merge into one node (no phantom peeks)', () => {
-      // Three releases with GA on the same date in cycle 3.6 → merged into 1 node
+    it('different release types on same date produce separate nodes (no phantom merge)', () => {
       var releases = [
         makeRelease('rhoai-3.6.EA1', { displayName: 'rhoai-3.6.EA1', shortname: 'rhoai',
           ga: '2026-10-15' }),
@@ -1230,8 +1242,7 @@ describe('ReleaseTimeline', () => {
       var wrapper = mount(ReleaseTimeline, { props: { releases } })
       var nodes = wrapper.vm.allNodes
       var oct15 = nodes.filter(function (n) { return n.date === '2026-10-15' })
-      expect(oct15.length).toBe(1)
-      expect(oct15[0].groupLabel).toMatch(/3\.6/)
+      expect(oct15.length).toBe(3)
     })
 
     it('1-day-apart milestones in same cycle keep all nodes', () => {
@@ -1365,39 +1376,42 @@ describe('ReleaseTimeline', () => {
       expect(dotOrder).toEqual([0, 1])
     })
 
-    it('sideLabel is an array of product names, not a joined string', () => {
+    it('productList is an array of product names, not a joined string', () => {
       var releases = [
         makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' }),
         makeRelease('rhelai-3.6', { displayName: 'rhelai-3.6', shortname: 'rhelai', ga: '2026-10-15' })
       ]
       var wrapper = mount(ReleaseTimeline, { props: { releases } })
       var gaNodes = wrapper.vm.allNodes.filter(function (n) { return n.isGa })
-      expect(gaNodes.length).toBeGreaterThanOrEqual(1)
+      expect(gaNodes).toHaveLength(2)
       expect(Array.isArray(gaNodes[0].productList)).toBe(true)
-      expect(gaNodes[0].productList.length).toBeGreaterThanOrEqual(2)
+      expect(gaNodes[0].productList).toHaveLength(1)
+      expect(Array.isArray(gaNodes[1].productList)).toBe(true)
+      expect(gaNodes[1].productList).toHaveLength(1)
     })
 
-    it('same-date milestones from same cycle merge into one node', () => {
-      // rhoai-3.6.EA1 GA and RHAII-3.6 GA both on Sep 17 → single node
+    it('different release types from same product on same date produce separate nodes', () => {
+      var releases = [
+        makeRelease('rhoai-3.6.EA1', { displayName: 'rhoai-3.6.EA1', shortname: 'rhoai', ga: '2026-09-17' }),
+        makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-09-17' })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases } })
+      var gaSep17 = wrapper.vm.allNodes.filter(function (n) { return n.date === '2026-09-17' && n.isGa })
+      expect(gaSep17.length).toBe(2)
+      expect(gaSep17[0].productList).toContain('rhoai')
+      expect(gaSep17[1].productList).toContain('rhoai')
+    })
+
+    it('cross-product same-date produces separate nodes', () => {
       var releases = [
         makeRelease('rhoai-3.6.EA1', { displayName: 'rhoai-3.6.EA1', shortname: 'rhoai', ga: '2026-09-17' }),
         makeRelease('RHAII-3.6', { displayName: 'RHAII-3.6', shortname: 'rhai', ga: '2026-09-17' })
       ]
       var wrapper = mount(ReleaseTimeline, { props: { releases } })
-      var nodes = wrapper.vm.allNodes
-      // Both releases produce GA on Sep 17 → merged into 1 node
-      var gaSep17 = nodes.filter(function (n) { return n.date === '2026-09-17' })
-      expect(gaSep17.length).toBe(1)
-    })
-
-    it('same-date merge preserves all products in productList', () => {
-      var releases = [
-        makeRelease('rhoai-3.6.EA1', { displayName: 'rhoai-3.6.EA1', shortname: 'rhoai', ga: '2026-09-17' }),
-        makeRelease('RHAII-3.6', { displayName: 'RHAII-3.6', shortname: 'rhai', ga: '2026-09-17' })
-      ]
-      var wrapper = mount(ReleaseTimeline, { props: { releases } })
-      var gaSep17 = wrapper.vm.allNodes.filter(function (n) { return n.date === '2026-09-17' })
-      expect(gaSep17[0].productList.length).toBeGreaterThanOrEqual(2)
+      var gaSep17 = wrapper.vm.allNodes.filter(function (n) { return n.date === '2026-09-17' && n.isGa })
+      expect(gaSep17.length).toBe(2)
+      expect(gaSep17[0].productList).toHaveLength(1)
+      expect(gaSep17[1].productList).toHaveLength(1)
     })
 
     it('different-date milestones from same cycle remain separate nodes', () => {
@@ -1421,10 +1435,11 @@ describe('ReleaseTimeline', () => {
       ]
       return mount(ReleaseTimeline, { props: { releases } }).vm
     }
-    function makeLayout(x, groupLabel, date, boxW) {
+    function makeLayout(x, groupLabel, date, boxW, product, subLane) {
       return {
         x: x, boxW: boxW || 120, above: true, stackLevel: 0,
-        nd: { date: date, groupLabel: groupLabel }
+        subLane: subLane !== undefined ? subLane : 0,
+        nd: { date: date, groupLabel: groupLabel, productList: product ? [product] : [] }
       }
     }
     var TODAY = new Date('2026-08-14').getTime()
@@ -1558,8 +1573,8 @@ describe('ReleaseTimeline', () => {
     it('different cycles do not stack with each other', () => {
       var vm = getVm()
       var layouts = [
-        makeLayout(200, '3.5 GA', '2026-09-16'),
-        makeLayout(250, '3.6 GA', '2026-09-17')
+        makeLayout(200, '3.5 GA', '2026-09-16', undefined, undefined, 0),
+        makeLayout(250, '3.6 GA', '2026-09-17', undefined, undefined, 1)
       ]
       vm.applyStacking(layouts, TODAY)
       expect(layouts[0].stackLevel).toBe(0)
@@ -1571,7 +1586,7 @@ describe('ReleaseTimeline', () => {
       var vm = getVm()
       var layouts = [
         makeLayout(200, '3.6 GA', '2026-09-16'),
-        { x: 250, boxW: 120, above: false, stackLevel: 0,
+        { x: 250, boxW: 120, above: false, stackLevel: 0, subLane: 0,
           nd: { date: '2026-09-17', groupLabel: '3.6 GA' } }
       ]
       vm.applyStacking(layouts, TODAY)
@@ -1579,7 +1594,7 @@ describe('ReleaseTimeline', () => {
       expect(layouts[1].stackLevel).toBe(0)
     })
 
-    it('above/below assignment is per-cycle, not per-node', () => {
+    it('above/below assignment is per-groupLabel, not per-node', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-08-14T12:00:00'))
       var releases = [
@@ -1593,18 +1608,13 @@ describe('ReleaseTimeline', () => {
       var wrapper = mount(ReleaseTimeline, { props: { releases } })
       var sides = wrapper.vm.cycleSides
       var nodes = wrapper.vm.allNodes
-      // Every node's cycle maps to the same side value
       for (var i = 0; i < nodes.length; i++) {
-        var cycle = nodes[i].groupLabel.match(/^(\d+\.\d+)/)[1]
-        var expectedSide = sides[cycle]
+        var expectedSide = sides[nodes[i].groupLabel]
         expect(expectedSide).toBeDefined()
-        // All nodes from the same cycle get the same side
-        var sameNodes = nodes.filter(function (n) {
-          return n.groupLabel.match(/^(\d+\.\d+)/)[1] === cycle
-        })
+        var gl = nodes[i].groupLabel
+        var sameNodes = nodes.filter(function (n) { return n.groupLabel === gl })
         for (var j = 0; j < sameNodes.length; j++) {
-          var c2 = sameNodes[j].groupLabel.match(/^(\d+\.\d+)/)[1]
-          expect(sides[c2]).toBe(expectedSide)
+          expect(sides[sameNodes[j].groupLabel]).toBe(expectedSide)
         }
       }
       vi.useRealTimers()
@@ -1707,10 +1717,11 @@ describe('ReleaseTimeline', () => {
       ]
       return mount(ReleaseTimeline, { props: { releases } }).vm
     }
-    function makeLayout(x, groupLabel, date, boxW) {
+    function makeLayout(x, groupLabel, date, boxW, product, subLane) {
       return {
         x: x, boxW: boxW || 120, above: true, stackLevel: 0,
-        nd: { date: date, groupLabel: groupLabel }
+        subLane: subLane !== undefined ? subLane : 0,
+        nd: { date: date, groupLabel: groupLabel, productList: product ? [product] : [] }
       }
     }
     var TODAY = new Date('2026-08-14').getTime()
@@ -1786,8 +1797,8 @@ describe('ReleaseTimeline', () => {
     it('cross-cycle never stacks even with overlapping boxes', () => {
       var vm = getVm()
       var layouts = [
-        makeLayout(258, '3.5 GA', '2026-09-10'),
-        makeLayout(260, '3.6 GA', '2026-09-17')
+        makeLayout(258, '3.5 GA', '2026-09-10', undefined, undefined, 0),
+        makeLayout(260, '3.6 GA', '2026-09-17', undefined, undefined, 1)
       ]
       vm.applyStacking(layouts, TODAY, 10)
       expect(layouts[0].stackLevel).toBe(0)
@@ -1814,5 +1825,532 @@ describe('ReleaseTimeline', () => {
       expect(fn('#000000', 1)).toBe('rgba(0,0,0,1)')
       expect(fn('invalid', 0.5)).toBe('invalid')
     })
+  })
+
+  it('stableCycleRowMap assigns row 0 to cycle with earliest GA on same side', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date(2026, 7, 1))
+      var wrapper = mount(ReleaseTimeline, {
+        props: {
+          releases: [
+            makeRelease('rhoai-3.4', { ga: '2026-12-01' }),
+            makeRelease('rhoai-3.5', { ga: '2026-09-01' }),
+            makeRelease('rhoai-3.6', { ga: '2026-11-01' })
+          ],
+          hidePast: false
+        }
+      })
+      var rowMap = wrapper.vm.stableCycleRowMap
+      // Find two cycles that share the same side (both -a or both -b)
+      var keys = Object.keys(rowMap)
+      var aboveKeys = keys.filter(function (k) { return k.endsWith('-a') })
+      var belowKeys = keys.filter(function (k) { return k.endsWith('-b') })
+      var sameSide = aboveKeys.length >= 2 ? aboveKeys : belowKeys
+      expect(sameSide.length).toBeGreaterThanOrEqual(2)
+      // Within same side, earlier GA should get lower row index
+      var sorted = sameSide.slice().sort(function (a, b) { return rowMap[a] - rowMap[b] })
+      for (var i = 0; i < sorted.length - 1; i++) {
+        expect(rowMap[sorted[i]]).toBeLessThan(rowMap[sorted[i + 1]])
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stableCycleRowMap is deterministic across calls', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: {
+        releases: [
+          makeRelease('rhoai-3.5', { ga: '2026-09-01' }),
+          makeRelease('rhoai-3.6', { ga: '2026-11-01' })
+        ],
+        hidePast: false
+      }
+    })
+    var map1 = JSON.stringify(wrapper.vm.stableCycleRowMap)
+    var map2 = JSON.stringify(wrapper.vm.stableCycleRowMap)
+    expect(map1).toBe(map2)
+  })
+
+  it('non-GA nodes have productList populated', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: {
+        releases: [makeRelease('rhoai-3.6.EA1', {
+          codeFreeze: localIso(2026, 9, 15)
+        })],
+        hidePast: false
+      }
+    })
+    var nodes = wrapper.vm.allNodes
+    expect(nodes.length).toBeGreaterThan(0)
+    expect(nodes[0].productList.length).toBeGreaterThan(0)
+  })
+
+  it('GA nodes have isGa flag for tint rendering', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: {
+        releases: [makeRelease('rhoai-3.6', {
+          ga: localIso(2026, 11, 5)
+        })],
+        hidePast: false
+      }
+    })
+    var gaNodes = wrapper.vm.allNodes.filter(function (n) { return n.isGa })
+    expect(gaNodes.length).toBe(1)
+    expect(gaNodes[0].isGa).toBe(true)
+  })
+
+  it('same-release-type products share a groupLabel-keyed row', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: {
+        releases: [
+          makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-11-01' }),
+          makeRelease('rhelai-3.6', { displayName: 'rhelai-3.6', shortname: 'rhelai', ga: '2026-11-01' })
+        ],
+        hidePast: false
+      }
+    })
+    var rowMap = wrapper.vm.stableCycleRowMap
+    var keys = Object.keys(rowMap)
+    expect(keys.length).toBe(1)
+    expect(keys[0]).toMatch(/^3\.6 GA-[ab]$/)
+    expect(keys.every(function (k) { return k.indexOf('rhoai') === -1 && k.indexOf('rhelai') === -1 })).toBe(true)
+  })
+
+  it('uses displayName as groupLabel when no version pattern found', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: {
+        releases: [makeRelease('infra-refresh', {
+          displayName: 'Infrastructure Refresh',
+          codeFreeze: localIso(2026, 10, 1)
+        })],
+        hidePast: false
+      }
+    })
+    var nodes = wrapper.vm.allNodes
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].groupLabel).toBe('Infrastructure Refresh')
+  })
+
+  it('different products on different subLanes do not stack', () => {
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' })
+    ]
+    var vm = mount(ReleaseTimeline, { props: { releases } }).vm
+    var layouts = [
+      { x: 100, boxW: 120, above: true, stackLevel: 0, subLane: 0,
+        nd: { date: '2026-10-15', groupLabel: '3.6 GA', productList: ['rhoai'] } },
+      { x: 105, boxW: 120, above: true, stackLevel: 0, subLane: 1,
+        nd: { date: '2026-10-16', groupLabel: '3.6 GA', productList: ['rhelai'] } }
+    ]
+    vm.applyStacking(layouts, new Date('2026-08-14').getTime(), 10)
+    expect(layouts[0].stackTopIdx).toBeUndefined()
+    expect(layouts[1].stackTopIdx).toBeUndefined()
+  })
+
+  it('same subLane cross-product cards stack together (merge-mode scenario)', () => {
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' })
+    ]
+    var vm = mount(ReleaseTimeline, { props: { releases } }).vm
+    var layouts = [
+      { x: 200, boxW: 120, above: true, stackLevel: 0, subLane: 0,
+        nd: { date: '2026-09-15', groupLabel: '3.6 GA', productList: ['rhoai'] } },
+      { x: 205, boxW: 120, above: true, stackLevel: 0, subLane: 0,
+        nd: { date: '2026-09-15', groupLabel: '3.6 Code Freeze', productList: ['rhelai'] } }
+    ]
+    vm.applyStacking(layouts, new Date('2026-08-14').getTime(), 10)
+    var stacked = layouts.filter(function (l) { return l.stackLevel > 0 })
+    expect(stacked.length).toBe(1)
+    expect(stacked[0].stackTopIdx).toBe(0)
+  })
+
+  it('stacked card retains node data (groupLabel, msLabel, productList)', () => {
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' })
+    ]
+    var vm = mount(ReleaseTimeline, { props: { releases } }).vm
+    var layouts = [
+      { x: 200, boxW: 120, above: true, stackLevel: 0, subLane: 0,
+        nd: { date: '2026-09-15', groupLabel: '3.6 GA', productList: ['rhoai'], msLabel: 'Generally Available' } },
+      { x: 205, boxW: 120, above: true, stackLevel: 0, subLane: 0,
+        nd: { date: '2026-09-15', groupLabel: '3.6 EA2', productList: ['rhelai'], msLabel: 'Code Freeze' } }
+    ]
+    vm.applyStacking(layouts, new Date('2026-08-14').getTime(), 10)
+    var behind = layouts.filter(function (l) { return l.stackLevel > 0 })
+    expect(behind.length).toBe(1)
+    expect(behind[0].nd).toHaveProperty('groupLabel')
+    expect(behind[0].nd).toHaveProperty('msLabel')
+    expect(behind[0].nd).toHaveProperty('productList')
+  })
+
+  it('two versions distribute above and below', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-01T12:00:00'))
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-10-15' }),
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-06-15' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var sides = wrapper.vm.cycleSides
+    var values = Object.values(sides)
+    var hasAbove = values.some(function (v) { return v === true })
+    var hasBelow = values.some(function (v) { return v === false })
+    expect(hasAbove).toBe(true)
+    expect(hasBelow).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('nodes carry sourceReleases array for tooltip', () => {
+    var releases = [
+      makeRelease('rhoai-3.6', { displayName: '3.6 GA RHOAI RELEASE', shortname: 'rhoai',
+        ga: '2026-10-15' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var gaNodes = wrapper.vm.allNodes.filter(function (n) { return n.isGa })
+    expect(gaNodes.length).toBeGreaterThanOrEqual(1)
+    expect(Array.isArray(gaNodes[0].releases)).toBe(true)
+    expect(gaNodes[0].releases.length).toBeGreaterThanOrEqual(1)
+    expect(gaNodes[0].releases[0]).toHaveProperty('state')
+    expect(gaNodes[0].releases[0]).toHaveProperty('displayName')
+  })
+
+  // --- Squeeze mode & hover discoverability tests ---
+
+  function makeMultiProductReleases() {
+    return [
+      makeRelease('rhoai-3.5-ea1', { displayName: 'rhoai-3.5-ea1', shortname: 'rhoai', ga: '2026-06-10', planningFreeze: '2026-04-01' }),
+      makeRelease('rhoai-3.5-ea2', { displayName: 'rhoai-3.5-ea2', shortname: 'rhoai', ga: '2026-07-14', planningFreeze: '2026-05-01' }),
+      makeRelease('rhoai-3.5-ga', { displayName: 'rhoai-3.5-ga', shortname: 'rhoai', ga: '2026-08-18', planningFreeze: '2026-06-01' }),
+      makeRelease('rhoai-3.6-ea1', { displayName: 'rhoai-3.6-ea1', shortname: 'rhoai', ga: '2026-09-15', planningFreeze: '2026-07-01' }),
+      makeRelease('rhoai-3.6-ea2', { displayName: 'rhoai-3.6-ea2', shortname: 'rhoai', ga: '2026-10-13', planningFreeze: '2026-08-01' }),
+      makeRelease('rhoai-3.6-ga', { displayName: 'rhoai-3.6-ga', shortname: 'rhoai', ga: '2026-11-17', planningFreeze: '2026-09-01' })
+    ]
+  }
+
+  it('isOverCard defaults to false', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-06-17' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    expect(wrapper.vm.isOverCard).toBe(false)
+  })
+
+  it('cursor style reflects isOverCard state', async () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-06-17' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var div = wrapper.find('.relative')
+    expect(div.attributes('style')).toContain('default')
+
+    wrapper.vm.isOverCard = true
+    await wrapper.vm.$nextTick()
+    expect(div.attributes('style')).toContain('pointer')
+  })
+
+  it('auto-compress keeps chartHeight within cap with many releases', () => {
+    var wrapper = mount(ReleaseTimeline, {
+      props: { releases: makeMultiProductReleases(), hidePast: false }
+    })
+    expect(wrapper.vm.chartHeight).toBeLessThanOrEqual(450)
+    expect(wrapper.vm.chartHeight).toBeGreaterThan(0)
+    expect(wrapper.vm.layoutMetrics.safeOff).toBeLessThan(98)
+  })
+
+  it('overlapping same-date cards are placed on opposite sides for hover-to-front', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-09-01' }),
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-09-01' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var nodes = wrapper.vm.allNodes
+    expect(nodes.length).toBe(2)
+    var sides = wrapper.vm.cycleSides
+    // Interleaved: one above, one below — they overlap visually at same x
+    expect(sides[nodes[0].groupLabel]).not.toBe(sides[nodes[1].groupLabel])
+  })
+
+  it('non-versioned releases get highest below-axis row index', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' }),
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-11-15' }),
+      makeRelease('infra-refresh', { displayName: 'Infrastructure Refresh', shortname: null, codeFreeze: '2026-10-01' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var rowMap = wrapper.vm.stableCycleRowMap
+    var infraIdx = rowMap['Infrastructure Refresh-b']
+    var productIdxes = Object.keys(rowMap)
+      .filter(function (k) { return k.endsWith('-b') && k !== 'Infrastructure Refresh-b' })
+      .map(function (k) { return rowMap[k] })
+    for (var i = 0; i < productIdxes.length; i++) {
+      expect(infraIdx).toBeGreaterThan(productIdxes[i])
+    }
+  })
+
+  describe('dim line logic', () => {
+    function isDimLineEligible(groupLabel) {
+      var m = /^(\d+\.\d+)\s/.exec(groupLabel)
+      var cycle = m ? m[1] : groupLabel
+      return /^\d+\.\d+$/.test(cycle)
+    }
+
+    function futureDate(daysAhead) {
+      var d = new Date()
+      d.setDate(d.getDate() + daysAhead)
+      return d.toISOString().split('T')[0]
+    }
+
+    it('versioned groupLabels pass the dim line eligibility filter', () => {
+      expect(isDimLineEligible('3.6 GA')).toBe(true)
+      expect(isDimLineEligible('3.5 EA1')).toBe(true)
+      expect(isDimLineEligible('3.7 EA2')).toBe(true)
+    })
+
+    it('non-versioned (infra) groupLabels fail the dim line eligibility filter', () => {
+      expect(isDimLineEligible('Security Hardening')).toBe(false)
+      expect(isDimLineEligible('Infrastructure Refresh')).toBe(false)
+      expect(isDimLineEligible('other')).toBe(false)
+    })
+
+    it('per-segment overlap marks segments sharing horizontal space on same side', () => {
+      var segs = [
+        { gi: 0, above: true, left: 100, right: 300, needsLabel: false },
+        { gi: 1, above: true, left: 200, right: 400, needsLabel: false }
+      ]
+      for (var i = 0; i < segs.length; i++) {
+        for (var j = 0; j < segs.length; j++) {
+          if (segs[j].gi !== segs[i].gi && segs[j].above === segs[i].above &&
+              segs[j].left < segs[i].right && segs[i].left < segs[j].right) {
+            segs[i].needsLabel = true
+            break
+          }
+        }
+      }
+      expect(segs[0].needsLabel).toBe(true)
+      expect(segs[1].needsLabel).toBe(true)
+    })
+
+    it('per-segment overlap does not mark non-overlapping segments', () => {
+      var segs = [
+        { gi: 0, above: true, left: 100, right: 200, needsLabel: false },
+        { gi: 1, above: true, left: 300, right: 400, needsLabel: false }
+      ]
+      for (var i = 0; i < segs.length; i++) {
+        for (var j = 0; j < segs.length; j++) {
+          if (segs[j].gi !== segs[i].gi && segs[j].above === segs[i].above &&
+              segs[j].left < segs[i].right && segs[i].left < segs[j].right) {
+            segs[i].needsLabel = true
+            break
+          }
+        }
+      }
+      expect(segs[0].needsLabel).toBe(false)
+      expect(segs[1].needsLabel).toBe(false)
+    })
+
+    it('per-segment overlap ignores segments on opposite sides', () => {
+      var segs = [
+        { gi: 0, above: true, left: 100, right: 300, needsLabel: false },
+        { gi: 1, above: false, left: 100, right: 300, needsLabel: false }
+      ]
+      for (var i = 0; i < segs.length; i++) {
+        for (var j = 0; j < segs.length; j++) {
+          if (segs[j].gi !== segs[i].gi && segs[j].above === segs[i].above &&
+              segs[j].left < segs[i].right && segs[i].left < segs[j].right) {
+            segs[i].needsLabel = true
+            break
+          }
+        }
+      }
+      expect(segs[0].needsLabel).toBe(false)
+      expect(segs[1].needsLabel).toBe(false)
+    })
+
+    it('per-segment overlap ignores segments from same group', () => {
+      var segs = [
+        { gi: 0, above: true, left: 100, right: 300, needsLabel: false },
+        { gi: 0, above: true, left: 200, right: 400, needsLabel: false }
+      ]
+      for (var i = 0; i < segs.length; i++) {
+        for (var j = 0; j < segs.length; j++) {
+          if (segs[j].gi !== segs[i].gi && segs[j].above === segs[i].above &&
+              segs[j].left < segs[i].right && segs[i].left < segs[j].right) {
+            segs[i].needsLabel = true
+            break
+          }
+        }
+      }
+      expect(segs[0].needsLabel).toBe(false)
+      expect(segs[1].needsLabel).toBe(false)
+    })
+
+    it('infra releases produce allNodes but their groupLabels are non-versioned', () => {
+      var releases = [
+        makeRelease('rhoai-3.5', { displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai',
+          planningFreeze: '2026-06-01', ga: '2026-06-17' }),
+        makeRelease('infra-security', { displayName: 'Security Hardening', shortname: null,
+          planningFreeze: '2026-10-15', featureFreeze: '2026-11-01',
+          codeFreeze: '2026-11-15', ga: null })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases } })
+      var nodes = wrapper.vm.allNodes
+      var infraNodes = nodes.filter(function (nd) { return nd.groupLabel === 'Security Hardening' })
+      expect(infraNodes.length).toBeGreaterThanOrEqual(2)
+      for (var i = 0; i < infraNodes.length; i++) {
+        var m = /^(\d+\.\d+)\s/.exec(infraNodes[i].groupLabel)
+        var cycle = m ? m[1] : infraNodes[i].groupLabel
+        expect(/^\d+\.\d+$/.test(cycle)).toBe(false)
+      }
+    })
+
+    it('nextMilestoneLabel includes product prefix and milestone for GA', () => {
+      var releases = [
+        makeRelease('rhoai-3.5', { displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai',
+          ga: futureDate(1) })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases } })
+      var nml = wrapper.vm.nextMilestoneLabel
+      expect(nml).not.toBeNull()
+      expect(nml.desc).toContain('RHOAI')
+      expect(nml.desc).toContain('3.5 GA')
+      expect(nml.desc).toContain('Generally Available')
+      expect(nml.daysText).toBe('in 1d')
+    })
+
+    it('nextMilestoneLabel includes product prefix for non-GA milestone', () => {
+      var releases = [
+        makeRelease('rhoai-3.6', { displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai',
+          featureFreeze: futureDate(3), ga: futureDate(30) })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases } })
+      var nml = wrapper.vm.nextMilestoneLabel
+      expect(nml).not.toBeNull()
+      expect(nml.desc).toContain('RHOAI')
+      expect(nml.desc).toContain('Feature Freeze')
+    })
+
+    it('nextMilestoneLabel omits product prefix for non-product releases', () => {
+      var releases = [{
+        id: 'infra-security-hardening',
+        displayName: 'Security Hardening',
+        state: 'active',
+        productPagesShortname: null,
+        milestones: { planningFreeze: futureDate(5), featureFreeze: null, codeFreeze: null, ga: null }
+      }]
+      var wrapper = mount(ReleaseTimeline, { props: { releases } })
+      var nml = wrapper.vm.nextMilestoneLabel
+      expect(nml).not.toBeNull()
+      expect(nml.desc).toMatch(/^Security Hardening/)
+    })
+
+    it('product prefix joins multiple products with slash via productLabel', () => {
+      var productList = ['rhelai', 'rhoai']
+      var prefix = productList.map(productLabel).join('/')
+      expect(prefix).toBe('RHELAI/RHOAI')
+    })
+
+    it('segment touching today gets leftIsToday/rightIsToday flags', () => {
+      var todayTs = 1000
+      var points = [
+        { x: 50, ts: 500 },
+        { x: 150, ts: todayTs },
+        { x: 250, ts: 1500 }
+      ]
+      points.sort(function (a, b) { return a.ts - b.ts })
+      var dimGap = 6
+      var segs = []
+      for (var j = 1; j < points.length; j++) {
+        segs.push({
+          left: points[j - 1].x + dimGap,
+          right: points[j].x - dimGap,
+          leftIsToday: points[j - 1].ts === todayTs,
+          rightIsToday: points[j].ts === todayTs
+        })
+      }
+      expect(segs[0].leftIsToday).toBe(false)
+      expect(segs[0].rightIsToday).toBe(true)
+      expect(segs[1].leftIsToday).toBe(true)
+      expect(segs[1].rightIsToday).toBe(false)
+    })
+
+    it('segment not touching today has no today flags', () => {
+      var todayTs = 9999
+      var points = [
+        { x: 50, ts: 500 },
+        { x: 150, ts: 1000 },
+        { x: 250, ts: 1500 }
+      ]
+      var segs = []
+      for (var j = 1; j < points.length; j++) {
+        segs.push({
+          leftIsToday: points[j - 1].ts === todayTs,
+          rightIsToday: points[j].ts === todayTs
+        })
+      }
+      expect(segs[0].leftIsToday).toBe(false)
+      expect(segs[0].rightIsToday).toBe(false)
+      expect(segs[1].leftIsToday).toBe(false)
+      expect(segs[1].rightIsToday).toBe(false)
+    })
+  })
+
+  it('visibleProducts lists only products present in data', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' }),
+      makeRelease('rhelai-3.5', { displayName: 'rhelai-3.5', shortname: 'rhelai', ga: '2026-10-20' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    expect(wrapper.vm.visibleProducts).toContain('rhoai')
+    expect(wrapper.vm.visibleProducts).toContain('rhelai')
+    expect(wrapper.vm.visibleProducts).not.toContain('rhaii')
+  })
+
+  it('no tooltip element in DOM', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    expect(wrapper.find('.z-20').exists()).toBe(false)
+  })
+
+  it('legend renders colored dots for visible products', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' }),
+      makeRelease('rhelai-3.5', { displayName: 'rhelai-3.5', shortname: 'rhelai', ga: '2026-10-20' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var legendDots = wrapper.findAll('.rounded-full.w-2')
+    expect(legendDots.length).toBe(2)
+  })
+
+  it('allNodes carry groupLabel, msLabel, and date (no product text line)', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var nodes = wrapper.vm.allNodes
+    expect(nodes.length).toBeGreaterThan(0)
+    expect(nodes[0].productList).toContain('rhoai')
+    expect(nodes[0].groupLabel).toBeTruthy()
+    expect(nodes[0].msLabel).toBeTruthy()
+    expect(nodes[0].date).toBeTruthy()
+  })
+
+  it('multiple releases on same side produce distinct stableCycleRowMap entries', () => {
+    var releases = [
+      makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai',
+        planningFreeze: '2026-06-01', ga: '2026-06-17' }),
+      makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai',
+        planningFreeze: '2026-09-01', ga: '2026-11-19' }),
+      makeRelease('rhoai-3.7', { displayName: 'rhoai-3.7', shortname: 'rhoai',
+        planningFreeze: '2026-12-01', ga: '2027-02-15' })
+    ]
+    var wrapper = mount(ReleaseTimeline, { props: { releases } })
+    var map = wrapper.vm.stableCycleRowMap
+    var aboveKeys = Object.keys(map).filter(function (k) { return k.endsWith('-a') })
+    var belowKeys = Object.keys(map).filter(function (k) { return k.endsWith('-b') })
+    expect(Math.max(aboveKeys.length, belowKeys.length)).toBeGreaterThanOrEqual(2)
   })
 })

--- a/modules/releases/__tests__/client/release-timeline.test.js
+++ b/modules/releases/__tests__/client/release-timeline.test.js
@@ -486,9 +486,9 @@ describe('ReleaseTimeline', () => {
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
-    // Both sides use laneBaseStem (28) for equal stem lengths
-    // belowSpace for 1 row = laneBaseStem + 70 = 98
-    expect(m.belowSpace).toBeGreaterThanOrEqual(98)
+    // Both sides use laneBaseStem (64) for equal stem lengths
+    // belowSpace for 1 row = laneBaseStem + 70 = 134
+    expect(m.belowSpace).toBeGreaterThanOrEqual(134)
     // infraSpace = 60, belowSpace must always exceed it when below tiles exist
     expect(m.belowSpace).toBeGreaterThan(60)
   })
@@ -504,13 +504,13 @@ describe('ReleaseTimeline', () => {
     var m = wrapper.vm.layoutMetrics
     // aboveSpace formula: laneBaseStem + (rows-1)*offset + 70
     // belowSpace formula: laneBaseStem + (rows-1)*offset + 70
-    // Both use laneBaseStem (28) so first-row stem length is identical
-    // For 1 row each: above = 28 + 70 = 98, below = 28 + 70 = 98
+    // Both use laneBaseStem (64) so first-row stem length is identical
+    // For 1 row each: above = 64 + 70 = 134, below = 64 + 70 = 134
     var aboveBase = m.aboveSpace - 70
     var belowBase = m.belowSpace - 70
-    // Both bases should be multiples of laneBaseStem (28) + row offsets
-    expect(aboveBase).toBeGreaterThanOrEqual(28)
-    expect(belowBase).toBeGreaterThanOrEqual(28)
+    // Both bases should be multiples of laneBaseStem (64) + row offsets
+    expect(aboveBase).toBeGreaterThanOrEqual(64)
+    expect(belowBase).toBeGreaterThanOrEqual(64)
   })
 
   it('visibleDays reflects the current zoom range', () => {
@@ -634,8 +634,8 @@ describe('ReleaseTimeline', () => {
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
     // With 4 nodes very close together, they need multiple rows
-    // aboveSpace must grow to accommodate them (laneBaseStem=28 + 70 = 98 min)
-    expect(m.aboveSpace).toBeGreaterThanOrEqual(98)
+    // aboveSpace must grow to accommodate them (laneBaseStem=64 + 70 = 134 min)
+    expect(m.aboveSpace).toBeGreaterThanOrEqual(134)
   })
 
   it('overlapping boxes in same cycle trigger stacking', () => {

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -252,4 +252,112 @@ describe('ScheduleView', () => {
     expect(apiRequest).toHaveBeenCalledTimes(2)
     expect(wrapper.text()).toContain('Sep 20, 2026')
   })
+
+  it('version filter pills appear when multiple versions exist', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-06-10'
+        }),
+        makeRelease('rhoai-3.5-ga', {
+          displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai', ga: '2028-08-18'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+    var buttons = wrapper.findAll('button').filter(b => /^\d+\.\d+\s+(EA\d+|GA)$/.test(b.text().trim()))
+    expect(buttons.length).toBe(3)
+  })
+
+  it('version pills are sorted most-recent-first', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-06-10'
+        }),
+        makeRelease('rhoai-3.5-ga', {
+          displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai', ga: '2028-08-18'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+    var buttons = wrapper.findAll('button').filter(b => /^\d+\.\d+\s+(EA\d+|GA)$/.test(b.text().trim()))
+    var labels = buttons.map(b => b.text().trim())
+    expect(labels).toEqual(['3.6 EA1', '3.5 GA', '3.5 EA1'])
+  })
+
+  it('clicking a version pill filters the releases passed to timeline', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ga', {
+          displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai', ga: '2028-08-18'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+    var versionBtns = wrapper.findAll('button').filter(b => b.text().trim() === '3.5 GA')
+    expect(versionBtns.length).toBe(1)
+    await versionBtns[0].trigger('click')
+    var timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('releases').length).toBe(1)
+    expect(timeline.props('releases')[0].id).toBe('rhoai-3.5-ga')
+  })
+
+  it('multi-select: two version pills can be active simultaneously', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-06-10'
+        }),
+        makeRelease('rhoai-3.5-ga', {
+          displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai', ga: '2028-08-18'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+    var ea1Btn = wrapper.findAll('button').filter(b => b.text().trim() === '3.5 EA1')[0]
+    var gaBtn = wrapper.findAll('button').filter(b => b.text().trim() === '3.5 GA')[0]
+    await ea1Btn.trigger('click')
+    await gaBtn.trigger('click')
+    var timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('releases').length).toBe(2)
+  })
+
+  it('Clear button resets version filter', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ga', {
+          displayName: '3.5 GA RHOAI RELEASE', shortname: 'rhoai', ga: '2028-08-18'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+    var versionBtn = wrapper.findAll('button').filter(b => b.text().trim() === '3.5 GA')[0]
+    await versionBtn.trigger('click')
+    var clearBtn = wrapper.findAll('button').filter(b => b.text().trim() === 'Clear')[0]
+    expect(clearBtn).toBeTruthy()
+    await clearBtn.trigger('click')
+    var timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('releases').length).toBe(2)
+  })
 })

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -79,6 +79,35 @@ describe('parseReleaseName', function () {
     expect(parseReleaseName('')).toBeNull()
     expect(parseReleaseName('random-text')).toBeNull()
   })
+
+  it('parses rhai legacy format', function () {
+    var r = parseReleaseName('rhai-3.6')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhai')
+    expect(r.major).toBe(3)
+    expect(r.minor).toBe(6)
+    expect(r.milestone).toBe('GA')
+  })
+
+  it('parses rhai with EA suffix', function () {
+    var r = parseReleaseName('rhai-3.6.EA1')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhai')
+    expect(r.milestone).toBe('EA1')
+  })
+
+  it('parses rhai product-family format', function () {
+    var r = parseReleaseName('3.6 GA RHAI RELEASE')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhai')
+    expect(r.milestone).toBe('GA')
+  })
+
+  it('rhaii still matches before rhai', function () {
+    var r = parseReleaseName('rhaii-3.5')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhaii')
+  })
 })
 
 // ═══ extractCycle / milestone ═══
@@ -92,6 +121,10 @@ describe('extractCycle', function () {
   it('extracts cycle from legacy names', function () {
     expect(extractCycle('rhoai-3.6.EA1')).toBe('3.6')
     expect(extractCycle('RHELAI-3.2')).toBe('3.2')
+  })
+
+  it('extracts cycle from rhai names', function () {
+    expect(extractCycle('rhai-3.6')).toBe('3.6')
   })
 })
 

--- a/modules/releases/__tests__/client/useProductColors.test.js
+++ b/modules/releases/__tests__/client/useProductColors.test.js
@@ -27,13 +27,23 @@ describe('useProductColors', () => {
   it('returns known colors for rhelai', () => {
     var colors = productColors('rhelai')
     expect(colors).toBe(PRODUCT_COLORS.rhelai)
-    expect(colors.dot).toContain('teal')
+    expect(colors.dot).toContain('emerald')
   })
 
   it('returns known colors for rhaii', () => {
     var colors = productColors('rhaii')
     expect(colors).toBe(PRODUCT_COLORS.rhaii)
-    expect(colors.dot).toContain('sky')
+    expect(colors.dot).toContain('pink')
+  })
+
+  it('returns known colors for rhai', () => {
+    var c = productColors('rhai')
+    expect(c.bg).toContain('amber')
+    expect(c.border).toContain('amber')
+  })
+
+  it('PRODUCT_HEX includes rhai with correct hex color', () => {
+    expect(PRODUCT_HEX.rhai).toBe('#f59e0b')
   })
 
   it('returns DEFAULT_COLORS for unknown product', () => {

--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -27,15 +27,16 @@ function groupKey(release) {
   for (var i = 0; i < names.length; i++) {
     if (!names[i]) continue
     var parsed = parseReleaseName(names[i])
-    if (parsed) return parsed.major + '.' + parsed.minor + '-' + parsed.milestone
+    if (parsed) return parsed.product + '-' + parsed.major + '.' + parsed.minor + '-' + parsed.milestone
   }
   var cycle = extractCycle(release.id) || extractCycle(release.displayName)
   if (cycle) {
     var eaMatch = (release.id || '').match(/ea(\d+)/i)
     var milestone = eaMatch ? 'EA' + eaMatch[1] : 'GA'
-    return cycle + '-' + milestone
+    var product = getProduct(release)
+    return (product ? product + '-' : '') + cycle + '-' + milestone
   }
-  return 'other'
+  return release.displayName || release.id || 'other'
 }
 
 function cycleFromGroupLabel(label) {
@@ -44,7 +45,7 @@ function cycleFromGroupLabel(label) {
 }
 
 function groupLabelFromKey(key) {
-  var m = /^(\d+\.\d+)-(EA\d+|GA)$/.exec(key)
+  var m = /^(?:[a-z]+-)?(\d+\.\d+)-(EA\d+|GA)$/i.exec(key)
   if (m) return m[1] + ' ' + m[2]
   return key
 }
@@ -79,6 +80,8 @@ var allNodes = computed(function () {
     g.milestones.ga = earlierDate(g.milestones.ga, ms.ga)
     var product = getProduct(r)
     if (product) g.products[product] = true
+    if (!g.sourceReleases) g.sourceReleases = []
+    g.sourceReleases.push(r)
   }
 
   var list = []
@@ -98,18 +101,17 @@ var allNodes = computed(function () {
         date: date,
         isPast: days !== null && days < 0,
         isGa: msKey.key === 'ga',
-        productList: productList
+        productList: productList,
+        releases: grp.sourceReleases
       })
     }
   }
 
-  // Merge nodes from the same cycle that share a date — e.g., "3.6 EA1" GA
-  // and "3.6 GA" GA both on Sep 17 should produce one node, not two.
+  // Merge nodes from the same release that share a date.
   var merged = {}
   for (var mi = 0; mi < list.length; mi++) {
     var node = list[mi]
-    var cycle = cycleFromGroupLabel(node.groupLabel)
-    var mergeKey = cycle + '|' + node.date
+    var mergeKey = node.groupLabel + '|' + node.productList.join(',') + '|' + node.date
     if (!merged[mergeKey]) {
       merged[mergeKey] = node
     } else {
@@ -117,10 +119,12 @@ var allNodes = computed(function () {
       if (node.isGa && !existing.isGa) {
         node.productList = existing.productList.concat(node.productList)
           .filter(function (v, i, a) { return a.indexOf(v) === i }).sort()
+        node.releases = (existing.releases || []).concat(node.releases || [])
         merged[mergeKey] = node
       } else {
         existing.productList = existing.productList.concat(node.productList)
           .filter(function (v, i, a) { return a.indexOf(v) === i }).sort()
+        existing.releases = (existing.releases || []).concat(node.releases || [])
       }
     }
   }
@@ -170,7 +174,7 @@ var laneCount = computed(function () {
 })
 
 // Layout constants (shared between chartHeight and plugin)
-var laneBaseStem = 65
+var laneBaseStem = 64
 var subLaneOffset = 80
 var infraSpace = 60
 var lineHeight = 16
@@ -181,6 +185,7 @@ var TODAY_DOT_RADIUS = 8
 var TODAY_DOT_BORDER = 2
 var DOT_HALO_PAD = 1.5
 var PEEK_W = 10
+var CHART_MAX_HEIGHT = 450
 
 function hexToRgba(hex, alpha) {
   if (!hex || hex.charAt(0) !== '#' || hex.length < 7) return hex
@@ -192,70 +197,101 @@ function hexToRgba(hex, alpha) {
 
 var cycleSides = computed(function () {
   var n = allNodes.value
-  var counts = {}
-  var nearestFuture = {}
-  var futureCounts = {}
+  var glMeta = {}
   for (var i = 0; i < n.length; i++) {
-    var cycle = cycleFromGroupLabel(n[i].groupLabel)
-    counts[cycle] = (counts[cycle] || 0) + 1
-    if (!n[i].isPast) {
-      futureCounts[cycle] = (futureCounts[cycle] || 0) + 1
-      var d = parseDate(n[i].date)
-      if (d) {
-        var ts = d.getTime()
-        if (!nearestFuture[cycle] || ts < nearestFuture[cycle]) {
-          nearestFuture[cycle] = ts
-        }
-      }
-    }
+    var gl = n[i].groupLabel
+    if (!glMeta[gl]) glMeta[gl] = { ga: Infinity, earliest: Infinity, versioned: false }
+    var ver = cycleFromGroupLabel(gl)
+    if (/^\d+\.\d+$/.test(ver)) glMeta[gl].versioned = true
+    var d = parseDate(n[i].date)
+    if (!d) continue
+    var ts = d.getTime()
+    if (ts < glMeta[gl].earliest) glMeta[gl].earliest = ts
+    if (n[i].isGa && ts < glMeta[gl].ga) glMeta[gl].ga = ts
   }
-
-  // Pick the cycle with the most future milestones; nearest as tiebreaker
-  var upcomingCycle = null
-  var bestFutureCount = 0
-  var upcomingTs = Infinity
-  var futureCycles = Object.keys(nearestFuture)
-  for (var fi = 0; fi < futureCycles.length; fi++) {
-    var fc = futureCounts[futureCycles[fi]] || 0
-    var fts = nearestFuture[futureCycles[fi]]
-    if (fc > bestFutureCount || (fc === bestFutureCount && fts < upcomingTs)) {
-      bestFutureCount = fc
-      upcomingTs = fts
-      upcomingCycle = futureCycles[fi]
-    }
+  function sortVal(gl) {
+    var m = glMeta[gl]
+    return m.ga < Infinity ? m.ga : m.earliest
   }
-
-  var cycles = Object.keys(counts).sort(function (a, b) {
-    var diff = counts[b] - counts[a]
-    if (diff !== 0) return diff
-    return a < b ? -1 : a > b ? 1 : 0
-  })
+  var versioned = Object.keys(glMeta).filter(function (gl) { return glMeta[gl].versioned })
+  versioned.sort(function (a, b) { return sortVal(a) - sortVal(b) })
   var sides = {}
-  var aboveCount = 0
-  var belowCount = 0
-
-  // Force upcoming cycle above first
-  if (upcomingCycle) {
-    sides[upcomingCycle] = true
-    aboveCount += counts[upcomingCycle]
+  for (var vi = 0; vi < versioned.length; vi++) {
+    sides[versioned[vi]] = vi % 2 === 0
   }
-
-  for (var j = 0; j < cycles.length; j++) {
-    if (sides[cycles[j]] !== undefined) continue
-    if (aboveCount <= belowCount) {
-      sides[cycles[j]] = true
-      aboveCount += counts[cycles[j]]
-    } else {
-      sides[cycles[j]] = false
-      belowCount += counts[cycles[j]]
-    }
+  var nonVersioned = Object.keys(glMeta).filter(function (gl) { return !glMeta[gl].versioned })
+  for (var nvi = 0; nvi < nonVersioned.length; nvi++) {
+    sides[nonVersioned[nvi]] = false
   }
   return sides
 })
 
-function cycleIsAbove(cycle) {
-  return cycleSides.value[cycle] !== false
+var visibleProducts = computed(function () {
+  var seen = {}
+  var n = allNodes.value
+  for (var i = 0; i < n.length; i++) {
+    for (var j = 0; j < n[i].productList.length; j++) {
+      seen[n[i].productList[j]] = true
+    }
+  }
+  return Object.keys(seen).sort()
+})
+
+function productHex(p) { return PRODUCT_HEX[p] || DEFAULT_HEX }
+
+function cycleIsAbove(groupLabel) {
+  if (cycleSides.value[groupLabel] !== undefined) return cycleSides.value[groupLabel] !== false
+  return true
 }
+
+
+var stableCycleRowMap = computed(function () {
+  var n = allNodes.value
+  var cycleMeta = {}
+  for (var i = 0; i < n.length; i++) {
+    var above = cycleIsAbove(n[i].groupLabel)
+    var suffix = above ? '-a' : '-b'
+    var rowKey = n[i].groupLabel + suffix
+    var d = parseDate(n[i].date)
+    if (!d) continue
+    var ts = d.getTime()
+    if (!cycleMeta[rowKey]) {
+      cycleMeta[rowKey] = { earliestGa: Infinity, earliest: Infinity }
+    }
+    if (n[i].isGa && ts < cycleMeta[rowKey].earliestGa) {
+      cycleMeta[rowKey].earliestGa = ts
+    }
+    if (ts < cycleMeta[rowKey].earliest) {
+      cycleMeta[rowKey].earliest = ts
+    }
+  }
+  function sortKey(k) {
+    var m = cycleMeta[k]
+    return m.earliestGa < Infinity ? m.earliestGa : m.earliest
+  }
+  var aboveKeys = []
+  var versionedBelow = []
+  var nonVersionedBelow = []
+  var keys = Object.keys(cycleMeta)
+  for (var ki = 0; ki < keys.length; ki++) {
+    if (keys[ki].endsWith('-a')) {
+      aboveKeys.push(keys[ki])
+    } else {
+      var gl = keys[ki].slice(0, -2)
+      var ver = cycleFromGroupLabel(gl)
+      if (/^\d+\.\d+$/.test(ver)) versionedBelow.push(keys[ki])
+      else nonVersionedBelow.push(keys[ki])
+    }
+  }
+  aboveKeys.sort(function (a, b) { return sortKey(a) - sortKey(b) })
+  versionedBelow.sort(function (a, b) { return sortKey(a) - sortKey(b) })
+  nonVersionedBelow.sort(function (a, b) { return sortKey(a) - sortKey(b) })
+  var belowKeys = versionedBelow.concat(nonVersionedBelow)
+  var map = {}
+  for (var ai = 0; ai < aboveKeys.length; ai++) map[aboveKeys[ai]] = ai
+  for (var bi = 0; bi < belowKeys.length; bi++) map[belowKeys[bi]] = bi
+  return map
+})
 
 var layoutMetrics = computed(function () {
   var n = allNodes.value
@@ -272,38 +308,46 @@ var layoutMetrics = computed(function () {
   var rangeSpan = rangeMax - rangeMin
   if (rangeSpan <= 0) return { aboveSpace: defaultAbove, belowSpace: defaultBelow }
 
-  var cycleRowMapMetrics = {}
+  var rowMap = stableCycleRowMap.value
   var aboveRows = 0
   var belowRows = 0
-  for (var i = 0; i < n.length; i++) {
-    var cycle = cycleFromGroupLabel(n[i].groupLabel)
-    var above = cycleIsAbove(cycle)
-    var sideKey = cycle + (above ? '-a' : '-b')
-    if (!cycleRowMapMetrics[sideKey]) {
-      cycleRowMapMetrics[sideKey] = true
-      if (above) aboveRows++
-      else belowRows++
-    }
+  var rmKeys = Object.keys(rowMap)
+  for (var rmi = 0; rmi < rmKeys.length; rmi++) {
+    if (rmKeys[rmi].endsWith('-a')) aboveRows++
+    else belowRows++
   }
   aboveRows = Math.max(aboveRows, 1)
-  // Use safe offset: max of subLaneOffset and estimated max box height + gap
-  var estMaxBoxH = 5 * lineHeight + boxPad * 2
+  var estMaxBoxH = 3 * lineHeight + boxPad * 2
   var safeOff = Math.max(subLaneOffset, estMaxBoxH + 4 + 6)
   var aboveSpace = laneBaseStem + (aboveRows - 1) * safeOff + 70
   var belowSpace = belowRows > 0
     ? (laneBaseStem + (belowRows - 1) * safeOff + 70)
     : 0
+  var totalRequired = aboveSpace + (belowSpace > infraSpace ? belowSpace : infraSpace) + 40
+  if (totalRequired > CHART_MAX_HEIGHT) {
+    var extraRows = Math.max(0, aboveRows - 1) + Math.max(0, belowRows > 0 ? belowRows - 1 : 0)
+    if (extraRows > 0) {
+      var fixedSpace = 40 + laneBaseStem + 70 + (belowRows > 0 ? laneBaseStem + 70 : infraSpace)
+      safeOff = Math.max(20, (CHART_MAX_HEIGHT - fixedSpace) / extraRows)
+    }
+    aboveSpace = laneBaseStem + Math.max(0, aboveRows - 1) * safeOff + 70
+    belowSpace = belowRows > 0
+      ? laneBaseStem + Math.max(0, belowRows - 1) * safeOff + 70
+      : 0
+  }
   return { aboveSpace: aboveSpace, belowSpace: Math.max(belowSpace, infraSpace), safeOff: safeOff }
 })
 
 var chartHeight = computed(function () {
   var m = layoutMetrics.value
-  return Math.min(m.aboveSpace + m.belowSpace + 40, 450)
+  return Math.min(m.aboveSpace + m.belowSpace + 40, CHART_MAX_HEIGHT)
 })
 
 function fmtDate(dateStr) {
   return formatShort(dateStr, { year: true })
 }
+
+
 
 // Pure stacking logic — extracted for testability.
 // Takes an array of layout objects [{x, boxW, nd: {date, groupLabel}, above}]
@@ -313,8 +357,7 @@ function applyStacking(nodeLayouts, todayTs, peekThreshold) {
   var cycleStacks = {}
   for (var i = 0; i < nodeLayouts.length; i++) {
     if (!nodeLayouts[i]) continue
-    var ckey = cycleFromGroupLabel(nodeLayouts[i].nd.groupLabel)
-      + (nodeLayouts[i].above ? '-a' : '-b')
+    var ckey = nodeLayouts[i].subLane + (nodeLayouts[i].above ? '-a' : '-b')
     if (!cycleStacks[ckey]) cycleStacks[ckey] = []
     cycleStacks[ckey].push(i)
   }
@@ -390,7 +433,10 @@ var nextMilestoneLabel = computed(function () {
   for (var i = 0; i < n.length; i++) {
     var days = daysFromNow(n[i].date)
     if (days !== null && days >= 0) {
-      var desc = n[i].isGa ? n[i].groupLabel : n[i].groupLabel + ' ' + n[i].msLabel
+      var knownProducts = n[i].productList.filter(function (p) { return productLabel(p) !== p })
+      var productPrefix = knownProducts.length
+        ? knownProducts.map(productLabel).join('/') + ' ' : ''
+      var desc = productPrefix + n[i].groupLabel + ' ' + n[i].msLabel
       if (days === 0) return { desc: desc, daysText: 'today' }
       return { desc: desc, daysText: 'in ' + days + 'd' }
     }
@@ -399,6 +445,7 @@ var nextMilestoneLabel = computed(function () {
 })
 
 var showDimLines = ref(true)
+var isOverCard = ref(false)
 var isDark = ref(false)
 var _observer
 onMounted(function () {
@@ -600,6 +647,37 @@ function onPointerUp(event) {
   }
 }
 
+function onCardHover(e) {
+  if (_dragStart) return
+  var canvas = e.currentTarget.querySelector('canvas')
+  if (!canvas) { isOverCard.value = false; return }
+  var canvasRect = canvas.getBoundingClientRect()
+  var cx = e.clientX - canvasRect.left
+  var cy = e.clientY - canvasRect.top
+  for (var i = _cardHitBoxes.length - 1; i >= 0; i--) {
+    var box = _cardHitBoxes[i]
+    if (cx >= box.x && cx <= box.x + box.w && cy >= box.y && cy <= box.y + box.h) {
+      isOverCard.value = true
+      var prevHovered = _hoveredBox
+      _hoveredBox = box
+      if (prevHovered !== _hoveredBox) {
+        if (!prevHovered) _frontNodes.clear()
+        _frontNodes.add(box.nd)
+        if (prevHovered && prevHovered.nd !== box.nd) {
+          _frontNodes.delete(prevHovered.nd)
+        }
+        if (_chartInstance) _chartInstance.draw()
+      }
+      return
+    }
+  }
+  isOverCard.value = false
+  if (_hoveredBox) {
+    _hoveredBox = null
+    if (_chartInstance) _chartInstance.draw()
+  }
+}
+
 var chartData = computed(function () {
   var milestonePoints = []
   var _radii = []
@@ -688,6 +766,10 @@ function _pluginSetup(chart) {
   return { ctx: ctx, area: area, xScale: xScale, yMid: yMid, dark: dark, r: xRange.value }
 }
 
+var _cardHitBoxes = []
+var _hoveredBox = null
+var _frontNodes = new Set()
+
 var timelinePlugin = {
   id: 'releaseTimeline',
   beforeDatasetsDraw: function (chart) {
@@ -758,7 +840,14 @@ var timelinePlugin = {
         for (var nci = 0; nci < nodePxList.length; nci++) {
           if (Math.abs(wpx - nodePxList[nci]) < nodeClearance) { tooCloseToNode = true; break }
         }
-        if (tooCloseToNode) continue
+        if (tooCloseToNode) {
+          if (wk > 0) continue
+          var monthTooClose = false
+          for (var mci = 0; mci < nodePxList.length; mci++) {
+            if (Math.abs(wpx - nodePxList[mci]) < 15) { monthTooClose = true; break }
+          }
+          if (monthTooClose) continue
+        }
         if (wpx > area.left - 60 && wpx < area.right - 15) {
           ctx.globalAlpha = 1.0
           var halfH = (area.bottom - area.top) / 4
@@ -777,9 +866,9 @@ var timelinePlugin = {
           ctx.setLineDash([])
           var wMonthName = MONTH_NAMES[wMonth.getMonth()]
           if (spansYears && wMonth.getMonth() === 0 && wk === 0) wMonthName += ' ' + wMonth.getFullYear()
-          ctx.fillText(wMonthName, wpx, yMid + 30)
+          ctx.fillText(wMonthName, wpx, yMid + 10)
           if (showWeeks) {
-            ctx.fillText('Week ' + (wk + 1), wpx, yMid + 43)
+            ctx.fillText('Week ' + (wk + 1), wpx, yMid + 23)
           }
           ctx.globalAlpha = 1.0
         }
@@ -807,6 +896,7 @@ var timelinePlugin = {
     var _haloPad = 3
 
     ctx.save()
+    _cardHitBoxes = []
 
     // Redraw arrowhead zone to cover any Chart.js dots near the right edge
     var bgColor = dark ? '#1f2937' : '#ffffff'
@@ -821,11 +911,6 @@ var timelinePlugin = {
     ctx.closePath()
     ctx.fill()
 
-    // Per-cycle row assignment: each release cycle gets its own row
-    var cycleRowMap = {}
-    var aboveRowEdges = []
-    var belowRowEdges = []
-
     // First pass: compute box dimensions and assign rows by cycle
     var nodeLayouts = []
     var todayForStack = new Date()
@@ -839,7 +924,6 @@ var timelinePlugin = {
       var x = xScale.getPixelForValue(dt.getTime())
       if (x < area.left - 80 || x > area.right - 15) { nodeLayouts.push(null); continue }
 
-      // Measure text lines (group label as first line in box)
       var lines = []
       ctx.font = 'bold 13px ' + FONT
       lines.push({ text: nd.groupLabel, font: 'bold 13px ' + FONT, color: null, w: ctx.measureText(nd.groupLabel).width })
@@ -848,14 +932,8 @@ var timelinePlugin = {
       ctx.font = '12px ' + FONT
       lines.push({ text: fmtDate(nd.date), font: '12px ' + FONT, color: null, w: ctx.measureText(fmtDate(nd.date)).width })
 
-      // Product label rendered vertically on left side of GA boxes
       var sideLabel = null
       var sideLabelW = 0
-      if (nd.isGa && nd.productList.length) {
-        sideLabel = nd.productList.map(function (p) { return productLabel(p) })
-        ctx.font = 'bold 10px ' + FONT
-        sideLabelW = 14 * nd.productList.length + 4
-      }
 
       var maxW = 0
       for (var li = 0; li < lines.length; li++) {
@@ -864,20 +942,10 @@ var timelinePlugin = {
       var boxW = maxW + boxPad * 2 + sideLabelW
       var boxH = lines.length * lineHeight + boxPad * 2
 
-      var cycle = cycleFromGroupLabel(nd.groupLabel)
-      var above = cycleIsAbove(cycle)
-      var sideKey = cycle + (above ? '-a' : '-b')
-      var edges = above ? aboveRowEdges : belowRowEdges
-
-      var subLane
-      if (cycleRowMap[sideKey] !== undefined) {
-        subLane = cycleRowMap[sideKey]
-      } else {
-        subLane = edges.length
-        edges.push(0)
-        cycleRowMap[sideKey] = subLane
-      }
-      edges[subLane] = Math.max(edges[subLane], x + boxW / 2)
+      var above = cycleIsAbove(nd.groupLabel)
+      var sideKey = nd.groupLabel + (above ? '-a' : '-b')
+      var subLane = stableCycleRowMap.value[sideKey]
+      if (subLane === undefined) subLane = 0
 
       nodeLayouts.push({
         nd: nd, x: x, lines: lines,
@@ -899,7 +967,27 @@ var timelinePlugin = {
       nodeLayouts[sli].stemLen = laneBaseStem + nodeLayouts[sli].subLane * stableOff
     }
 
-    // (Stems are drawn AFTER cards/peeks so the card halo doesn't cover them)
+    // Second pass: draw stems BEFORE cards so card halos cover cross-row overlap
+    for (var ssj = 0; ssj < nodeLayouts.length; ssj++) {
+      var ssLay = nodeLayouts[ssj]
+      if (!ssLay) continue
+      var ssPrimary = ssLay.nd.productList.length
+        ? (PRODUCT_HEX[ssLay.nd.productList[0]] || DEFAULT_HEX)
+        : (ssLay.nd.isPast ? pastColor : futureColor)
+      var stemX = ssLay.x
+      ctx.beginPath()
+      ctx.strokeStyle = ssPrimary
+      ctx.lineWidth = 1
+      ctx.setLineDash([])
+      if (ssLay.above) {
+        ctx.moveTo(stemX, yMid - 6)
+        ctx.lineTo(stemX, yMid - ssLay.stemLen - 8)
+      } else {
+        ctx.moveTo(stemX, yMid + 6)
+        ctx.lineTo(stemX, yMid + ssLay.stemLen + 8)
+      }
+      ctx.stroke()
+    }
 
     // Third pass: draw boxes as card stacks
     // Sort: behind full-cards first (highest stackLevel), top cards last
@@ -909,6 +997,9 @@ var timelinePlugin = {
       if (nodeLayouts[boi]) boxRenderOrder.push(boi)
     }
     boxRenderOrder.sort(function (a, b) {
+      var aFront = _frontNodes.has(nodeLayouts[a].nd) ? 1 : 0
+      var bFront = _frontNodes.has(nodeLayouts[b].nd) ? 1 : 0
+      if (aFront !== bFront) return aFront - bFront
       var sl = (nodeLayouts[b].stackLevel || 0) - (nodeLayouts[a].stackLevel || 0)
       if (sl !== 0) return sl
       // Same stackLevel: draw farther-from-today first so closer cards paint on top
@@ -975,11 +1066,14 @@ var timelinePlugin = {
 
         // Top card: card-like appearance with shadow + glassy fill
         var dateColor = nd2.isPast ? mutedTextColor : (dark ? '#9ca3af' : '#6b7280')
-        layout2.lines[0].color = dark ? '#d1d5db' : '#374151'
-        layout2.lines[1].color = basePrimary2
-        layout2.lines[2].color = dateColor
-        for (var pi = 3; pi < layout2.lines.length; pi++) {
-          layout2.lines[pi].color = PRODUCT_HEX[nd2.productList[pi - 3]] || DEFAULT_HEX
+        for (var ci = 0; ci < layout2.lines.length; ci++) {
+          if (layout2.lines[ci].text === nd2.groupLabel) {
+            layout2.lines[ci].color = dark ? '#d1d5db' : '#374151'
+          } else if (layout2.lines[ci].text === nd2.msLabel) {
+            layout2.lines[ci].color = basePrimary2
+          } else {
+            layout2.lines[ci].color = dateColor
+          }
         }
 
         // Opaque halo: wider on right to cover 2nd card overlap
@@ -1025,53 +1119,42 @@ var timelinePlugin = {
 
         // Border
         drawRoundedRect(ctx, boxX, boxY, layout2.boxW, layout2.boxH, 4)
-        ctx.strokeStyle = dark ? 'rgba(75,85,99,0.6)' : 'rgba(203,213,225,0.8)'
+        var borderHex = nd2.productList.length ? (PRODUCT_HEX[nd2.productList[0]] || DEFAULT_HEX) : null
+        ctx.strokeStyle = borderHex
+          ? hexToRgba(borderHex, dark ? 0.6 : 0.5)
+          : (dark ? 'rgba(75,85,99,0.6)' : 'rgba(203,213,225,0.8)')
         ctx.lineWidth = 1
         ctx.stroke()
 
-        // Side label (vertical product name on GA boxes)
-        var textOffsetX = layout2.sideLabelW
-        if (layout2.sideLabel) {
-          var divX = boxX + layout2.sideLabelW
-          ctx.beginPath()
-          ctx.moveTo(divX, boxY + 6)
-          ctx.lineTo(divX, boxY + layout2.boxH - 6)
-          ctx.strokeStyle = dark ? 'rgba(75,85,99,0.4)' : 'rgba(209,213,219,0.6)'
-          ctx.lineWidth = 0.5
-          ctx.stroke()
-          var labelCy = boxY + layout2.boxH / 2
-          ctx.font = 'bold 10px ' + FONT
-          ctx.textAlign = 'center'
-          ctx.textBaseline = 'middle'
-          for (var pli = 0; pli < layout2.sideLabel.length; pli++) {
-            ctx.save()
-            var labelCx = boxX + 7 + pli * 14
-            ctx.translate(labelCx, labelCy)
-            ctx.rotate(-Math.PI / 2)
-            ctx.fillStyle = PRODUCT_HEX[nd2.productList[pli]] || DEFAULT_HEX
-            ctx.fillText(layout2.sideLabel[pli], 0, 0)
-            ctx.restore()
-          }
+        var textOffsetX = 0
+        if (nd2.productList.length) {
+          var tintHex = PRODUCT_HEX[nd2.productList[0]] || DEFAULT_HEX
+          drawRoundedRect(ctx, boxX, boxY, layout2.boxW, layout2.boxH, 4)
+          ctx.fillStyle = hexToRgba(tintHex, 0.08)
+          ctx.fill()
         }
 
         var textX = boxX + textOffsetX + (layout2.boxW - textOffsetX) / 2
         ctx.textAlign = 'center'
         ctx.textBaseline = 'top'
-        var applyFade = clipApplied && visibleWidth < layout2.boxW * 0.9
+        var applyFade = clipApplied && visibleWidth < layout2.boxW * 0.7
         for (var ti = 0; ti < layout2.lines.length; ti++) {
           ctx.font = layout2.lines[ti].font
+          var lineY = boxY + boxPad + ti * lineHeight
           if (applyFade && fadeOuterX !== null) {
-            var fadeGrad = ctx.createLinearGradient(fadeOuterX, 0, fadeInnerX, 0)
-            fadeGrad.addColorStop(0, layout2.lines[ti].color)
-            fadeGrad.addColorStop(1, hexToRgba(layout2.lines[ti].color, 0))
-            ctx.fillStyle = fadeGrad
-          } else {
-            ctx.fillStyle = layout2.lines[ti].color
-          }
-          ctx.fillText(layout2.lines[ti].text, textX, boxY + boxPad + ti * lineHeight)
+              var fadeGrad = ctx.createLinearGradient(fadeOuterX, 0, fadeInnerX, 0)
+              fadeGrad.addColorStop(0, layout2.lines[ti].color)
+              fadeGrad.addColorStop(0.7, layout2.lines[ti].color)
+              fadeGrad.addColorStop(1, hexToRgba(layout2.lines[ti].color, 0.4))
+              ctx.fillStyle = fadeGrad
+            } else {
+              ctx.fillStyle = layout2.lines[ti].color
+            }
+            ctx.fillText(layout2.lines[ti].text, textX, lineY)
         }
         ctx.globalAlpha = 1.0
         if (clipApplied) ctx.restore()
+        _cardHitBoxes.push({ x: boxX, y: boxY, w: layout2.boxW, h: layout2.boxH, nd: nd2 })
       } else {
         // Behind card: render as peek strip — one per stacked card.
         var topLayout = nodeLayouts[layout2.stackTopIdx]
@@ -1097,7 +1180,8 @@ var timelinePlugin = {
 
         deferredPeeks.push({
           x: peekStripX, y: peekStripY, w: PEEK_W, h: peekStripH,
-          isLeft: behindIsLeft, frontIdx: layout2.stackTopIdx, dotX: layout2.x
+          isLeft: behindIsLeft, frontIdx: layout2.stackTopIdx, dotX: layout2.x,
+          nd: nd2
         })
       }
     }
@@ -1142,6 +1226,10 @@ var timelinePlugin = {
       }
       ctx.fillStyle = peekGrad
       ctx.fill()
+      if (pk.nd.productList.length) {
+        ctx.fillStyle = hexToRgba(PRODUCT_HEX[pk.nd.productList[0]] || DEFAULT_HEX, 0.08)
+        ctx.fill()
+      }
       ctx.restore()
       // Border — open path, skip inner flat edge so it looks like a card edge
       ctx.beginPath()
@@ -1162,32 +1250,13 @@ var timelinePlugin = {
         ctx.arcTo(pk.x + pk.w, pk.y, pk.x + pk.w - peekR, pk.y, peekR)
         ctx.lineTo(pk.x, pk.y)
       }
-      ctx.strokeStyle = dark ? 'rgba(75,85,99,0.6)' : 'rgba(203,213,225,0.8)'
+      var peekBorderHex = pk.nd.productList.length ? (PRODUCT_HEX[pk.nd.productList[0]] || DEFAULT_HEX) : null
+      ctx.strokeStyle = peekBorderHex
+        ? hexToRgba(peekBorderHex, dark ? 0.6 : 0.5)
+        : (dark ? 'rgba(75,85,99,0.6)' : 'rgba(203,213,225,0.8)')
       ctx.lineWidth = 1
       ctx.stroke()
-    }
-
-    // Fifth pass: draw stems AFTER cards/peeks so the card's
-    // opaque halo never covers them.
-    // Every dot gets a stem at its real date position (layout.x).
-    // Stems are straight vertical — OK if they connect to front card's box.
-    for (var ssj = 0; ssj < nodeLayouts.length; ssj++) {
-      var ssLay = nodeLayouts[ssj]
-      if (!ssLay) continue
-      var ssPrimary = ssLay.nd.isPast ? pastColor : futureColor
-      var stemX = ssLay.x
-      ctx.beginPath()
-      ctx.strokeStyle = ssPrimary
-      ctx.lineWidth = 1
-      ctx.setLineDash([])
-      if (ssLay.above) {
-        ctx.moveTo(stemX, yMid - 6)
-        ctx.lineTo(stemX, yMid - ssLay.stemLen - 4)
-      } else {
-        ctx.moveTo(stemX, yMid + 6)
-        ctx.lineTo(stemX, yMid + ssLay.stemLen + 4)
-      }
-      ctx.stroke()
+      _cardHitBoxes.push({ x: pk.x, y: pk.y, w: pk.w, h: pk.h, nd: pk.nd })
     }
 
     // Draw milestone dots
@@ -1214,7 +1283,9 @@ var timelinePlugin = {
     for (var dri = 0; dri < dotOrder.length; dri++) {
       var dLayout = nodeLayouts[dotOrder[dri]]
       var dIdx = dotOrder[dri]
-      var dotColor = n[dIdx].isPast ? pastColor : futureColor
+      var dotColor = n[dIdx].productList.length
+        ? (PRODUCT_HEX[n[dIdx].productList[0]] || DEFAULT_HEX)
+        : (n[dIdx].isPast ? pastColor : futureColor)
       var dotDrawX = dLayout.x
       ctx.globalAlpha = 1.0
 
@@ -1254,72 +1325,132 @@ var timelinePlugin = {
       var dimColor = dark ? 'rgba(107,114,128,0.35)' : 'rgba(156,163,175,0.35)'
       var dimTextColor = dark ? 'rgba(107,114,128,0.55)' : 'rgba(156,163,175,0.65)'
 
-      var aboveDimPoints = []
-      var belowDimPoints = []
-      for (var di = 0; di < nodeLayouts.length; di++) {
-        var dl = nodeLayouts[di]
-        if (!dl) continue
-        var dDate = parseDate(dl.nd.date)
-        if (!dDate) continue
-        var pt = { x: dl.x, ts: dDate.getTime() }
-        if (dl.above) aboveDimPoints.push(pt)
-        else belowDimPoints.push(pt)
-      }
-
       var todayDim = new Date()
       todayDim.setHours(0, 0, 0, 0)
       var todayTsDim = todayDim.getTime()
-      if (todayTsDim >= r.min && todayTsDim <= r.max) {
-        var todayPxDim = xScale.getPixelForValue(todayTsDim)
-        var todayPtDim = { x: todayPxDim, ts: todayTsDim }
-        aboveDimPoints.push(todayPtDim)
-        belowDimPoints.push(todayPtDim)
+      var todayInView = todayTsDim >= r.min && todayTsDim <= r.max
+      var todayPxDim = todayInView ? xScale.getPixelForValue(todayTsDim) : null
+
+      var dimGroups = {}
+      for (var di = 0; di < nodeLayouts.length; di++) {
+        var dl = nodeLayouts[di]
+        if (!dl) continue
+        if (!/^\d+\.\d+$/.test(cycleFromGroupLabel(dl.nd.groupLabel))) continue
+        var dDate = parseDate(dl.nd.date)
+        if (!dDate) continue
+        var dimKey = dl.nd.groupLabel + (dl.above ? '-a' : '-b')
+        if (!dimGroups[dimKey]) dimGroups[dimKey] = { points: [], above: dl.above, productList: dl.nd.productList || [] }
+        dimGroups[dimKey].points.push({ x: dl.x, ts: dDate.getTime() })
       }
 
-      var dimSets = [
-        { points: aboveDimPoints, lineY: yMid - 14, textBase: 'bottom', textOff: -3 },
-        { points: belowDimPoints, lineY: yMid + 14, textBase: 'top', textOff: 2 }
-      ]
+      if (todayInView) {
+        var dgKeys = Object.keys(dimGroups)
+        for (var tdi = 0; tdi < dgKeys.length; tdi++) {
+          dimGroups[dgKeys[tdi]].points.push({ x: todayPxDim, ts: todayTsDim })
+        }
+      }
 
-      for (var dsi = 0; dsi < dimSets.length; dsi++) {
-        var ds = dimSets[dsi]
-        ds.points.sort(function (a, b) { return a.ts - b.ts })
-        for (var dj = 1; dj < ds.points.length; dj++) {
-          var diffDays = Math.round((ds.points[dj].ts - ds.points[dj - 1].ts) / DAY_MS)
-          var leftX = ds.points[dj - 1].x + dimGap
-          var rightX = ds.points[dj].x - dimGap
-          var dimMidX = (leftX + rightX) / 2
-          var dimLabelOverlapsToday = todayPxDim !== undefined
-            && Math.abs(dimMidX - todayPxDim) < 40
-            && ds.lineY > yMid
-          if (diffDays > 0 && rightX - leftX > 20 && !dimLabelOverlapsToday) {
-            ctx.globalAlpha = 1.0
-            ctx.strokeStyle = dimColor
-            ctx.fillStyle = dimColor
-            ctx.lineWidth = 0.5
-            ctx.setLineDash([])
-            ctx.beginPath()
-            ctx.moveTo(leftX, ds.lineY)
-            ctx.lineTo(rightX, ds.lineY)
-            ctx.stroke()
-            ctx.beginPath()
-            ctx.moveTo(leftX + arrowSize * 2, ds.lineY - arrowSize)
-            ctx.lineTo(leftX, ds.lineY)
-            ctx.lineTo(leftX + arrowSize * 2, ds.lineY + arrowSize)
-            ctx.stroke()
-            ctx.beginPath()
-            ctx.moveTo(rightX - arrowSize * 2, ds.lineY - arrowSize)
-            ctx.lineTo(rightX, ds.lineY)
-            ctx.lineTo(rightX - arrowSize * 2, ds.lineY + arrowSize)
-            ctx.stroke()
-            ctx.font = '10px ' + FONT
-            ctx.fillStyle = dimTextColor
-            ctx.textAlign = 'center'
-            ctx.textBaseline = ds.textBase
-            ctx.fillText(diffDays + 'd', (leftX + rightX) / 2, ds.lineY + ds.textOff)
-            ctx.globalAlpha = 1.0
+      var dimGroupKeys = Object.keys(dimGroups)
+
+      // Build all segments from viewport-filtered dim groups
+      var allDimSegs = []
+      for (var dgi = 0; dgi < dimGroupKeys.length; dgi++) {
+        var dg = dimGroups[dimGroupKeys[dgi]]
+        if (dg.points.length < 2) continue
+        dg.points.sort(function (a, b) { return a.ts - b.ts })
+        for (var dj = 1; dj < dg.points.length; dj++) {
+          var segDiffDays = Math.round((dg.points[dj].ts - dg.points[dj - 1].ts) / DAY_MS)
+          if (segDiffDays <= 0) continue
+          var segLeftX = dg.points[dj - 1].x + dimGap
+          var segRightX = dg.points[dj].x - dimGap
+          if (segRightX - segLeftX <= 20) continue
+          allDimSegs.push({
+            gi: dgi, above: dg.above,
+            left: segLeftX, right: segRightX,
+            diffDays: segDiffDays,
+            needsLabel: false,
+            leftIsToday: dg.points[dj - 1].ts === todayTsDim,
+            rightIsToday: dg.points[dj].ts === todayTsDim
+          })
+        }
+      }
+
+      // Per-segment overlap: mark segments that share horizontal space with a different group on same side
+      for (var osi = 0; osi < allDimSegs.length; osi++) {
+        for (var osj = 0; osj < allDimSegs.length; osj++) {
+          if (allDimSegs[osj].gi !== allDimSegs[osi].gi &&
+              allDimSegs[osj].above === allDimSegs[osi].above &&
+              allDimSegs[osj].left < allDimSegs[osi].right &&
+              allDimSegs[osi].left < allDimSegs[osj].right) {
+            allDimSegs[osi].needsLabel = true
+            break
           }
         }
+      }
+
+      // Render segments
+      for (var sri = 0; sri < allDimSegs.length; sri++) {
+        var seg = allDimSegs[sri]
+        var srDgKey = dimGroupKeys[seg.gi]
+        var srRowIdx = stableCycleRowMap.value[srDgKey] || 0
+        var srYOff = 36 + srRowIdx * 14
+        var srLineY = seg.above ? yMid - srYOff : yMid + srYOff
+        ctx.globalAlpha = 1.0
+        ctx.strokeStyle = dimColor
+        ctx.fillStyle = dimColor
+        ctx.lineWidth = 0.5
+        ctx.setLineDash([])
+
+        ctx.font = '10px ' + FONT
+        var srLabel = seg.diffDays + 'd'
+        if (seg.needsLabel) {
+          var srProducts = dimGroups[srDgKey].productList.filter(function (p) { return productLabel(p) !== p })
+          var srProductPrefix = srProducts.length ? srProducts.map(productLabel).join('/') + ' ' : ''
+          srLabel += ' (' + srProductPrefix + srDgKey.replace(/-[ab]$/, '') + ')'
+        }
+        var srLabelW = ctx.measureText(srLabel).width
+        var srLabelX = (seg.left + seg.right) / 2
+        var srGapHalf = srLabelW / 2 + 4
+
+        ctx.beginPath()
+        ctx.moveTo(seg.left, srLineY)
+        ctx.lineTo(srLabelX - srGapHalf, srLineY)
+        ctx.stroke()
+        ctx.beginPath()
+        ctx.moveTo(srLabelX + srGapHalf, srLineY)
+        ctx.lineTo(seg.right, srLineY)
+        ctx.stroke()
+
+        if (seg.leftIsToday) {
+          ctx.beginPath()
+          ctx.arc(seg.left, srLineY, arrowSize + 1, 0, Math.PI * 2)
+          ctx.fillStyle = dark ? '#f87171' : '#ef4444'
+          ctx.fill()
+        } else {
+          ctx.beginPath()
+          ctx.moveTo(seg.left + arrowSize * 2, srLineY - arrowSize)
+          ctx.lineTo(seg.left, srLineY)
+          ctx.lineTo(seg.left + arrowSize * 2, srLineY + arrowSize)
+          ctx.stroke()
+        }
+        if (seg.rightIsToday) {
+          ctx.beginPath()
+          ctx.arc(seg.right, srLineY, arrowSize + 1, 0, Math.PI * 2)
+          ctx.fillStyle = dark ? '#f87171' : '#ef4444'
+          ctx.fill()
+        } else {
+          ctx.beginPath()
+          ctx.moveTo(seg.right - arrowSize * 2, srLineY - arrowSize)
+          ctx.lineTo(seg.right, srLineY)
+          ctx.lineTo(seg.right - arrowSize * 2, srLineY + arrowSize)
+          ctx.stroke()
+        }
+
+        ctx.fillStyle = dimTextColor
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.fillText(srLabel, srLabelX, srLineY)
+        ctx.globalAlpha = 1.0
       }
     }
 
@@ -1355,7 +1486,7 @@ var timelinePlugin = {
       var haloW = Math.max(youW, nmlW) + 12
       var haloH = nmlText ? 30 : 16
       var haloX = todayX - haloW / 2
-      var haloY = yMid + 25
+      var haloY = yMid + 5
       ctx.fillStyle = dark ? '#1f2937' : '#ffffff'
       ctx.fillRect(haloX, haloY, haloW, haloH)
 
@@ -1363,16 +1494,26 @@ var timelinePlugin = {
       ctx.fillStyle = redColor
       ctx.textAlign = 'center'
       ctx.textBaseline = 'top'
-      ctx.fillText(youText, todayX, yMid + 30)
+      ctx.fillText(youText, todayX, yMid + 10)
 
       if (nmlText) {
         ctx.font = '10px ' + FONT
         ctx.fillStyle = dark ? '#fca5a5' : '#dc2626'
-        ctx.fillText(nmlText, todayX, yMid + 43)
+        ctx.fillText(nmlText, todayX, yMid + 23)
       }
       ctx.globalAlpha = 1.0
     } else {
       _todayPx.value = null
+    }
+
+    if (_hoveredBox) {
+      ctx.save()
+      ctx.strokeStyle = dark ? 'rgba(96,165,250,0.5)' : 'rgba(59,130,246,0.4)'
+      ctx.lineWidth = 2
+      drawRoundedRect(ctx, _hoveredBox.x - 1, _hoveredBox.y - 1,
+                      _hoveredBox.w + 2, _hoveredBox.h + 2, 5)
+      ctx.stroke()
+      ctx.restore()
     }
 
     ctx.restore()
@@ -1400,12 +1541,14 @@ var timelinePlugin = {
       </div>
       <div
         class="relative"
-        :style="{ height: chartHeight + 'px', cursor: isZoomed ? 'grab' : 'default' }"
+        :style="{ height: chartHeight + 'px', cursor: isOverCard ? 'pointer' : (isZoomed ? 'grab' : 'default') }"
         @wheel="onWheel"
         @pointerdown="onPointerDown"
         @pointermove="onPointerMove"
         @pointerup="onPointerUp"
         @pointercancel="onPointerUp"
+        @mousemove="onCardHover"
+        @mouseleave="isOverCard = false"
       >
         <Scatter :data="chartData" :options="chartOptions"
                  :plugins="[timelinePlugin]" />
@@ -1421,6 +1564,12 @@ var timelinePlugin = {
         <!-- Days view indicator -->
         <span class="absolute bottom-1 right-2 text-[10px] text-gray-400 dark:text-gray-500 tabular-nums pointer-events-none">
           {{ visibleDays }}d view
+        </span>
+      </div>
+      <div v-if="visibleProducts.length" class="flex items-center justify-center gap-4 mt-1.5 text-[10px] text-gray-500 dark:text-gray-400">
+        <span v-for="p in visibleProducts" :key="p" class="flex items-center gap-1">
+          <span class="w-2 h-2 rounded-full" :style="{ backgroundColor: productHex(p) }"></span>
+          {{ productLabel(p) }}
         </span>
       </div>
     </div>

--- a/modules/releases/client/composables/useProductColors.js
+++ b/modules/releases/client/composables/useProductColors.js
@@ -1,15 +1,17 @@
 var PRODUCT_COLORS = {
   rhoai: { bg: 'bg-violet-50 dark:bg-violet-900/15', border: 'border-l-violet-500', badge: 'bg-violet-100 dark:bg-violet-800/40 text-violet-700 dark:text-violet-300', dot: 'bg-violet-500' },
-  rhelai: { bg: 'bg-teal-50 dark:bg-teal-900/15', border: 'border-l-teal-500', badge: 'bg-teal-100 dark:bg-teal-800/40 text-teal-700 dark:text-teal-300', dot: 'bg-teal-500' },
-  rhaii: { bg: 'bg-sky-50 dark:bg-sky-900/15', border: 'border-l-sky-500', badge: 'bg-sky-100 dark:bg-sky-800/40 text-sky-700 dark:text-sky-300', dot: 'bg-sky-500' }
+  rhelai: { bg: 'bg-emerald-50 dark:bg-emerald-900/15', border: 'border-l-emerald-500', badge: 'bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300', dot: 'bg-emerald-500' },
+  rhaii: { bg: 'bg-pink-50 dark:bg-pink-900/15', border: 'border-l-pink-500', badge: 'bg-pink-100 dark:bg-pink-800/40 text-pink-700 dark:text-pink-300', dot: 'bg-pink-500' },
+  rhai: { bg: 'bg-amber-50 dark:bg-amber-900/15', border: 'border-l-amber-500', badge: 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300', dot: 'bg-amber-500' }
 }
 
 var DEFAULT_COLORS = { bg: 'bg-gray-50 dark:bg-gray-800/50', border: 'border-l-gray-400', badge: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300', dot: 'bg-gray-400' }
 
 var PRODUCT_HEX = {
   rhoai: '#8b5cf6',
-  rhelai: '#14b8a6',
-  rhaii: '#0ea5e9'
+  rhelai: '#10b981',
+  rhaii: '#f472b6',
+  rhai: '#f59e0b'
 }
 var DEFAULT_HEX = '#9ca3af'
 

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -4,13 +4,13 @@ import { countUniqueCategoryTotals } from './mergeReleaseDetails'
 // ═══ RELEASE NAME PARSING ═══
 
 /** Legacy: rhoai-3.6.EA1, RHELAI-3.2 */
-var LEGACY_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+var LEGACY_PATTERN = /^(rhoai|rhelai|rhaii|rhai)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
 
 /** Product-family Jira names: "3.6 EA1 RHOAI RELEASE", "3.5 GA RHELAI RELEASE" */
-var PRODUCT_FAMILY_PATTERN = /^(\d+)\.(\d+)\s+(EA(\d+)|GA)\s+(RHOAI|RHAII|RHELAI)\s+RELEASE$/i
+var PRODUCT_FAMILY_PATTERN = /^(\d+)\.(\d+)\s+(EA(\d+)|GA)\s+(RHOAI|RHAII|RHELAI|RHAI)\s+RELEASE$/i
 
-var PRODUCT_ORDER = { rhoai: 0, rhaii: 1, rhelai: 2 }
-var PRODUCT_LABELS = { rhoai: 'RHOAI', rhelai: 'RHELAI', rhaii: 'RHAII' }
+var PRODUCT_ORDER = { rhoai: 0, rhaii: 1, rhelai: 2, rhai: 3 }
+var PRODUCT_LABELS = { rhoai: 'RHOAI', rhelai: 'RHELAI', rhaii: 'RHAII', rhai: 'RHAI' }
 
 /**
  * Parse a release name into structured parts.
@@ -85,7 +85,7 @@ function formatSortedVersions(value) {
 function extractProduct(name) {
   var parsed = parseReleaseName(name)
   if (parsed) return parsed.product
-  var m = /^(rhoai|rhelai|rhaii)/i.exec(name)
+  var m = /^(rhoai|rhelai|rhaii|rhai)/i.exec(name)
   return m ? m[1].toLowerCase() : null
 }
 
@@ -152,13 +152,13 @@ function getAlignmentTarget(days) {
 function extractFamily(name) {
   var parsed = parseReleaseName(name)
   if (parsed) return parsed.product + '-' + parsed.major + '.' + parsed.minor
-  var m = /^(rhoai|rhelai|rhaii)[- _](\d+\.\d+)/i.exec(name)
+  var m = /^(rhoai|rhelai|rhaii|rhai)[- _](\d+\.\d+)/i.exec(name)
   if (m) return m[1].toLowerCase() + '-' + m[2]
   return name.toLowerCase()
 }
 
 function familyLabel(familyKey) {
-  var m = /^(rhoai|rhelai|rhaii)-(.+)$/.exec(familyKey)
+  var m = /^(rhoai|rhelai|rhaii|rhai)-(.+)$/.exec(familyKey)
   if (m) return PRODUCT_LABELS[m[1]] + ' ' + m[2]
   return familyKey
 }

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -133,6 +133,23 @@
         </label>
       </div>
 
+      <div v-if="availableVersions.length > 1" class="flex flex-wrap gap-2 mb-5 -mt-3">
+        <button
+          v-for="v in availableVersions"
+          :key="v"
+          @click="toggleVersion(v)"
+          class="px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors border"
+          :class="selectedVersions.indexOf(v) !== -1
+            ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+            : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+        >{{ v }}</button>
+        <button
+          v-if="selectedVersions.length > 0"
+          @click="selectedVersions = []"
+          class="px-2.5 py-0.5 rounded-full text-[11px] font-medium text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        >Clear</button>
+      </div>
+
       <!-- Release Timeline -->
       <ReleaseTimeline :releases="baseFilteredReleases" :hide-past="hideReleased" />
 
@@ -198,6 +215,7 @@ import {
   getProduct, getStream, releasePhase, milestoneProgress
 } from '../composables/useScheduleHelpers.js'
 import ReleaseTimeline from '../components/ReleaseTimeline.vue'
+import { parseReleaseName } from '../composables/useReleaseFamily.js'
 
 function formatShort(dateStr) {
   return formatShortBase(dateStr, { year: true })
@@ -211,6 +229,7 @@ const error = ref(null)
 const selectedProduct = ref(null)
 const selectedStream = ref(null)
 const hideReleased = ref(true)
+const selectedVersions = ref([])
 
 async function fetchRegistry() {
   loading.value = true
@@ -232,6 +251,22 @@ onMounted(fetchRegistry)
 
 function getGaDate(release) {
   return release.milestones?.ga || null
+}
+
+function versionLabel(release) {
+  var name = release.displayName || release.id
+  var parsed = parseReleaseName(name)
+  if (parsed) return parsed.major + '.' + parsed.minor + ' ' + parsed.milestone
+  return null
+}
+
+function toggleVersion(v) {
+  var idx = selectedVersions.value.indexOf(v)
+  if (idx === -1) {
+    selectedVersions.value = selectedVersions.value.concat(v)
+  } else {
+    selectedVersions.value = selectedVersions.value.filter(function (x) { return x !== v })
+  }
 }
 
 function nextMilestone(release) {
@@ -270,6 +305,36 @@ const streams = computed(() => {
   return Object.keys(set).sort()
 })
 
+const availableVersions = computed(() => {
+  var seen = {}
+  var list = []
+  var base = releases.value
+  if (selectedProduct.value) {
+    base = base.filter(r => getProduct(r) === selectedProduct.value)
+  }
+  for (var i = 0; i < base.length; i++) {
+    var v = versionLabel(base[i])
+    if (v && !seen[v]) {
+      seen[v] = true
+      list.push(v)
+    }
+  }
+  list.sort(function (a, b) {
+    var ma = /^(\d+)\.(\d+)\s+(EA(\d+)|GA)$/.exec(a)
+    var mb = /^(\d+)\.(\d+)\s+(EA(\d+)|GA)$/.exec(b)
+    if (!ma && !mb) return a.localeCompare(b)
+    if (!ma) return 1
+    if (!mb) return -1
+    var ca = parseInt(ma[1]) * 100 + parseInt(ma[2])
+    var cb = parseInt(mb[1]) * 100 + parseInt(mb[2])
+    if (ca !== cb) return cb - ca
+    var oa = ma[3] === 'GA' ? 99 : parseInt(ma[4])
+    var ob = mb[3] === 'GA' ? 99 : parseInt(mb[4])
+    return ob - oa
+  })
+  return list
+})
+
 const baseFilteredReleases = computed(() => {
   let list = releases.value
   if (selectedProduct.value) {
@@ -277,6 +342,12 @@ const baseFilteredReleases = computed(() => {
   }
   if (selectedStream.value) {
     list = list.filter(r => getStream(r) === selectedStream.value)
+  }
+  if (selectedVersions.value.length > 0) {
+    list = list.filter(r => {
+      var v = versionLabel(r)
+      return v && selectedVersions.value.indexOf(v) !== -1
+    })
   }
   return list
 })

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -136,6 +136,7 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }

--- a/tests/integration/release-timeline.spec.js
+++ b/tests/integration/release-timeline.spec.js
@@ -272,4 +272,25 @@ test.describe('Release Timeline @release-timeline @releases', () => {
     await expect(canvas).toBeVisible();
     expect(page.errors).toHaveLength(0);
   });
+
+  test('version filter pills appear and are clickable', async ({ page }) => {
+    await page.goto('/#/releases/schedule');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var versionPills = page.locator('button').filter({ hasText: /^\d+\.\d+\s+(EA\d+|GA)$/ });
+    var pillCount = await versionPills.count();
+    expect(pillCount).toBeGreaterThan(0);
+
+    await versionPills.first().click();
+    await page.waitForTimeout(500);
+
+    var clearBtn = page.locator('button', { hasText: 'Clear' });
+    await expect(clearBtn).toBeVisible();
+
+    await clearBtn.click();
+    await page.waitForTimeout(500);
+
+    expect(page.errors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- **Inline dim line labels**: Text sits centered on the line with a gap, like technical dimension lines — replaces the floating text with opaque background
- **Red dot at "today"**: Dim line endpoints touching the today marker render as a small red filled dot instead of an arrowhead
- **Product name in labels**: Overlapping dim lines show product prefix (e.g., "4d (RHOAI 3.6 EA2)" instead of "4d (3.6 EA2)")
- **"YOU ARE HERE" caption**: Now includes product name and always shows full milestone (e.g., "RHOAI 3.5 GA Generally Available in 1d")
- **Infra exclusion**: Non-versioned releases (e.g., "Security Hardening") excluded from dim line rendering
- **Per-segment overlap**: Version labels only appear on segments that actually overlap horizontally, not globally
- **Y layout reorder**: Tick labels closest to axis → dim lines → cards, with increased spacing (laneBaseStem 28→64)

Follows up on #1454 (merged).

**Jira**: [RHOAIENG-82037](https://redhat.atlassian.net/browse/RHOAIENG-82037)

## Test plan
- [x] All 5445 unit tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [ ] Visual verification at `/#/releases/schedule` — dim line labels inline, red dots at today, product names in overlapping labels, correct Y spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)