### PR TITLE
feat(releases): Add Docs Required filter to Feature Execution Tracking

### DIFF
--- a/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
+++ b/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
@@ -8,6 +8,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
   var selectedStatuses = ref([])
   var selectedComponents = ref([])
   var selectedOwners = ref([])
+  var selectedDocsRequired = ref([])
   var activeCardFilter = ref(null)
 
   // --- Derived option lists from FULL unfiltered groups (Risk 3 mitigation) ---
@@ -88,6 +89,29 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     return result
   })
 
+  var availableDocsRequired = computed(function () {
+    var seen = {}
+    var result = []
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        var val = features[j].docsRequired || null
+        var label = val || 'Not Set'
+        if (!seen[label]) {
+          seen[label] = true
+          result.push(label)
+        }
+      }
+    }
+    var order = { Yes: 0, No: 1, 'Not Set': 2 }
+    result.sort(function (a, b) {
+      var oa = order[a] != null ? order[a] : 99
+      var ob = order[b] != null ? order[b] : 99
+      return oa - ob
+    })
+    return result
+  })
+
   // --- Total (unfiltered) counts for summary cards (Risk 2 mitigation) ---
 
   var totalFeatures = computed(function () {
@@ -150,7 +174,8 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     var hasFeatureFilters = searchQuery.value ||
       selectedStatuses.value.length > 0 ||
       selectedComponents.value.length > 0 ||
-      selectedOwners.value.length > 0
+      selectedOwners.value.length > 0 ||
+      selectedDocsRequired.value.length > 0
 
     if (!hasFeatureFilters) return result
 
@@ -182,6 +207,10 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
           var ownerMatch = (f.assignee && selectedOwners.value.includes(f.assignee)) ||
             (f.pmOwner && selectedOwners.value.includes(f.pmOwner))
           if (!ownerMatch) return false
+        }
+        if (selectedDocsRequired.value.length > 0) {
+          var docVal = f.docsRequired || 'Not Set'
+          if (!selectedDocsRequired.value.includes(docVal)) return false
         }
         return true
       })
@@ -239,7 +268,8 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
       selectedProducts.value.length > 0 ||
       selectedStatuses.value.length > 0 ||
       selectedComponents.value.length > 0 ||
-      selectedOwners.value.length > 0)
+      selectedOwners.value.length > 0 ||
+      selectedDocsRequired.value.length > 0)
   })
 
   var isFiltered = computed(function () {
@@ -259,6 +289,9 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     }
     if (selectedOwners.value.length > 0) {
       labels.push({ type: 'owners', label: 'Owner: ' + selectedOwners.value.join(', ') })
+    }
+    if (selectedDocsRequired.value.length > 0) {
+      labels.push({ type: 'docsRequired', label: 'Docs Required: ' + selectedDocsRequired.value.join(', ') })
     }
     if (searchQuery.value) {
       labels.push({ type: 'search', label: 'Search: "' + searchQuery.value + '"' })
@@ -283,6 +316,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     else if (type === 'status') selectedStatuses.value = []
     else if (type === 'components') selectedComponents.value = []
     else if (type === 'owners') selectedOwners.value = []
+    else if (type === 'docsRequired') selectedDocsRequired.value = []
     else if (type === 'search') searchQuery.value = ''
     else if (type === 'card') activeCardFilter.value = null
   }
@@ -293,6 +327,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     selectedStatuses.value = []
     selectedComponents.value = []
     selectedOwners.value = []
+    selectedDocsRequired.value = []
     activeCardFilter.value = null
   }
 
@@ -312,7 +347,8 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
           selectedProducts: selectedProducts.value,
           selectedStatuses: selectedStatuses.value,
           selectedComponents: selectedComponents.value,
-          selectedOwners: selectedOwners.value
+          selectedOwners: selectedOwners.value,
+          selectedDocsRequired: selectedDocsRequired.value
         })
       )
     } catch { /* quota / private mode */ }
@@ -333,6 +369,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
         var stats = availableStatuses.value
         var comps = availableComponents.value
         var owners = availableOwners.value
+        var docs = availableDocsRequired.value
         if (Array.isArray(saved.selectedProducts)) {
           selectedProducts.value = saved.selectedProducts.filter(function (v) { return prods.includes(v) })
         }
@@ -341,6 +378,9 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
         }
         if (Array.isArray(saved.selectedComponents)) {
           selectedComponents.value = saved.selectedComponents.filter(function (v) { return comps.includes(v) })
+        }
+        if (Array.isArray(saved.selectedDocsRequired)) {
+          selectedDocsRequired.value = saved.selectedDocsRequired.filter(function (v) { return docs.includes(v) })
         }
         if (Array.isArray(saved.selectedOwners)) {
           selectedOwners.value = saved.selectedOwners.filter(function (v) { return owners.includes(v) })
@@ -357,12 +397,13 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     selectedStatuses.value = []
     selectedComponents.value = []
     selectedOwners.value = []
+    selectedDocsRequired.value = []
     activeCardFilter.value = null
     nextTick(function () { _suspendSave = false })
   }
 
   watch(
-    [searchQuery, selectedProducts, selectedStatuses, selectedComponents, selectedOwners],
+    [searchQuery, selectedProducts, selectedStatuses, selectedComponents, selectedOwners, selectedDocsRequired],
     saveFilters,
     { deep: true }
   )
@@ -373,12 +414,14 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     selectedStatuses,
     selectedComponents,
     selectedOwners,
+    selectedDocsRequired,
     activeCardFilter,
 
     availableProducts,
     availableStatuses,
     availableComponents,
     availableOwners,
+    availableDocsRequired,
 
     totalFeatures,
     totalAddedCount,

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -42,12 +42,14 @@ const {
   selectedStatuses,
   selectedComponents,
   selectedOwners,
+  selectedDocsRequired,
   activeCardFilter,
 
   availableProducts,
   availableStatuses,
   availableComponents,
   availableOwners,
+  availableDocsRequired,
 
   totalFeatures,
   totalAddedCount,
@@ -254,6 +256,12 @@ onMounted(async () => {
         :options="availableOwners"
         placeholder="All Owners"
         @update:modelValue="v => selectedOwners = v"
+      />
+      <HygieneSelect
+        :modelValue="selectedDocsRequired"
+        :options="availableDocsRequired"
+        placeholder="Docs Required"
+        @update:modelValue="v => selectedDocsRequired = v"
       />
       <span
         v-if="isToolbarFiltered"

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -87,7 +87,8 @@ const FIELDS_TO_FETCH = [
   CUSTOM_FIELDS.statusSummary,
   CUSTOM_FIELDS.colorStatus,
   CUSTOM_FIELDS.productManager,
-  CUSTOM_FIELDS.blockedDropdown
+  CUSTOM_FIELDS.blockedDropdown,
+  CUSTOM_FIELDS.docsRequired
 ].join(',')
 
 function cacheKey(portfolioVersion) {
@@ -738,7 +739,8 @@ module.exports = async function registerFeatureTrackingRoutes(router, context) {
               team: f.team || null,
               scopeChange: f.scopeChange || null,
               fixVersionAddedAt: f.fixVersionAddedAt || null,
-              fixVersionRemovedAt: f.fixVersionRemovedAt || null
+              fixVersionRemovedAt: f.fixVersionRemovedAt || null,
+              docsRequired: f.docsRequired || null
             }
           })
         })

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1644,6 +1644,46 @@ async function dismissHygieneWelcome(page) {
   }
 }
 
+test.describe('Feature Execution Tracking @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should load Feature Tracking view with Docs Required filter', async ({ page }) => {
+    // Navigate to Execute view (Feature Tracking is the default tab)
+    await page.goto('/#/releases/execute');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Verify the "Docs Required" filter is present (it might be the active chip or the placeholder)
+    // The placeholder is "Docs Required", but when an option is selected it changes (e.g. "Docs Required: Not Set")
+    // We use a broader locator to find the dropdown container
+    const filterContainer = page.locator('text=Docs Required').first();
+    await expect(filterContainer).toBeVisible();
+
+    // Click to open the dropdown
+    await filterContainer.click();
+    await page.waitForTimeout(500);
+
+    // Verify the expected options are present
+    await expect(page.locator('text=Clear all').first()).toBeVisible();
+    await expect(page.locator('text=Yes').first()).toBeVisible();
+    await expect(page.locator('text=No').first()).toBeVisible();
+    await expect(page.locator('text=Not Set').first()).toBeVisible();
+
+    // Close the dropdown
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    // Verify no errors occurred
+    expect(page.errors).toHaveLength(0);
+  });
+});
+
 test.describe('Feature Status filtering @releases', () => {
   test.beforeEach(async ({ page }) => {
     setupErrorTracking(page);

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1669,17 +1669,20 @@ test.describe('Feature Execution Tracking @releases', () => {
     await filterContainer.click();
     await page.waitForTimeout(500);
 
-    // Verify the expected options are present
-    await expect(page.locator('text=Yes').first()).toBeVisible();
-    await expect(page.locator('text=No').first()).toBeVisible();
-    await expect(page.locator('text=Not Set').first()).toBeVisible();
+    // Locate the opened dropdown menu
+    const dropdownMenu = page.locator('.absolute.z-30').first();
+
+    // Verify the expected options are present inside the dropdown
+    await expect(dropdownMenu.locator('text=Yes').first()).toBeVisible();
+    await expect(dropdownMenu.locator('text=No').first()).toBeVisible();
+    await expect(dropdownMenu.locator('text=Not Set').first()).toBeVisible();
 
     // Select "Not Set"
-    await page.locator('text=Not Set').first().click();
+    await dropdownMenu.locator('text=Not Set').first().click();
     await page.waitForTimeout(300);
 
     // Now Clear all should be visible because an option is selected
-    await expect(page.locator('text=Clear all').first()).toBeVisible();
+    await expect(dropdownMenu.locator('text=Clear all').first()).toBeVisible();
 
     // Close the dropdown
     await page.keyboard.press('Escape');

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1670,10 +1670,16 @@ test.describe('Feature Execution Tracking @releases', () => {
     await page.waitForTimeout(500);
 
     // Verify the expected options are present
-    await expect(page.locator('text=Clear all').first()).toBeVisible();
     await expect(page.locator('text=Yes').first()).toBeVisible();
     await expect(page.locator('text=No').first()).toBeVisible();
     await expect(page.locator('text=Not Set').first()).toBeVisible();
+
+    // Select "Not Set"
+    await page.locator('text=Not Set').first().click();
+    await page.waitForTimeout(300);
+
+    // Now Clear all should be visible because an option is selected
+    await expect(page.locator('text=Clear all').first()).toBeVisible();
 
     // Close the dropdown
     await page.keyboard.press('Escape');


### PR DESCRIPTION
This PR adds a new "Docs Required" filter to the Feature Execution Tracking dashboard in the `releases` module.

### Changes made
* **Backend**: Updated the Jira tracking query (`FIELDS_TO_FETCH`) to include the `CUSTOM_FIELDS.docsRequired` custom field, and added it to the feature projection returned by the tracking API endpoint.
* **Frontend**: Added a new multi-select dropdown filter for "Docs Required" to the `FeatureTrackingView`, mirroring the existing filter patterns (Products, Statuses, Components, Owners). The filter includes session persistence and chip label support. 
* **Tests**: Added Playwright integration test coverage for the new filter in `releases.spec.js`, scoping the UI locators strictly to the dropdown container to ensure test stability.

Closes #1286