### PR TITLE
fix(tests): use synthetic WheelEvent for release-timeline zoom tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,11 +57,16 @@ jobs:
             releases:
               - 'modules/releases/server/execution/**'
               - 'modules/releases/server/planning/**'
+              - 'modules/releases/server/rhoai-component-architectures/**'
               - 'modules/releases/client/views/FeatureDetailView.vue'
+              - 'modules/releases/client/views/ScheduleView.vue'
               - 'modules/releases/client/execute/**'
               - 'modules/releases/client/plan/**'
+              - 'modules/releases/client/components/ReleaseTimeline.vue'
+              - 'modules/releases/client/reports/RhoaiComponentArchitecturesReport.vue'
               - 'tests/integration/execution-data.spec.js'
               - 'tests/integration/releases.spec.js'
+              - 'tests/integration/release-timeline.spec.js'
             tv-fv-delta:
               - 'modules/releases/server/tv-fv-delta/**'
               - 'modules/releases/server/index.js'
@@ -144,7 +149,7 @@ jobs:
           check_module "package-analysis" \
             "^(modules/product-builds/server/(analysis|index)\.js|modules/product-builds/client/views/PackageAnalysisView\.vue|tests/integration/package-analysis\.spec\.js)"
           check_module "releases" \
-            "^(modules/releases/server/(execution|planning)/|modules/releases/client/views/FeatureDetailView\.vue|modules/releases/client/(execute|plan)/|tests/integration/(execution-data|releases)\.spec\.js)"
+            "^(modules/releases/server/(execution|planning|rhoai-component-architectures)/|modules/releases/client/views/(FeatureDetailView|ScheduleView)\.vue|modules/releases/client/(execute|plan)/|modules/releases/client/components/ReleaseTimeline\.vue|modules/releases/client/reports/RhoaiComponentArchitecturesReport\.vue|tests/integration/(execution-data|releases|release-timeline)\.spec\.js)"
           check_module "tv-fv-delta" \
             "^(modules/releases/server/(tv-fv-delta/|index\.js)|modules/releases/client/views/TvFvDeltaView\.vue|modules/releases/client/composables/use.*(TvFv|ReleasePicker|ComponentBreakdown)\.js|modules/releases/client/components/(FeatureTable|ClickableCount)\.vue|tests/integration/tv-fv-delta\.spec\.js)"
           check_module "feature-pressure" \

--- a/tests/integration/release-timeline.spec.js
+++ b/tests/integration/release-timeline.spec.js
@@ -69,12 +69,19 @@ test.describe('Release Timeline @release-timeline @releases', () => {
     var labelBefore = await page.locator('text=/\\d+d view/').first().textContent();
     var daysBefore = parseInt(labelBefore.match(/(\d+)d/)[1]);
 
-    // Zoom in
-    var cx = box.x + box.width * 0.3;
+    // Zoom in — dispatch synthetic WheelEvent with explicit clientX/clientY
+    // (page.mouse.wheel may not set clientX/clientY in headless Chromium,
+    // causing the onWheel handler to early-return when checking chart bounds)
+    var cx = box.x + box.width * 0.5;
     var cy = box.y + box.height * 0.5;
     for (var i = 0; i < 10; i++) {
-      await page.mouse.move(cx, cy);
-      await page.mouse.wheel(0, -200);
+      await page.evaluate(({ x, y }) => {
+        var canvas = document.querySelector('canvas');
+        canvas.dispatchEvent(new WheelEvent('wheel', {
+          clientX: x, clientY: y, deltaX: 0, deltaY: -200,
+          bubbles: true, cancelable: true
+        }));
+      }, { x: cx, y: cy });
       await page.waitForTimeout(50);
     }
     await page.waitForTimeout(500);
@@ -102,10 +109,17 @@ test.describe('Release Timeline @release-timeline @releases', () => {
     // Get initial label
     var labelBefore = await page.locator('text=/\\d+d view/').first().textContent();
 
-    // Zoom in
+    // Zoom in — dispatch synthetic WheelEvent with explicit clientX/clientY
+    var cx = box.x + box.width * 0.5;
+    var cy = box.y + box.height * 0.5;
     for (var i = 0; i < 10; i++) {
-      await page.mouse.move(box.x + box.width * 0.3, box.y + box.height * 0.5);
-      await page.mouse.wheel(0, -200);
+      await page.evaluate(({ x, y }) => {
+        var canvas = document.querySelector('canvas');
+        canvas.dispatchEvent(new WheelEvent('wheel', {
+          clientX: x, clientY: y, deltaX: 0, deltaY: -200,
+          bubbles: true, cancelable: true
+        }));
+      }, { x: cx, y: cy });
       await page.waitForTimeout(50);
     }
     await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary

- **Fix 2 failing release-timeline zoom integration tests** — `page.mouse.wheel()` in headless Chromium doesn't reliably set `clientX`/`clientY` on the dispatched `WheelEvent`, causing the `onWheel` handler in `ReleaseTimeline.vue` to early-return when checking chart area bounds. Switched to `page.evaluate()` with synthetic `WheelEvent` that carries explicit coordinates.
- **Add missing paths to `releases` filter in `integration-tests.yml`** — `ReleaseTimeline.vue`, `ScheduleView.vue`, `release-timeline.spec.js`, and `rhoai-component-architectures/` were not triggering releases integration tests when changed.

## Test plan

- [ ] CI integration tests pass (the 2 previously failing zoom tests now pass)
- [ ] Existing release-timeline tests (no-error, pan, distances, filter) still pass
- [ ] Verify the `releases` path filter picks up changes to newly added paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)