### PR TITLE
fix(releases): fetch component maturity without GITLAB_CEE_TOKEN

### DIFF
--- a/modules/releases/__tests__/server/rhoai-component-architectures/fetcher.test.js
+++ b/modules/releases/__tests__/server/rhoai-component-architectures/fetcher.test.js
@@ -145,8 +145,9 @@ describe('rhoai-component-architectures fetcher integration', () => {
     expect(res._json.maturity.warning).toContain('GitLab down')
   })
 
-  it('skips maturity when GITLAB_CEE_TOKEN is not set', async () => {
+  it('fetches maturity without token when GITLAB_CEE_TOKEN is not set', async () => {
     setupOctokit()
+    mockMaturityFetch.mockResolvedValueOnce(makeMaturityResponse(MATURITY_COMPONENTS))
 
     const storage = makeStorage({
       [REGISTRY_KEY]: { releases: [{ id: 'rhoai-3.5' }] }
@@ -165,9 +166,10 @@ describe('rhoai-component-architectures fetcher integration', () => {
     await handler(makeReq(), res)
 
     expect(res._json.status).toBe('ok')
-    expect(res._json.maturity.available).toBe(false)
-    expect(res._json.maturity.warning).toContain('GITLAB_CEE_TOKEN not configured')
-    expect(mockMaturityFetch).not.toHaveBeenCalled()
+    expect(res._json.maturity.available).toBe(true)
+    expect(mockMaturityFetch).toHaveBeenCalledTimes(1)
+    const [, fetchOptions] = mockMaturityFetch.mock.calls[0]
+    expect(fetchOptions.headers).toBeUndefined()
   })
 
   it('preserves cached maturity on partial failure', async () => {

--- a/modules/releases/__tests__/server/rhoai-component-architectures/maturity-mapping.test.js
+++ b/modules/releases/__tests__/server/rhoai-component-architectures/maturity-mapping.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-const { fetchMaturityMapping, applyMaturityMapping, _setFetch } = require('../../../server/rhoai-component-architectures/maturity-mapping')
+const { fetchMaturityMapping, applyMaturityMapping, _setFetch, MATURITY_URL } = require('../../../server/rhoai-component-architectures/maturity-mapping')
 
 const mockFetch = vi.fn()
 
@@ -92,6 +92,26 @@ describe('fetchMaturityMapping', () => {
       { name: 'AI Pipelines', owner: null, team: null },
       { name: 'Serving Orchestration', owner: 'jdoe', team: 'Model Serving' }
     ])
+  })
+
+  it('fetches without Authorization header when no token is provided', async () => {
+    mockFetch.mockResolvedValueOnce(makeMaturityResponse(SAMPLE_COMPONENTS))
+
+    const result = await fetchMaturityMapping()
+
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]
+    expect(lastCall[0]).toBe(MATURITY_URL)
+    expect(lastCall[1].headers).toBeUndefined()
+    expect(result.mapping['odh-kserve-controller-rhel9']).toBe('Serving Orchestration')
+  })
+
+  it('sends Authorization header when token is provided', async () => {
+    mockFetch.mockResolvedValueOnce(makeMaturityResponse(SAMPLE_COMPONENTS))
+
+    await fetchMaturityMapping('my-token')
+
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]
+    expect(lastCall[1].headers).toEqual({ 'Authorization': 'Bearer my-token' })
   })
 
   it('extracts image short name from full registry path', async () => {

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -74,7 +74,7 @@
       },
       {
         "key": "GITLAB_CEE_TOKEN",
-        "description": "GitLab PAT for gitlab.cee.redhat.com (read_api scope). Used to fetch component maturity data.",
+        "description": "GitLab PAT for gitlab.cee.redhat.com (read_api scope). Optional — maturity data is fetched without authentication by default. Provide a token for improved rate limits.",
         "required": false
       }
     ]

--- a/modules/releases/server/rhoai-component-architectures/fetcher.js
+++ b/modules/releases/server/rhoai-component-architectures/fetcher.js
@@ -132,20 +132,15 @@ function registerRhoaiComponentArchitecturesFetcher(router, context) {
     let allProductComponents = []
     let maturityWarning = null
 
-    if (gitlabCeeToken) {
-      try {
-        console.log('[rhoai-component-architectures] Fetching component maturity mapping from gitlab.cee.redhat.com')
-        const maturityResult = await fetchMaturityMapping(gitlabCeeToken)
-        mapping = maturityResult.mapping
-        allProductComponents = maturityResult.allProductComponents
-        console.log(`[rhoai-component-architectures] Maturity mapping: ${Object.keys(mapping).length} images across ${allProductComponents.length} product components`)
-      } catch (err) {
-        maturityWarning = `Component maturity fetch failed: ${err.message}`
-        console.warn('[rhoai-component-architectures]', maturityWarning)
-      }
-    } else {
-      maturityWarning = 'GITLAB_CEE_TOKEN not configured — skipping component maturity mapping'
-      console.log('[rhoai-component-architectures]', maturityWarning)
+    try {
+      console.log('[rhoai-component-architectures] Fetching component maturity mapping from gitlab.cee.redhat.com')
+      const maturityResult = await fetchMaturityMapping(gitlabCeeToken || undefined)
+      mapping = maturityResult.mapping
+      allProductComponents = maturityResult.allProductComponents
+      console.log(`[rhoai-component-architectures] Maturity mapping: ${Object.keys(mapping).length} images across ${allProductComponents.length} product components`)
+    } catch (err) {
+      maturityWarning = `Component maturity fetch failed: ${err.message}`
+      console.warn('[rhoai-component-architectures]', maturityWarning)
     }
 
     if (mapping) {

--- a/modules/releases/server/rhoai-component-architectures/maturity-mapping.js
+++ b/modules/releases/server/rhoai-component-architectures/maturity-mapping.js
@@ -9,10 +9,11 @@ function _setFetch(fn) {
 }
 
 async function fetchMaturityMapping(token) {
-  const response = await _fetch(MATURITY_URL, {
-    headers: { 'Authorization': `Bearer ${token}` },
-    signal: AbortSignal.timeout(30000),
-  })
+  const options = { signal: AbortSignal.timeout(30000) }
+  if (token) {
+    options.headers = { 'Authorization': `Bearer ${token}` }
+  }
+  const response = await _fetch(MATURITY_URL, options)
 
   if (!response.ok) {
     if (response.status === 401) {


### PR DESCRIPTION
## Summary
- The GitLab CEE CI artifact endpoint for `maturity-report.json` is publicly accessible — no auth token needed
- Made the `Authorization` header conditional in `fetchMaturityMapping()` so it works with or without a token
- Removed the `if (gitlabCeeToken)` guard in the fetcher — maturity data is now always fetched
- This enables the **Product Component** column in the Component Architectures report without configuring `GITLAB_CEE_TOKEN` in the deployment

## Test plan
- [x] All existing tests pass (25/25 in component-architectures test suite)
- [x] Added tests for unauthenticated fetch (no `Authorization` header sent)
- [x] Added test for authenticated fetch (header sent when token provided)
- [x] Updated fetcher integration test to verify maturity is fetched without token
- [x] Lint passes
- [ ] Deploy and verify Product Component column appears in prod

Jira: [RHOAIENG-84746](https://redhat.atlassian.net/browse/RHOAIENG-84746)

🤖 Generated with [Claude Code](https://claude.com/claude-code)