### PR TITLE
feat(releases): hover tooltip, reversed row order, and today marker fix

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -48,10 +48,10 @@
       "displayName": "rhelai-3.5.EA1",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-06-23",
-        "codeFreeze": "2026-05-12",
+        "ga": "2026-09-21",
+        "codeFreeze": "2026-08-10",
         "featureFreeze": null,
-        "planningFreeze": "2026-04-17"
+        "planningFreeze": "2026-07-16"
       },
       "state": "active",
       "fixVersions": [
@@ -63,10 +63,10 @@
       "displayName": "rhelai-3.5.EA2",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-07-21",
-        "codeFreeze": "2026-06-10",
+        "ga": "2026-10-19",
+        "codeFreeze": "2026-09-08",
         "featureFreeze": null,
-        "planningFreeze": "2026-05-15"
+        "planningFreeze": "2026-08-13"
       },
       "state": "active",
       "fixVersions": [
@@ -78,10 +78,10 @@
       "displayName": "rhelai-3.5",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-08-25",
-        "codeFreeze": "2026-07-20",
-        "featureFreeze": "2026-07-17",
-        "planningFreeze": "2026-06-24"
+        "ga": "2026-11-23",
+        "codeFreeze": "2026-10-18",
+        "featureFreeze": "2026-10-15",
+        "planningFreeze": "2026-09-22"
       },
       "state": "active",
       "fixVersions": [
@@ -109,10 +109,10 @@
       "displayName": "rhaii-3.5.EA2",
       "productPagesShortname": "rhaii",
       "milestones": {
-        "ga": "2026-06-30",
-        "codeFreeze": "2026-06-10",
+        "ga": "2026-09-28",
+        "codeFreeze": "2026-09-08",
         "featureFreeze": null,
-        "planningFreeze": "2026-05-15"
+        "planningFreeze": "2026-08-13"
       },
       "state": "active",
       "fixVersions": [
@@ -140,10 +140,10 @@
       "displayName": "rhaii-3.5",
       "productPagesShortname": "rhaii",
       "milestones": {
-        "ga": "2026-08-06",
-        "codeFreeze": "2026-07-20",
-        "featureFreeze": "2026-07-17",
-        "planningFreeze": "2026-06-24"
+        "ga": "2026-11-04",
+        "codeFreeze": "2026-10-18",
+        "featureFreeze": "2026-10-15",
+        "planningFreeze": "2026-09-22"
       },
       "state": "active",
       "fixVersions": [
@@ -156,10 +156,10 @@
       "displayName": "rhoai-3.5.EA1",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-06-17",
-        "codeFreeze": "2026-05-15",
+        "ga": "2026-09-15",
+        "codeFreeze": "2026-08-13",
         "featureFreeze": null,
-        "planningFreeze": "2026-05-01"
+        "planningFreeze": "2026-07-30"
       },
       "state": "active",
       "fixVersions": [
@@ -171,10 +171,10 @@
       "displayName": "rhoai-3.5.EA2",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-07-15",
-        "codeFreeze": "2026-06-20",
+        "ga": "2026-10-13",
+        "codeFreeze": "2026-09-18",
         "featureFreeze": null,
-        "planningFreeze": "2026-05-15"
+        "planningFreeze": "2026-08-13"
       },
       "state": "active",
       "fixVersions": [
@@ -186,10 +186,10 @@
       "displayName": "rhoai-3.5",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-08-26",
-        "codeFreeze": "2026-07-31",
-        "featureFreeze": "2026-07-17",
-        "planningFreeze": "2026-06-24"
+        "ga": "2026-11-24",
+        "codeFreeze": "2026-10-29",
+        "featureFreeze": "2026-10-15",
+        "planningFreeze": "2026-09-22"
       },
       "state": "active",
       "fixVersions": [

--- a/modules/releases/__tests__/client/release-timeline.test.js
+++ b/modules/releases/__tests__/client/release-timeline.test.js
@@ -626,6 +626,24 @@ describe('ReleaseTimeline', () => {
     expect(range.max - lastTs).toBeGreaterThanOrEqual(7 * 86400000)
   })
 
+  it('fullRange always includes today so pan can reach the today marker', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-23T00:00:00'))
+    try {
+      var todayTs = new Date('2026-08-23T00:00:00').getTime()
+      var releases = [
+        makeRelease('rhoai-3.5.ea1', { displayName: 'rhoai-3.5.EA1', shortname: 'rhoai', ga: '2026-09-15' }),
+        makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-11-24' })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases, hidePast: true } })
+      var range = wrapper.vm.fullRange
+      expect(range.min).toBeLessThan(todayTs)
+      expect(range.max).toBeGreaterThan(todayTs)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('single dataset when all nodes are past or future (no today marker)', () => {
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2090-06-17' })
@@ -684,6 +702,25 @@ describe('ReleaseTimeline', () => {
     expect(leftPortion).toBeLessThan(0.45)
     expect(leftPortion).toBeGreaterThan(0.15)
     vi.useRealTimers()
+  })
+
+  it('defaultRange includes today when hidePast is true and all milestones are far in the future', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-23T00:00:00'))
+    try {
+      var todayTs = new Date('2026-08-23T00:00:00').getTime()
+      var releases = [
+        makeRelease('rhoai-3.5.ea1', { displayName: 'rhoai-3.5.EA1', shortname: 'rhoai', ga: '2026-09-15' }),
+        makeRelease('rhoai-3.5.ea2', { displayName: 'rhoai-3.5.EA2', shortname: 'rhoai', ga: '2026-10-13' }),
+        makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-11-24' })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases, hidePast: true } })
+      var range = wrapper.vm.defaultRange
+      expect(range.min).toBeLessThanOrEqual(todayTs)
+      expect(range.max).toBeGreaterThan(todayTs)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('layoutMetrics exposes safeOff for stable stem computation', () => {
@@ -1388,7 +1425,7 @@ describe('ReleaseTimeline', () => {
     })
   })
 
-  it('stableCycleRowMap assigns row 0 to cycle with earliest GA on same side', () => {
+  it('stableCycleRowMap assigns nearest row to cycle with latest GA on same side', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date(2026, 7, 1))
@@ -1409,7 +1446,7 @@ describe('ReleaseTimeline', () => {
       var belowKeys = keys.filter(function (k) { return k.endsWith('-b') })
       var sameSide = aboveKeys.length >= 2 ? aboveKeys : belowKeys
       expect(sameSide.length).toBeGreaterThanOrEqual(2)
-      // Within same side, earlier GA should get lower row index
+      // Later GA gets lower row index (closer to axis)
       var sorted = sameSide.slice().sort(function (a, b) { return rowMap[a] - rowMap[b] })
       for (var i = 0; i < sorted.length - 1; i++) {
         expect(rowMap[sorted[i]]).toBeLessThan(rowMap[sorted[i + 1]])
@@ -1432,6 +1469,27 @@ describe('ReleaseTimeline', () => {
     var map1 = JSON.stringify(wrapper.vm.stableCycleRowMap)
     var map2 = JSON.stringify(wrapper.vm.stableCycleRowMap)
     expect(map1).toBe(map2)
+  })
+
+  it('latest cycle gets lowest row index (closest to axis)', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date(2026, 7, 1))
+      var releases = [
+        makeRelease('rhoai-3.4', { ga: '2026-09-01' }),
+        makeRelease('rhoai-3.5', { ga: '2026-11-01' }),
+        makeRelease('rhoai-3.6', { ga: '2027-02-01' })
+      ]
+      var wrapper = mount(ReleaseTimeline, { props: { releases, hidePast: false } })
+      var rowMap = wrapper.vm.stableCycleRowMap
+      var aboveKeys = Object.keys(rowMap).filter(function (k) { return k.endsWith('-a') })
+      var belowKeys = Object.keys(rowMap).filter(function (k) { return k.endsWith('-b') })
+      var sameSide = aboveKeys.length >= 2 ? aboveKeys : belowKeys
+      sameSide.sort(function (a, b) { return rowMap[a] - rowMap[b] })
+      expect(sameSide[0]).toMatch(/3\.6/)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('non-GA nodes have productList populated', () => {
@@ -1581,7 +1639,7 @@ describe('ReleaseTimeline', () => {
     expect(sides[nodes[0].groupLabel]).not.toBe(sides[nodes[1].groupLabel])
   })
 
-  it('non-versioned releases get highest below-axis row index', () => {
+  it('non-versioned releases get highest below-axis row index (farthest from axis)', () => {
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-10-15' }),
       makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-11-15' }),

--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -286,10 +286,10 @@ var stableCycleRowMap = computed(function () {
   aboveKeys.sort(function (a, b) { return sortKey(a) - sortKey(b) })
   versionedBelow.sort(function (a, b) { return sortKey(a) - sortKey(b) })
   nonVersionedBelow.sort(function (a, b) { return sortKey(a) - sortKey(b) })
-  var belowKeys = versionedBelow.concat(nonVersionedBelow)
   var map = {}
-  for (var ai = 0; ai < aboveKeys.length; ai++) map[aboveKeys[ai]] = ai
-  for (var bi = 0; bi < belowKeys.length; bi++) map[belowKeys[bi]] = bi
+  for (var ai = 0; ai < aboveKeys.length; ai++) map[aboveKeys[ai]] = aboveKeys.length - 1 - ai
+  for (var bi = 0; bi < versionedBelow.length; bi++) map[versionedBelow[bi]] = versionedBelow.length - 1 - bi
+  for (var nbi = 0; nbi < nonVersionedBelow.length; nbi++) map[nonVersionedBelow[nbi]] = versionedBelow.length + nbi
   return map
 })
 
@@ -395,9 +395,14 @@ var fullRange = computed(function () {
   var first = parseDate(n[0].date)
   var last = parseDate(n[n.length - 1].date)
   if (!first || !last) return { min: 0, max: 1 }
-  var range = last.getTime() - first.getTime()
+  var today = new Date()
+  today.setHours(0, 0, 0, 0)
+  var todayTs = today.getTime()
+  var minTs = Math.min(first.getTime(), todayTs)
+  var maxTs = Math.max(last.getTime(), todayTs)
+  var range = maxTs - minTs
   var pad = Math.max(range * 0.05, 86400000 * 7)
-  return { min: first.getTime() - pad, max: last.getTime() + pad }
+  return { min: minTs - pad, max: maxTs + pad }
 })
 
 var DAY_MS = 86400000
@@ -428,9 +433,8 @@ var defaultRange = computed(function () {
     var windowSpan = DEFAULT_WINDOW_DAYS * DAY_MS
     var min = todayTs - padLeft
     var max = min + windowSpan
-    if (min < full.min) { min = full.min; max = min + windowSpan }
     if (max > full.max) { max = full.max; min = max - windowSpan }
-    if (min < full.min) min = full.min
+    if (min > todayTs - padLeft) min = todayTs - padLeft
     if (max <= min) return capRange(full, full)
     return { min: min, max: max }
   }
@@ -1307,6 +1311,32 @@ var timelinePlugin = {
                       _hoveredBox.w + 2, _hoveredBox.h + 2, 5)
       ctx.stroke()
       ctx.restore()
+
+      var hoverDays = daysFromNow(_hoveredBox.nd.date)
+      var hoverDaysText = hoverDays === null ? null
+        : hoverDays === 0 ? 'today'
+        : hoverDays > 0 ? 'in ' + hoverDays + 'd'
+        : Math.abs(hoverDays) + 'd ago'
+      if (hoverDaysText) {
+        ctx.save()
+        ctx.font = 'bold 10px ' + FONT
+        var badgeW = ctx.measureText(hoverDaysText).width + 8
+        var badgeH = 16
+        var badgeX = _hoveredBox.x - badgeW / 2
+        var badgeY = _hoveredBox.y - badgeH / 2
+        if (badgeX < area.left) badgeX = area.left
+        if (badgeX + badgeW > area.right) badgeX = area.right - badgeW
+        if (badgeY < area.top) badgeY = area.top
+        var badgeColor = hoverHex || (dark ? '#60a5fa' : '#3b82f6')
+        drawRoundedRect(ctx, badgeX, badgeY, badgeW, badgeH, 8)
+        ctx.fillStyle = badgeColor
+        ctx.fill()
+        ctx.fillStyle = '#ffffff'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.fillText(hoverDaysText, badgeX + badgeW / 2, badgeY + badgeH / 2)
+        ctx.restore()
+      }
     }
 
     ctx.restore()

--- a/tests/integration/release-timeline.spec.js
+++ b/tests/integration/release-timeline.spec.js
@@ -38,6 +38,70 @@ test.describe('Release Timeline @release-timeline @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 
+  test('today marker pulse dot is visible on the timeline', async ({ page }) => {
+    await page.goto('/#/releases/schedule');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // The "YOU ARE HERE" marker is a pulsing red dot overlay positioned by _todayPx
+    var todayPulse = page.locator('.animate-ping');
+    await expect(todayPulse).toBeVisible();
+
+    // The solid red dot next to the ping animation
+    var todayDot = page.locator('.bg-red-500, .dark\\:bg-red-400');
+    await expect(todayDot.first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('today marker is reachable after panning right and back', async ({ page }) => {
+    await page.goto('/#/releases/schedule');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var canvas = page.locator('canvas');
+    var box = await canvas.boundingBox();
+
+    // Confirm today marker is visible initially
+    var todayPulse = page.locator('.animate-ping');
+    await expect(todayPulse).toBeVisible();
+
+    // Pan right (drag left) to move the view into the future
+    var startX = box.x + box.width * 0.7;
+    var endX = box.x + box.width * 0.1;
+    var cy = box.y + box.height * 0.5;
+    for (var i = 0; i < 3; i++) {
+      await page.mouse.move(startX, cy);
+      await page.mouse.down();
+      for (var s = 0; s < 10; s++) {
+        await page.mouse.move(startX + (endX - startX) * s / 10, cy);
+        await page.waitForTimeout(20);
+      }
+      await page.mouse.move(endX, cy);
+      await page.mouse.up();
+      await page.waitForTimeout(200);
+    }
+
+    // Pan back left (drag right) to return toward today
+    for (var j = 0; j < 4; j++) {
+      await page.mouse.move(endX, cy);
+      await page.mouse.down();
+      for (var s2 = 0; s2 < 10; s2++) {
+        await page.mouse.move(endX + (startX - endX) * s2 / 10, cy);
+        await page.waitForTimeout(20);
+      }
+      await page.mouse.move(startX, cy);
+      await page.mouse.up();
+      await page.waitForTimeout(200);
+    }
+    await page.waitForTimeout(500);
+
+    // Today marker must be reachable — it should be visible again
+    await expect(todayPulse).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   test('timeline renders milestone cards above and below axis', async ({ page }) => {
     await page.goto('/#/releases/schedule');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- **Hover tooltip**: hovering a timeline card shows a days-from-today badge (top-left corner) — "in Xd" / "today" / "Xd ago"
- **Reversed row order**: latest versioned cycles now sit closest to the axis; non-versioned releases stay at outermost rows
- **Today marker fix**: `fullRange` always includes today so the "YOU ARE HERE" marker stays reachable after panning; `defaultRange` no longer clamps past today when `hidePast` is on
- **Fixture dates**: shifted 3.5-era releases +90 days so demo mode has future milestones for visual verification

## Test plan
- [x] Unit: `defaultRange includes today when hidePast is true and all milestones are far in the future`
- [x] Unit: `fullRange always includes today so pan can reach the today marker`
- [x] Unit: `latest cycle gets lowest row index (closest to axis)`
- [x] Unit: `stableCycleRowMap assigns nearest row to cycle with latest GA on same side`
- [x] Unit: `non-versioned releases get highest below-axis row index (farthest from axis)`
- [x] Integration: `today marker pulse dot is visible on the timeline`
- [x] Integration: `today marker is reachable after panning right and back`
- [x] Full suite: 5548 tests pass (286 files)

Closes RHOAIENG-82037

🤖 Generated with [Claude Code](https://claude.com/claude-code)