### PR TITLE
fix(allocation): pass auditLog to createTeamStore for core v2.0.70 compat

### DIFF
--- a/platform/allocation/server/routes.js
+++ b/platform/allocation/server/routes.js
@@ -12,9 +12,10 @@ const { allocationKey } = require('./config');
 // Normalise the team-store API across two generations of the core package:
 //  - core ≤ 2.0.x: factory pattern — module.exports = { createTeamStore, extractBoardId, … }
 //  - core ≥ 2.0.64 (npm): standalone functions — module.exports = { readTeams, updateTeamFields, … }
-function _getTeamStore(storage) {
+// auditLog is required by createTeamStore ≥ 2.0.70; pass it through when available.
+function _getTeamStore(storage, auditLog) {
   if (typeof _teamStoreModule.createTeamStore === 'function') {
-    return _teamStoreModule.createTeamStore(storage);
+    return _teamStoreModule.createTeamStore(storage, { auditLog });
   }
   return {
     readTeams: () => _teamStoreModule.readTeams(storage),
@@ -31,7 +32,7 @@ const ALLOCATION_MODES = ['points', 'counts'];
 module.exports = function registerAllocationRoutes(router, context) {
   const { storage, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
-  const teamStore = _getTeamStore(storage);
+  const teamStore = context.teamStore || _getTeamStore(storage, context.auditLog);
 
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
 


### PR DESCRIPTION
## Summary

- `@org-pulse/core` v2.0.70 made `auditLog` a required argument to `createTeamStore`, but the allocation platform extension was calling it without that option
- This caused the extension to throw at mount time, leaving all `/api/modules/team-tracker/allocation/*` routes unregistered → every request returns 404
- Production symptom: 40/40/20 allocation tab shows "No allocation data available" and the refresh button returns "Refresh failed"

**Root cause** (from prod logs):
```
[platform] Failed to mount module-views extension "allocation": createTeamStore requires options.auditLog (from the module context) — there is no fallback
```

**Fix:** Prefer `context.teamStore` (already fully configured by core with `auditLog`) and thread `context.auditLog` through the `_getTeamStore` fallback path. No other callsites are affected — this is the only place in the non-core codebase that calls `createTeamStore` directly.

## Test plan

- [ ] Verify prod backend logs show `[platform] Mounted module-views extension "allocation"` after deploy
- [ ] Confirm `GET /api/modules/team-tracker/allocation/refresh/status` returns 200 (not 404)
- [ ] Confirm allocation tab loads data on a team page
- [ ] Trigger a team-scoped refresh and confirm it completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)