### PR TITLE
feat(releases): add Draft Plans viewer access for planning stakeholders

### DIFF
--- a/modules/releases/server/draft-plans/plan-admins.js
+++ b/modules/releases/server/draft-plans/plan-admins.js
@@ -13,7 +13,12 @@ var { normalizeEmail: normalizeEmailForAuth } = require('../../../../shared/serv
 var DEFAULT_PLAN_ADMIN_EMAILS = ['emarion@redhat.com', 'trozell@redhat.com']
 
 /** Preview gate: who can see the Draft Plans tab and call draft-plans APIs. */
-var DEFAULT_VIEWER_EMAILS = ['emarion@redhat.com']
+var DEFAULT_VIEWER_EMAILS = [
+  'emarion@redhat.com',
+  'ahinek@redhat.com',
+  'yluria@redhat.com',
+  'jgraham@redhat.com'
+]
 
 var DEFAULT_PLAN_ADMIN_NAMES_BY_EMAIL = {
   'emarion@redhat.com': 'Emarion',


### PR DESCRIPTION
## Summary
- Extend `DEFAULT_VIEWER_EMAILS` in the Draft Plans allowlist so Arjay Hinek, Yuval Luria, and John Graham can see the Draft Plans tab and call draft-plans APIs in production.
- Access is controlled in `modules/releases/server/draft-plans/plan-admins.js` via `draftPlansViewerEmails` (default list used when no config override is stored).

## Test plan
- [x] `npm run validate:modules`
- [x] `npx vitest run modules/releases/__tests__/server/draft-plans/plan-admins.test.js modules/releases/__tests__/server/draft-plans/acl.test.js`

Made with [Cursor](https://cursor.com)