### PR TITLE
fix(releases): timeline stem hover tip + clamp highlight

### DIFF
--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -5,6 +5,7 @@ import { Chart as ChartJS, LinearScale, PointElement, Tooltip } from 'chart.js'
 import { parseReleaseName, extractCycle, productLabel } from '../composables/useReleaseFamily.js'
 import { parseDate, daysFromNow, formatShort, getProduct } from '../composables/useScheduleHelpers.js'
 import { PRODUCT_HEX, DEFAULT_HEX } from '../composables/useProductColors.js'
+import { clampStemToCard } from './timeline-geometry.js'
 
 ChartJS.register(LinearScale, PointElement, Tooltip)
 
@@ -186,6 +187,7 @@ var TODAY_DOT_BORDER = 2
 var DOT_HALO_PAD = 1.5
 var TODAY_TEXT_START = Math.ceil(TODAY_DOT_RADIUS + TODAY_DOT_BORDER + DOT_HALO_PAD) + 4
 var CHART_MAX_HEIGHT = 450
+var STEM_HIT_TOL = 6
 
 function hexToRgba(hex, alpha) {
   if (!hex || hex.charAt(0) !== '#' || hex.length < 7) return hex
@@ -574,35 +576,62 @@ function onPointerUp(event) {
   }
 }
 
+function _setHoveredBox(box) {
+  if (!box) {
+    isOverCard.value = false
+    if (_hoveredBox) {
+      _hoveredBox = null
+      if (_chartInstance) _chartInstance.draw()
+    }
+    return
+  }
+  isOverCard.value = true
+  var prevHovered = _hoveredBox
+  _hoveredBox = box
+  if (prevHovered !== _hoveredBox) {
+    if (!prevHovered) _frontNodes.clear()
+    _frontNodes.add(box.nd)
+    if (prevHovered && prevHovered.nd !== box.nd) {
+      _frontNodes.delete(prevHovered.nd)
+    }
+    if (_chartInstance) _chartInstance.draw()
+  }
+}
+
+function _cardBoxForNode(nd) {
+  for (var i = 0; i < _cardHitBoxes.length; i++) {
+    if (_cardHitBoxes[i].nd === nd) return _cardHitBoxes[i]
+  }
+  return null
+}
+
 function onCardHover(e) {
   if (_dragStart) return
   var canvas = e.currentTarget.querySelector('canvas')
-  if (!canvas) { isOverCard.value = false; return }
+  if (!canvas) { _setHoveredBox(null); return }
   var canvasRect = canvas.getBoundingClientRect()
   var cx = e.clientX - canvasRect.left
   var cy = e.clientY - canvasRect.top
+
+  // Cards take priority (they render on top of stems)
   for (var i = _cardHitBoxes.length - 1; i >= 0; i--) {
     var box = _cardHitBoxes[i]
     if (cx >= box.x && cx <= box.x + box.w && cy >= box.y && cy <= box.y + box.h) {
-      isOverCard.value = true
-      var prevHovered = _hoveredBox
-      _hoveredBox = box
-      if (prevHovered !== _hoveredBox) {
-        if (!prevHovered) _frontNodes.clear()
-        _frontNodes.add(box.nd)
-        if (prevHovered && prevHovered.nd !== box.nd) {
-          _frontNodes.delete(prevHovered.nd)
-        }
-        if (_chartInstance) _chartInstance.draw()
-      }
+      _setHoveredBox(box)
       return
     }
   }
-  isOverCard.value = false
-  if (_hoveredBox) {
-    _hoveredBox = null
-    if (_chartInstance) _chartInstance.draw()
+
+  // Fall back to stems — resolve to the same node's card so the tip matches
+  for (var si = _stemHitBoxes.length - 1; si >= 0; si--) {
+    var sbox = _stemHitBoxes[si]
+    if (cx >= sbox.x && cx <= sbox.x + sbox.w && cy >= sbox.y && cy <= sbox.y + sbox.h) {
+      var cardBox = _cardBoxForNode(sbox.nd)
+      if (cardBox) { _setHoveredBox(cardBox); return }
+    }
   }
+
+  _setHoveredBox(null)
 }
 
 var chartData = computed(function () {
@@ -694,6 +723,7 @@ function _pluginSetup(chart) {
 }
 
 var _cardHitBoxes = []
+var _stemHitBoxes = []
 var _hoveredBox = null
 var _frontNodes = new Set()
 
@@ -824,6 +854,7 @@ var timelinePlugin = {
 
     ctx.save()
     _cardHitBoxes = []
+    _stemHitBoxes = []
 
     // Redraw arrowhead zone to cover any Chart.js dots near the right edge
     var bgColor = dark ? '#1f2937' : '#ffffff'
@@ -905,18 +936,28 @@ var timelinePlugin = {
         ? (PRODUCT_HEX[ssLay.nd.productList[0]] || DEFAULT_HEX)
         : (ssLay.nd.isPast ? pastColor : futureColor)
       var stemX = ssLay.x
+      var stemTop, stemBottom
       ctx.beginPath()
       ctx.strokeStyle = ssPrimary
       ctx.lineWidth = 1
       ctx.setLineDash([])
       if (ssLay.above) {
-        ctx.moveTo(stemX, yMid - 6)
-        ctx.lineTo(stemX, yMid - ssLay.stemLen - 8)
+        stemTop = yMid - ssLay.stemLen - 8
+        stemBottom = yMid - 6
+        ctx.moveTo(stemX, stemBottom)
+        ctx.lineTo(stemX, stemTop)
       } else {
-        ctx.moveTo(stemX, yMid + 6)
-        ctx.lineTo(stemX, yMid + ssLay.stemLen + 8)
+        stemTop = yMid + 6
+        stemBottom = yMid + ssLay.stemLen + 8
+        ctx.moveTo(stemX, stemTop)
+        ctx.lineTo(stemX, stemBottom)
       }
       ctx.stroke()
+      _stemHitBoxes.push({
+        x: stemX - STEM_HIT_TOL, y: stemTop,
+        w: STEM_HIT_TOL * 2, h: stemBottom - stemTop,
+        above: ssLay.above, nd: ssLay.nd
+      })
     }
 
     // Today dashed line (drawn before cards so cards render on top)
@@ -1314,9 +1355,26 @@ var timelinePlugin = {
         ? hexToRgba(hoverHex, dark ? 0.7 : 0.6)
         : (dark ? 'rgba(96,165,250,0.5)' : 'rgba(59,130,246,0.4)')
       ctx.lineWidth = 2
+      ctx.setLineDash([])
       drawRoundedRect(ctx, _hoveredBox.x - 1, _hoveredBox.y - 1,
                       _hoveredBox.w + 2, _hoveredBox.h + 2, 5)
       ctx.stroke()
+      // Highlight the connecting stem with the same stroke as the card border
+      for (var shi = 0; shi < _stemHitBoxes.length; shi++) {
+        var shBox = _stemHitBoxes[shi]
+        if (shBox.nd !== _hoveredBox.nd) continue
+        var shX = shBox.x + STEM_HIT_TOL
+        var shEnds = clampStemToCard(
+          { top: shBox.y, bottom: shBox.y + shBox.h },
+          { y: _hoveredBox.y, h: _hoveredBox.h },
+          shBox.above
+        )
+        ctx.beginPath()
+        ctx.moveTo(shX, shEnds.top)
+        ctx.lineTo(shX, shEnds.bottom)
+        ctx.stroke()
+        break
+      }
       ctx.restore()
 
       var hoverDays = daysFromNow(_hoveredBox.nd.date)

--- a/modules/releases/client/components/__tests__/timeline-geometry.test.js
+++ b/modules/releases/client/components/__tests__/timeline-geometry.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { clampStemToCard } from '../timeline-geometry.js'
+
+// Mirrors the pixel geometry used in ReleaseTimeline.vue:
+//   above node: stem top = yMid - stemLen - 8, card bottom = yMid - stemLen - 4
+//   below node: stem bottom = yMid + stemLen + 8, card top = yMid + stemLen + 4
+// The base stem overshoots the card by 4px on the card-facing side.
+
+describe('clampStemToCard', function () {
+  describe('above the axis (card sits above, stem goes down to the axis)', function () {
+    // yMid=300, stemLen=64 → stem top=228, bottom=294; card bottom edge=232
+    var card = { y: 172, h: 60 } // card bottom = 232
+    var stem = { top: 228, bottom: 294 }
+
+    it('pulls the stem top down to the card bottom edge so it does not pierce', function () {
+      var ends = clampStemToCard(stem, card, true)
+      expect(ends.top).toBe(232) // card.y + card.h
+      expect(ends.bottom).toBe(294) // axis-side end untouched
+    })
+
+    it('never renders above (into) the card body', function () {
+      var ends = clampStemToCard(stem, card, true)
+      expect(ends.top).toBeGreaterThanOrEqual(card.y + card.h)
+    })
+
+    it('leaves an already-flush stem unchanged', function () {
+      var flush = { top: 232, bottom: 294 }
+      var ends = clampStemToCard(flush, card, true)
+      expect(ends.top).toBe(232)
+      expect(ends.bottom).toBe(294)
+    })
+  })
+
+  describe('below the axis (card sits below, stem goes up to the axis)', function () {
+    // yMid=300, stemLen=64 → stem top=306, bottom=372; card top edge=368
+    var card = { y: 368, h: 60 }
+    var stem = { top: 306, bottom: 372 }
+
+    it('pulls the stem bottom up to the card top edge so it does not pierce', function () {
+      var ends = clampStemToCard(stem, card, false)
+      expect(ends.bottom).toBe(368) // card.y
+      expect(ends.top).toBe(306) // axis-side end untouched
+    })
+
+    it('never renders below (into) the card body', function () {
+      var ends = clampStemToCard(stem, card, false)
+      expect(ends.bottom).toBeLessThanOrEqual(card.y)
+    })
+  })
+
+  it('never produces an inverted line when the card fully covers the stem', function () {
+    // Degenerate: card overlaps entire stem span.
+    var card = { y: 100, h: 400 }
+    var stem = { top: 228, bottom: 294 }
+    var above = clampStemToCard(stem, card, true)
+    expect(above.bottom).toBeGreaterThanOrEqual(above.top)
+    var below = clampStemToCard(stem, card, false)
+    expect(below.bottom).toBeGreaterThanOrEqual(below.top)
+  })
+})

--- a/modules/releases/client/components/timeline-geometry.js
+++ b/modules/releases/client/components/timeline-geometry.js
@@ -1,0 +1,33 @@
+// Pure geometry helpers for the release timeline canvas rendering.
+// Extracted so the stem/card hover math can be unit-tested without a canvas.
+
+/**
+ * Clamp a stem's highlight endpoints so the highlighted (on-top) stroke meets
+ * the card's edge without piercing into its body.
+ *
+ * The base stem intentionally overshoots into the card by a few pixels so there
+ * is no visible gap; that overshoot is normally hidden because the card fill is
+ * painted after the stem. The hover highlight, however, is drawn *on top* of the
+ * card, so it must stop at the card edge facing the axis.
+ *
+ * @param {{top:number, bottom:number}} stem  Stem line, pixel Y (top < bottom).
+ * @param {{y:number, h:number}} card         Card rect, pixel coords.
+ * @param {boolean} above                     True if the card sits above the axis.
+ * @returns {{top:number, bottom:number}}     Clamped endpoints for the highlight.
+ */
+export function clampStemToCard(stem, card, above) {
+  var top = stem.top
+  var bottom = stem.bottom
+  if (above) {
+    // Card is above the axis; its bottom edge faces the stem.
+    var cardBottom = card.y + card.h
+    if (top < cardBottom) top = cardBottom
+  } else {
+    // Card is below the axis; its top edge faces the stem.
+    var cardTop = card.y
+    if (bottom > cardTop) bottom = cardTop
+  }
+  // Guard against an inverted/zero-length line if the card fully covers the stem.
+  if (bottom < top) bottom = top
+  return { top: top, bottom: bottom }
+}


### PR DESCRIPTION
## Summary

Follow-up polish to the release timeline graph ([RHOAIENG-82037](https://redhat.atlassian.net/browse/RHOAIENG-82037)).

- **Stem hover tip** — hovering a timeline *stem* now surfaces the same tip as hovering its card: the node is brought to the front, the card halo is drawn, and the "in Nd / Nd ago" badge appears. Cards keep priority when both overlap.
- **Stem highlight** — when either the stem or its card is hovered, the connecting stem is stroked with the *same* style as the card's hover border (width 2, matching product/blue color), so halo + stem + badge read as one highlighted unit.
- **Piercing fix** — the base stem intentionally overshoots into the card by a few px (hidden by the card fill). The on-top hover highlight exposed that overshoot, so the highlighted stem visibly pierced the card body. The highlight is now clamped to the card's axis-facing edge.

## Implementation

- Extracted the clamp geometry into a pure `clampStemToCard()` in `modules/releases/client/components/timeline-geometry.js` (the drawing itself lives in a Chart.js plugin closure and isn't unit-testable directly — this is the testable seam).
- `ReleaseTimeline.vue` records stem hit-boxes (with `above` flag) and resolves stem hovers to the owning node's card box.

## Testing

- New unit tests in `timeline-geometry.test.js` guard the clamp: above/below edge clamping, the "never enters the card body" invariant, an already-flush stem left untouched, and the degenerate full-overlap case (no inverted line). 6/6 pass.
- `npm run lint` clean.
- Canvas rendering still warrants a visual check in `npm run dev:full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)