### PR TITLE
fix(releases): timeline hover tip on milestone dots

### DIFF
--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -1178,7 +1178,7 @@ var timelinePlugin = {
       _dotHitBoxes.push({
         x: dotDrawX, y: yMid,
         r: MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HIT_TOL,
-        nd: n[dIdx]
+        color: dotColor, nd: n[dIdx]
       })
     }
 
@@ -1393,11 +1393,27 @@ var timelinePlugin = {
         ctx.stroke()
         break
       }
-      // Highlight the milestone dot with a ring in the same stroke
+      // Highlight the milestone dot: a solid (non-transparent) backing fills the
+      // gap between the dot and the ring, then the dot and ring are drawn on top.
       var dotRingR = MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HALO_PAD + 1
       for (var dhi = 0; dhi < _dotHitBoxes.length; dhi++) {
         var dhBox = _dotHitBoxes[dhi]
         if (dhBox.nd !== _hoveredBox.nd) continue
+        // Solid backing (white in light mode, dark surface in dark mode)
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, dotRingR, 0, Math.PI * 2)
+        ctx.fillStyle = bgColor
+        ctx.fill()
+        // Redraw the dot on top of the backing
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER, 0, Math.PI * 2)
+        ctx.fillStyle = dotBorderColor
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, MILESTONE_DOT_RADIUS, 0, Math.PI * 2)
+        ctx.fillStyle = dhBox.color
+        ctx.fill()
+        // Ring in the same stroke as the card border
         ctx.beginPath()
         ctx.arc(dhBox.x, dhBox.y, dotRingR, 0, Math.PI * 2)
         ctx.stroke()

--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -5,7 +5,7 @@ import { Chart as ChartJS, LinearScale, PointElement, Tooltip } from 'chart.js'
 import { parseReleaseName, extractCycle, productLabel } from '../composables/useReleaseFamily.js'
 import { parseDate, daysFromNow, formatShort, getProduct } from '../composables/useScheduleHelpers.js'
 import { PRODUCT_HEX, DEFAULT_HEX } from '../composables/useProductColors.js'
-import { clampStemToCard } from './timeline-geometry.js'
+import { clampStemToCard, pointInCircle } from './timeline-geometry.js'
 
 ChartJS.register(LinearScale, PointElement, Tooltip)
 
@@ -188,6 +188,7 @@ var DOT_HALO_PAD = 1.5
 var TODAY_TEXT_START = Math.ceil(TODAY_DOT_RADIUS + TODAY_DOT_BORDER + DOT_HALO_PAD) + 4
 var CHART_MAX_HEIGHT = 450
 var STEM_HIT_TOL = 6
+var DOT_HIT_TOL = 4
 
 function hexToRgba(hex, alpha) {
   if (!hex || hex.charAt(0) !== '#' || hex.length < 7) return hex
@@ -622,6 +623,15 @@ function onCardHover(e) {
     }
   }
 
+  // Then milestone dots on the axis — resolve to the same node's card
+  for (var di = _dotHitBoxes.length - 1; di >= 0; di--) {
+    var dbox = _dotHitBoxes[di]
+    if (pointInCircle(cx, cy, dbox.x, dbox.y, dbox.r)) {
+      var dotCardBox = _cardBoxForNode(dbox.nd)
+      if (dotCardBox) { _setHoveredBox(dotCardBox); return }
+    }
+  }
+
   // Fall back to stems — resolve to the same node's card so the tip matches
   for (var si = _stemHitBoxes.length - 1; si >= 0; si--) {
     var sbox = _stemHitBoxes[si]
@@ -724,6 +734,7 @@ function _pluginSetup(chart) {
 
 var _cardHitBoxes = []
 var _stemHitBoxes = []
+var _dotHitBoxes = []
 var _hoveredBox = null
 var _frontNodes = new Set()
 
@@ -855,6 +866,7 @@ var timelinePlugin = {
     ctx.save()
     _cardHitBoxes = []
     _stemHitBoxes = []
+    _dotHitBoxes = []
 
     // Redraw arrowhead zone to cover any Chart.js dots near the right edge
     var bgColor = dark ? '#1f2937' : '#ffffff'
@@ -1162,6 +1174,12 @@ var timelinePlugin = {
       ctx.fillStyle = dotColor
       ctx.fill()
       ctx.globalAlpha = 1.0
+
+      _dotHitBoxes.push({
+        x: dotDrawX, y: yMid,
+        r: MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HIT_TOL,
+        nd: n[dIdx]
+      })
     }
 
     // Dimension lines
@@ -1372,6 +1390,16 @@ var timelinePlugin = {
         ctx.beginPath()
         ctx.moveTo(shX, shEnds.top)
         ctx.lineTo(shX, shEnds.bottom)
+        ctx.stroke()
+        break
+      }
+      // Highlight the milestone dot with a ring in the same stroke
+      var dotRingR = MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HALO_PAD + 1
+      for (var dhi = 0; dhi < _dotHitBoxes.length; dhi++) {
+        var dhBox = _dotHitBoxes[dhi]
+        if (dhBox.nd !== _hoveredBox.nd) continue
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, dotRingR, 0, Math.PI * 2)
         ctx.stroke()
         break
       }

--- a/modules/releases/client/components/__tests__/timeline-geometry.test.js
+++ b/modules/releases/client/components/__tests__/timeline-geometry.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { clampStemToCard } from '../timeline-geometry.js'
+import { clampStemToCard, pointInCircle } from '../timeline-geometry.js'
 
 // Mirrors the pixel geometry used in ReleaseTimeline.vue:
 //   above node: stem top = yMid - stemLen - 8, card bottom = yMid - stemLen - 4
@@ -56,5 +56,31 @@ describe('clampStemToCard', function () {
     expect(above.bottom).toBeGreaterThanOrEqual(above.top)
     var below = clampStemToCard(stem, card, false)
     expect(below.bottom).toBeGreaterThanOrEqual(below.top)
+  })
+})
+
+describe('pointInCircle (milestone-dot hit test)', function () {
+  // Dot centered at (200, 300) with a 10px hit radius.
+  var cx = 200
+  var cy = 300
+  var r = 10
+
+  it('hits at the exact center', function () {
+    expect(pointInCircle(cx, cy, cx, cy, r)).toBe(true)
+  })
+
+  it('hits just inside the radius (orthogonal and diagonal)', function () {
+    expect(pointInCircle(cx + 9, cy, cx, cy, r)).toBe(true)
+    expect(pointInCircle(cx, cy - 9, cx, cy, r)).toBe(true)
+    expect(pointInCircle(cx + 6, cy + 6, cx, cy, r)).toBe(true) // dist ≈ 8.49
+  })
+
+  it('hits exactly on the boundary', function () {
+    expect(pointInCircle(cx + r, cy, cx, cy, r)).toBe(true)
+  })
+
+  it('misses just outside the radius', function () {
+    expect(pointInCircle(cx + 11, cy, cx, cy, r)).toBe(false)
+    expect(pointInCircle(cx + 8, cy + 8, cx, cy, r)).toBe(false) // dist ≈ 11.3
   })
 })

--- a/modules/releases/client/components/timeline-geometry.js
+++ b/modules/releases/client/components/timeline-geometry.js
@@ -31,3 +31,20 @@ export function clampStemToCard(stem, card, above) {
   if (bottom < top) bottom = top
   return { top: top, bottom: bottom }
 }
+
+/**
+ * Circular hit test — true if point (px, py) is within radius r of (cx, cy).
+ * Used for milestone-dot hover detection.
+ *
+ * @param {number} px  Point X.
+ * @param {number} py  Point Y.
+ * @param {number} cx  Circle center X.
+ * @param {number} cy  Circle center Y.
+ * @param {number} r   Circle radius.
+ * @returns {boolean}
+ */
+export function pointInCircle(px, py, cx, cy, r) {
+  var dx = px - cx
+  var dy = py - cy
+  return dx * dx + dy * dy <= r * r
+}


### PR DESCRIPTION
## Summary

Follow-up to [#1482](https://github.com/red-hat-data-services/rhai-org-pulse/pull/1482) ([RHOAIENG-82037](https://redhat.atlassian.net/browse/RHOAIENG-82037)) — extend the timeline hover interaction to the milestone **dots** on the axis, so all three elements of a milestone (card, stem, dot) react identically.

- Hovering a milestone dot now surfaces the same tip as hovering its card or stem: the node is brought to the front, the card halo is drawn, and the "in Nd / Nd ago" badge appears.
- The dot itself is highlighted with a ring in the same stroke as the card's hover border (width 2, matching product/blue color), consistent with the card halo and stem highlight.
- Hit priority: cards → dots → stems.

## Implementation

- Added `pointInCircle()` to `timeline-geometry.js` for the circular dot hit test.
- `ReleaseTimeline.vue` records dot hit-boxes (center + hit radius) during the dot-drawing pass and resolves dot hovers to the owning node's card box.

## Testing

- New unit tests for `pointInCircle` (center, inside, boundary, outside — orthogonal and diagonal). Full geometry suite: 10/10 pass.
- `npm run lint` clean.
- Canvas rendering still warrants a visual check in `npm run dev:full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)