### PR TITLE
fix(releases): solid backing between milestone dot and highlight ring

### DIFF
--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -1178,7 +1178,7 @@ var timelinePlugin = {
       _dotHitBoxes.push({
         x: dotDrawX, y: yMid,
         r: MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HIT_TOL,
-        nd: n[dIdx]
+        color: dotColor, nd: n[dIdx]
       })
     }
 
@@ -1393,11 +1393,27 @@ var timelinePlugin = {
         ctx.stroke()
         break
       }
-      // Highlight the milestone dot with a ring in the same stroke
+      // Highlight the milestone dot: a solid (non-transparent) backing fills the
+      // gap between the dot and the ring, then the dot and ring are drawn on top.
       var dotRingR = MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER + DOT_HALO_PAD + 1
       for (var dhi = 0; dhi < _dotHitBoxes.length; dhi++) {
         var dhBox = _dotHitBoxes[dhi]
         if (dhBox.nd !== _hoveredBox.nd) continue
+        // Solid backing (white in light mode, dark surface in dark mode)
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, dotRingR, 0, Math.PI * 2)
+        ctx.fillStyle = bgColor
+        ctx.fill()
+        // Redraw the dot on top of the backing
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, MILESTONE_DOT_RADIUS + MILESTONE_DOT_BORDER, 0, Math.PI * 2)
+        ctx.fillStyle = dotBorderColor
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(dhBox.x, dhBox.y, MILESTONE_DOT_RADIUS, 0, Math.PI * 2)
+        ctx.fillStyle = dhBox.color
+        ctx.fill()
+        // Ring in the same stroke as the card border
         ctx.beginPath()
         ctx.arc(dhBox.x, dhBox.y, dotRingR, 0, Math.PI * 2)
         ctx.stroke()


### PR DESCRIPTION
## Summary

Follow-up to [#1483](https://github.com/red-hat-data-services/rhai-org-pulse/pull/1483) ([RHOAIENG-82037](https://redhat.atlassian.net/browse/RHOAIENG-82037)). Stacked on that branch.

When a milestone dot is highlighted, the gap between the dot and its ring is now filled with a solid, non-transparent backing:

- **Light mode:** white (`#ffffff`)
- **Dark mode:** the dark card surface (`#1f2937`)

This reuses the same `bgColor` / `dotBorderColor` already used for the dot's normal halo and border, so it stays consistent with the rest of the chart. The axis line, stems, and any neighboring dots no longer bleed through the ring gap. Draw order in the hover block: solid backing → dot border → colored dot → ring (in the card-border hover stroke).

## Testing

- `npm run lint` clean; existing timeline geometry suite unaffected (10/10).
- This is a fill-color change with no new pure geometry, so no new unit test — best verified visually in `npm run dev:full`.

> Note: stacked on the #1483 branch; GitHub will retarget this PR to `main` once #1483 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)