### PR TITLE
Fix team-scoped allocation refresh behavior

### DIFF
--- a/platform/allocation/__tests__/client/TeamAllocationTab.test.js
+++ b/platform/allocation/__tests__/client/TeamAllocationTab.test.js
@@ -17,7 +17,7 @@ vi.mock('../../client/composables/useAllocationStrategy', () => ({
 vi.mock('../../client/composables/useAllocationRefresh', async () => {
   const { ref } = await import('vue')
   return {
-    useAllocationRefresh: () => ({ refreshing: ref(false), message: ref(''), triggerRefresh: vi.fn() })
+    useAllocationRefresh: () => ({ refreshing: ref(false), message: ref(''), triggerRefresh: vi.fn(), resumeRefresh: vi.fn() })
   }
 })
 
@@ -63,7 +63,7 @@ describe('TeamAllocationTab board selection', () => {
     })
     await flushPromises()
 
-    expect(getBoardSprints).toHaveBeenCalledWith(1103, undefined)
+    expect(getBoardSprints).toHaveBeenCalledWith(1103, 'team_1', undefined)
     expect(wrapper.text()).toContain('detected as a')
     expect(wrapper.text()).toContain('Scrum board')
   })
@@ -125,7 +125,7 @@ describe('TeamAllocationTab board selection', () => {
     await wrapper.setProps({ teamDetail: { boards: [{ url: 'x/boards/1103', name: 'AI Hub Board', boardId: 1103 }] } })
     await flushPromises()
 
-    expect(getBoardSprints).toHaveBeenCalledWith(1103, undefined)
+    expect(getBoardSprints).toHaveBeenCalledWith(1103, 'team_1', undefined)
     expect(wrapper.text()).toContain('Scrum board')
   })
 

--- a/platform/allocation/__tests__/server/orchestration.test.js
+++ b/platform/allocation/__tests__/server/orchestration.test.js
@@ -72,7 +72,7 @@ describe('processBoard', () => {
     // Should write sprint data and sprint index
     const writeCalls = deps.writeStorage.mock.calls;
     expect(writeCalls.some(c => c[0] === 'sprints/100.json')).toBe(true);
-    expect(writeCalls.some(c => c[0] === 'sprints/board-42.json')).toBe(true);
+    expect(writeCalls.some(c => c[0] === 'sprints/board-42-team-team_abc.json')).toBe(true);
 
     // Sprint data should include teamId
     const sprintDataCall = writeCalls.find(c => c[0] === 'sprints/100.json');
@@ -222,7 +222,7 @@ describe('processKanbanBoard', () => {
     // Should write sprint data and sprint index
     const writeCalls = deps.writeStorage.mock.calls;
     expect(writeCalls.some(c => c[0] === 'sprints/kanban-50.json')).toBe(true);
-    expect(writeCalls.some(c => c[0] === 'sprints/board-50.json')).toBe(true);
+    expect(writeCalls.some(c => c[0] === 'sprints/board-50-team-team_abc.json')).toBe(true);
   });
 
   it('strips ORDER BY from JQL and adds date constraint', async () => {

--- a/platform/allocation/client/TeamAllocationTab.vue
+++ b/platform/allocation/client/TeamAllocationTab.vue
@@ -330,7 +330,7 @@ const isConfigured = computed(() =>
   teamAllocationMode.value === 'points' || teamAllocationMode.value === 'counts'
 )
 
-const { refreshing, message: refreshMessage, triggerRefresh } = useAllocationRefresh()
+const { refreshing, message: refreshMessage, triggerRefresh, resumeRefresh } = useAllocationRefresh()
 
 // --- Computed ---
 const allocationBoards = computed(() => {
@@ -491,7 +491,7 @@ async function loadSprints() {
 
   loadingSprints.value = true
   try {
-    const data = await getBoardSprints(board.boardId, board.sprintFilter)
+    const data = await getBoardSprints(board.boardId, props.teamId, board.sprintFilter)
     sprints.value = Array.isArray(data) ? data : (data.sprints || [])
     // `synced: false` means the board has no data file yet (never refreshed).
     boardSynced.value = Array.isArray(data) ? true : data.synced !== false
@@ -621,5 +621,6 @@ onMounted(() => {
   }
   // …then fetch the authoritative setting + edit permission.
   loadSettings()
+  resumeRefresh({ onComplete: loadSprints })
 })
 </script>

--- a/platform/allocation/client/composables/useAllocationRefresh.js
+++ b/platform/allocation/client/composables/useAllocationRefresh.js
@@ -16,11 +16,11 @@ import { refreshAllocation, getRefreshStatus } from '../services/allocation-api'
  *
  * @param {Object} [opts]
  * @param {number} [opts.pollIntervalMs] - Poll cadence (default 3000).
- * @param {number} [opts.maxPolls] - Safety cap on poll attempts (default 60 ≈ 3 min).
+ * @param {number} [opts.maxPolls] - Safety cap on poll attempts (default 120 ≈ 6 min).
  */
 export function useAllocationRefresh(opts = {}) {
   const pollIntervalMs = opts.pollIntervalMs ?? 3000
-  const maxPolls = opts.maxPolls ?? 60
+  const maxPolls = opts.maxPolls ?? 120
 
   const refreshing = ref(false)
   // 'idle' | 'starting' | 'running' | 'done' | 'cooldown' | 'unavailable' | 'error'
@@ -59,6 +59,36 @@ export function useAllocationRefresh(opts = {}) {
     return false
   }
 
+  async function resumeRefresh({ onComplete } = {}) {
+    if (refreshing.value) return { status: 'busy' }
+    const status = await readStatusSafe()
+    if (!status) return { status: 'unknown' }
+
+    if (status.running) {
+      refreshing.value = true
+      phase.value = 'running'
+      message.value = 'A refresh is already in progress…'
+      try {
+        const ok = await pollUntilComplete(status.completedAt || null)
+        if (onComplete) await onComplete()
+        phase.value = ok ? 'done' : 'error'
+        message.value = ok
+          ? 'Done — data updated.'
+          : 'The refresh is still running. You can check again shortly.'
+        return { status: ok ? 'completed' : 'still_running' }
+      } finally {
+        refreshing.value = false
+      }
+    }
+
+    if (status.completedAt && status.lastResult?.status === 'success' && onComplete) {
+      await onComplete()
+      phase.value = 'done'
+      message.value = 'Loaded the latest refresh results.'
+    }
+    return { status: 'idle' }
+  }
+
   /**
    * @param {Object} [args]
    * @param {string|null} [args.teamId] - Refresh a single team (self-service). Omit for a full, admin-only refresh.
@@ -90,7 +120,7 @@ export function useAllocationRefresh(opts = {}) {
         // A run finished within the cooldown window, so the latest data is
         // already on disk — just reload it.
         phase.value = 'done'
-        message.value = 'Just refreshed a moment ago — loading the latest data.'
+        message.value = `Just refreshed a moment ago — loading the latest data${res.retryAfter ? ` (try again in ${res.retryAfter}s)` : ''}.`
         if (onComplete) await onComplete()
         return res
       }
@@ -110,7 +140,7 @@ export function useAllocationRefresh(opts = {}) {
         message.value = 'Done — data updated.'
       } else {
         phase.value = 'error'
-        message.value = 'The refresh is taking longer than expected. Please check back shortly.'
+        message.value = 'The refresh is still running. You can check again shortly.'
       }
       return res
     } catch {
@@ -122,5 +152,5 @@ export function useAllocationRefresh(opts = {}) {
     }
   }
 
-  return { refreshing, phase, message, triggerRefresh }
+  return { refreshing, phase, message, triggerRefresh, resumeRefresh }
 }

--- a/platform/allocation/client/services/allocation-api.js
+++ b/platform/allocation/client/services/allocation-api.js
@@ -18,9 +18,10 @@ export async function updateTeamAllocationSettings(teamId, allocationMode) {
   })
 }
 
-export async function getBoardSprints(boardId, sprintFilter) {
-  const params = sprintFilter ? `?sprintFilter=${encodeURIComponent(sprintFilter)}` : ''
-  return apiRequest(`${BASE}/board/${encodeURIComponent(boardId)}/sprints${params}`)
+export async function getBoardSprints(boardId, teamId, sprintFilter) {
+  const params = new URLSearchParams({ teamId })
+  if (sprintFilter) params.set('sprintFilter', sprintFilter)
+  return apiRequest(`${BASE}/board/${encodeURIComponent(boardId)}/sprints?${params}`)
 }
 
 // Live, unfiltered sprint list from Jira — used to preview a name filter.
@@ -76,4 +77,3 @@ export async function getGlobalAllocationSummary() {
 export async function getAllocationStrategy() {
   return apiRequest(`${BASE}/strategy`)
 }
-

--- a/platform/allocation/server/orchestration.js
+++ b/platform/allocation/server/orchestration.js
@@ -7,6 +7,10 @@ const { buildSprintSummary, buildTeamSummary, buildOrgSummary } = require('./cla
  */
 const ALLOWED_ISSUE_TYPES = ['Bug', 'Task', 'Story', 'Spike', 'Vulnerability', 'Weakness'];
 
+function sprintIndexKey(boardId, teamId) {
+  return `sprints/board-${boardId}-team-${teamId}.json`;
+}
+
 /**
  * Process a single scrum board: fetch sprints and issues, classify, write to storage.
  */
@@ -97,7 +101,7 @@ async function processBoard({ board, teamId, allocationMode, strategy, hardRefre
   }
 
   // Write sprint index for this board
-  await writeStorage(`sprints/board-${board.boardId}.json`, {
+  await writeStorage(sprintIndexKey(board.boardId, teamId), {
     boardId: board.boardId,
     boardName: board.name,
     teamId,
@@ -179,7 +183,7 @@ async function processKanbanBoard({ board, teamId, allocationMode, strategy, fet
 
   await writeStorage(`sprints/${syntheticSprintId}.json`, sprintData);
 
-  await writeStorage(`sprints/board-${board.boardId}.json`, {
+  await writeStorage(sprintIndexKey(board.boardId, teamId), {
     boardId: board.boardId,
     boardName: board.name,
     teamId,

--- a/platform/allocation/server/routes.js
+++ b/platform/allocation/server/routes.js
@@ -564,6 +564,12 @@ module.exports = function registerAllocationRoutes(router, context) {
    *         schema:
    *           type: string
    *       - in: query
+   *         name: teamId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Team owning the board index
+   *       - in: query
    *         name: sprintFilter
    *         schema:
    *           type: string
@@ -579,15 +585,26 @@ module.exports = function registerAllocationRoutes(router, context) {
         return res.status(400).json({ error: 'Invalid request parameter' });
       }
 
-      // If sprintFilter query param, try filter-specific index first
-      const sprintFilter = req.query.sprintFilter;
-      if (sprintFilter) {
-        const filterKey = sprintFilter.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-        const filtered = await allocRead(`sprints/board-${boardId}-${filterKey}.json`);
-        if (filtered) return res.json({ synced: true, ...filtered });
+      const { teamId } = req.query;
+      if (!isValidTeamId(teamId)) {
+        return res.status(400).json({ error: 'Invalid request parameter' });
       }
 
-      const data = await allocRead(`sprints/board-${boardId}.json`);
+      const sprintFilter = req.query.sprintFilter;
+      const scopedKey = `sprints/board-${boardId}-team-${teamId}.json`;
+      let data = await allocRead(scopedKey);
+      // Read the legacy index only when it belongs to this team. This supports
+      // migration without allowing a shared board's other team's index through.
+      if (!data) {
+        const legacy = await allocRead(`sprints/board-${boardId}.json`);
+        if (legacy?.teamId === teamId) data = legacy;
+      }
+      if (data && sprintFilter?.trim()) {
+        const filterLower = sprintFilter.trim().toLowerCase();
+        data = { ...data, sprints: (data.sprints || []).filter(s =>
+          String(s.name || '').toLowerCase().includes(filterLower)
+        ) };
+      }
       if (!data) {
         // No index file for this board yet — it has never been synced from Jira.
         // `synced: false` lets the client distinguish this from a synced board


### PR DESCRIPTION
## Summary
- store allocation sprint indexes per team to prevent shared-board collisions
- load sprint indexes with the team scope and safely migrate legacy indexes
- improve refresh UX by resuming backend runs after reload, showing cooldown details, and extending recoverable polling

## Validation
- 41 targeted allocation tests passed
- npm run lint -- --no-fix
- npm run validate:openapi

Fixes the Compass/Forge/Heimdall shared-board allocation issue.