### PR TITLE
fix(releases): keep schedule tiles visible & timeline height stable for released versions

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -48,10 +48,10 @@
       "displayName": "rhelai-3.5.EA1",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-09-21",
-        "codeFreeze": "2026-08-10",
+        "ga": "2026-07-20",
+        "codeFreeze": "2026-06-08",
         "featureFreeze": null,
-        "planningFreeze": "2026-07-16"
+        "planningFreeze": "2026-05-14"
       },
       "state": "active",
       "fixVersions": [
@@ -63,10 +63,10 @@
       "displayName": "rhelai-3.5.EA2",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-10-19",
-        "codeFreeze": "2026-09-08",
+        "ga": "2026-08-17",
+        "codeFreeze": "2026-07-07",
         "featureFreeze": null,
-        "planningFreeze": "2026-08-13"
+        "planningFreeze": "2026-06-11"
       },
       "state": "active",
       "fixVersions": [
@@ -78,10 +78,10 @@
       "displayName": "rhelai-3.5",
       "productPagesShortname": "rhelai",
       "milestones": {
-        "ga": "2026-11-23",
-        "codeFreeze": "2026-10-18",
-        "featureFreeze": "2026-10-15",
-        "planningFreeze": "2026-09-22"
+        "ga": "2026-09-21",
+        "codeFreeze": "2026-08-16",
+        "featureFreeze": "2026-08-13",
+        "planningFreeze": "2026-07-21"
       },
       "state": "active",
       "fixVersions": [
@@ -94,10 +94,10 @@
       "displayName": "rhaii-3.5.EA1",
       "productPagesShortname": "rhaii",
       "milestones": {
-        "ga": "2026-06-02",
-        "codeFreeze": "2026-05-26",
+        "ga": "2026-03-31",
+        "codeFreeze": "2026-03-24",
         "featureFreeze": null,
-        "planningFreeze": "2026-04-17"
+        "planningFreeze": "2026-02-13"
       },
       "state": "archived",
       "fixVersions": [
@@ -109,10 +109,10 @@
       "displayName": "rhaii-3.5.EA2",
       "productPagesShortname": "rhaii",
       "milestones": {
-        "ga": "2026-09-28",
-        "codeFreeze": "2026-09-08",
+        "ga": "2026-07-27",
+        "codeFreeze": "2026-07-07",
         "featureFreeze": null,
-        "planningFreeze": "2026-08-13"
+        "planningFreeze": "2026-06-11"
       },
       "state": "active",
       "fixVersions": [
@@ -140,10 +140,10 @@
       "displayName": "rhaii-3.5",
       "productPagesShortname": "rhaii",
       "milestones": {
-        "ga": "2026-11-04",
-        "codeFreeze": "2026-10-18",
-        "featureFreeze": "2026-10-15",
-        "planningFreeze": "2026-09-22"
+        "ga": "2026-09-02",
+        "codeFreeze": "2026-08-16",
+        "featureFreeze": "2026-08-13",
+        "planningFreeze": "2026-07-21"
       },
       "state": "active",
       "fixVersions": [
@@ -156,10 +156,10 @@
       "displayName": "rhoai-3.5.EA1",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-09-15",
-        "codeFreeze": "2026-08-13",
+        "ga": "2026-07-14",
+        "codeFreeze": "2026-06-11",
         "featureFreeze": null,
-        "planningFreeze": "2026-07-30"
+        "planningFreeze": "2026-05-28"
       },
       "state": "active",
       "fixVersions": [
@@ -171,10 +171,10 @@
       "displayName": "rhoai-3.5.EA2",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-10-13",
-        "codeFreeze": "2026-09-18",
+        "ga": "2026-08-11",
+        "codeFreeze": "2026-07-17",
         "featureFreeze": null,
-        "planningFreeze": "2026-08-13"
+        "planningFreeze": "2026-06-11"
       },
       "state": "active",
       "fixVersions": [
@@ -186,10 +186,10 @@
       "displayName": "rhoai-3.5",
       "productPagesShortname": "rhoai",
       "milestones": {
-        "ga": "2026-11-24",
-        "codeFreeze": "2026-10-29",
-        "featureFreeze": "2026-10-15",
-        "planningFreeze": "2026-09-22"
+        "ga": "2026-09-22",
+        "codeFreeze": "2026-08-27",
+        "featureFreeze": "2026-08-13",
+        "planningFreeze": "2026-07-21"
       },
       "state": "active",
       "fixVersions": [

--- a/modules/releases/__tests__/client/release-timeline.test.js
+++ b/modules/releases/__tests__/client/release-timeline.test.js
@@ -298,7 +298,7 @@ describe('ReleaseTimeline', () => {
     expect(wrapper.vm.laneCount).toBe(2)
   })
 
-  it('scales chart height with visible node count', () => {
+  it('keeps a constant chart height regardless of visible node count', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-13T00:00:00'))
     try {
@@ -316,7 +316,9 @@ describe('ReleaseTimeline', () => {
           planningFreeze: '2026-08-28', codeFreeze: '2026-09-01', ga: '2026-09-05' })
       ]
       var wrapper2 = mount(ReleaseTimeline, { props: { releases: releases2 } })
-      expect(wrapper2.vm.chartHeight).toBeGreaterThan(singleHeight)
+      // The timeline box must not resize when the selection (node count) changes.
+      expect(wrapper2.vm.chartHeight).toBe(singleHeight)
+      expect(singleHeight).toBe(450)
     } finally {
       vi.useRealTimers()
     }
@@ -353,6 +355,34 @@ describe('ReleaseTimeline', () => {
 
     var wrapper2 = mount(ReleaseTimeline, { props: { releases, hidePast: true } })
     expect(wrapper2.vm.chartHeight).toBe(heightWithPast)
+  })
+
+  it('chart height is identical for a single release and many releases (no box resize on selection)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-13T00:00:00'))
+    try {
+      var one = [
+        makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2026-09-19' })
+      ]
+      var many = [
+        makeRelease('rhoai-3.4', { displayName: 'rhoai-3.4', shortname: 'rhoai',
+          planningFreeze: '2026-04-01', ga: '2026-07-01' }),
+        makeRelease('rhelai-3.4', { displayName: 'rhelai-3.4', shortname: 'rhelai',
+          planningFreeze: '2026-04-05', ga: '2026-07-05' }),
+        makeRelease('rhaii-3.4', { displayName: 'rhaii-3.4', shortname: 'rhaii',
+          planningFreeze: '2026-04-10', ga: '2026-07-10' }),
+        makeRelease('rhoai-3.6', { displayName: 'rhoai-3.6', shortname: 'rhoai',
+          planningFreeze: '2027-01-01', ga: '2027-05-19' }),
+        makeRelease('rhelai-3.6', { displayName: 'rhelai-3.6', shortname: 'rhelai',
+          planningFreeze: '2027-01-05', ga: '2027-05-25' })
+      ]
+      var wrapperOne = mount(ReleaseTimeline, { props: { releases: one } })
+      var wrapperMany = mount(ReleaseTimeline, { props: { releases: many } })
+      expect(wrapperOne.vm.chartHeight).toBe(wrapperMany.vm.chartHeight)
+      expect(wrapperOne.vm.chartHeight).toBe(450)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('allNodes contains all nodes regardless of hidePast', () => {
@@ -425,10 +455,8 @@ describe('ReleaseTimeline', () => {
       var wrapper = mount(ReleaseTimeline, { props: { releases, hidePast: true } })
       var heightAtDefault = wrapper.vm.chartHeight
 
-      // chartHeight depends only on layoutMetrics (allNodes), not on zoom/xRange
-      // Verify it equals layoutMetrics-derived value regardless of visible days
-      var m = wrapper.vm.layoutMetrics
-      expect(heightAtDefault).toBe(Math.min(m.aboveSpace + m.belowSpace + 40, 450))
+      // chartHeight is a fixed constant independent of zoom/xRange and node count
+      expect(heightAtDefault).toBe(450)
       expect(heightAtDefault).toBeGreaterThan(0)
     } finally {
       vi.useRealTimers()
@@ -592,9 +620,9 @@ describe('ReleaseTimeline', () => {
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     var m = wrapper.vm.layoutMetrics
     var h = wrapper.vm.chartHeight
-    // chartHeight = min(aboveSpace + belowSpace + 40, 450)
-    expect(h).toBe(Math.min(m.aboveSpace + m.belowSpace + 40, 450))
-    expect(h).toBeLessThanOrEqual(450)
+    // Height is a fixed 450 and must still accommodate the required row space.
+    expect(h).toBe(450)
+    expect(h).toBeGreaterThanOrEqual(m.aboveSpace + m.belowSpace + 40)
     expect(h).toBeGreaterThan(0)
   })
 
@@ -1101,9 +1129,10 @@ describe('ReleaseTimeline', () => {
       expect(m.aboveSpace).toBeGreaterThan(0)
       expect(m.belowSpace).toBeGreaterThan(0)
       expect(m.safeOff).toBeGreaterThan(0)
-      // chartHeight is deterministic from layoutMetrics
+      // chartHeight is a fixed constant that still fits the required row space
       var h = wrapper.vm.chartHeight
-      expect(h).toBe(Math.min(m.aboveSpace + m.belowSpace + 40, 450))
+      expect(h).toBe(450)
+      expect(h).toBeGreaterThanOrEqual(m.aboveSpace + m.belowSpace + 40)
       vi.useRealTimers()
     })
   })
@@ -1367,9 +1396,9 @@ describe('ReleaseTimeline', () => {
         var wrapper = mount(ReleaseTimeline, { props: { releases } })
         var m = wrapper.vm.layoutMetrics
         var h = wrapper.vm.chartHeight
-        // Height must accommodate both above and below spaces plus axis padding
-        expect(h).toBe(Math.min(m.aboveSpace + m.belowSpace + 40, 450))
-        expect(h).toBeGreaterThan(0)
+        // Fixed height must still accommodate both above and below spaces plus padding
+        expect(h).toBe(450)
+        expect(h).toBeGreaterThanOrEqual(m.aboveSpace + m.belowSpace + 40)
         expect(m.aboveSpace).toBeGreaterThan(0)
         expect(m.belowSpace).toBeGreaterThan(0)
       }

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -291,6 +291,117 @@ describe('ScheduleView', () => {
     expect(wrapper.text()).toContain('3d ago')
   })
 
+  it('keeps milestone tiles visible for an already-released version (past milestone fallback)', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 5)
+    const dateStr = localDateStr(past)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: dateStr
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, {
+      props: {},
+      global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } }
+    })
+    await flushPromises()
+
+    // Show released rows so the past-only version is present.
+    const hideReleased = wrapper.find('input[type="checkbox"]')
+    await hideReleased.setValue(false)
+    await flushPromises()
+
+    const cards = wrapper.findAll('[data-testid="milestone-countdown-card"]')
+    expect(cards.length).toBeGreaterThan(0)
+    expect(wrapper.text()).toContain('days ago')
+    expect(wrapper.text()).toContain('5')
+  })
+
+  it('auto-unticks "Hide released" when a released version pill is selected', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 5)
+    const pastStr = localDateStr(past)
+    const future = new Date()
+    future.setDate(future.getDate() + 30)
+    const futureStr = localDateStr(future)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: pastStr
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: futureStr
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    // "Hide released" is on by default.
+    const hideReleased = wrapper.find('input[type="checkbox"]')
+    expect(hideReleased.element.checked).toBe(true)
+
+    // Selecting the released version pill should untick it and keep the view populated.
+    const ea1 = wrapper.findAll('button').find(b => b.text().trim() === '3.5 EA1')
+    expect(ea1).toBeTruthy()
+    await ea1.trigger('click')
+    await flushPromises()
+
+    expect(hideReleased.element.checked).toBe(false)
+    expect(wrapper.text()).not.toContain('No releases match the current filters')
+    const rows = getReleaseRows(wrapper)
+    expect(rows.length).toBe(1)
+    expect(wrapper.text()).toContain('3.5 EA1 RHOAI RELEASE')
+    expect(wrapper.findAll('[data-testid="milestone-countdown-card"]').length).toBeGreaterThan(0)
+  })
+
+  it('does not untick "Hide released" when the selected version is unreleased', async () => {
+    const future = new Date()
+    future.setDate(future.getDate() + 30)
+    const futureStr = localDateStr(future)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: futureStr
+        }),
+        makeRelease('rhoai-3.7-ea1', {
+          displayName: '3.7 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-06-10'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    const hideReleased = wrapper.find('input[type="checkbox"]')
+    expect(hideReleased.element.checked).toBe(true)
+
+    const ea1 = wrapper.findAll('button').find(b => b.text().trim() === '3.6 EA1')
+    await ea1.trigger('click')
+    await flushPromises()
+
+    // Unreleased selection leaves the toggle untouched.
+    expect(hideReleased.element.checked).toBe(true)
+  })
+
+  it('shows an N/A tile when a release has no dated milestones', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', {})
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    const cards = wrapper.findAll('[data-testid="milestone-countdown-card"]')
+    expect(cards.length).toBe(1)
+    expect(cards[0].text()).toContain('N/A')
+  })
+
   it('refresh button re-fetches registry', async () => {
     apiRequest.mockResolvedValue({ releases: [makeRelease('rhoai-3.5', { ga: '2026-09-15' })] })
     const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })

--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -341,9 +341,14 @@ var layoutMetrics = computed(function () {
   return { aboveSpace: aboveSpace, belowSpace: Math.max(belowSpace, infraSpace), safeOff: safeOff }
 })
 
+// Fixed chart height so the timeline box never resizes when the release
+// selection changes (e.g. picking an older EA version). Row layout is always
+// shrunk to fit within CHART_MAX_HEIGHT (see layoutMetrics), so a constant
+// height never overflows — it only removes the vertical "jumping" between
+// selections. The axis position within the box stays proportional via the
+// y-scale (belowSpace/aboveSpace ratio in chartOptions).
 var chartHeight = computed(function () {
-  var m = layoutMetrics.value
-  return Math.min(m.aboveSpace + m.belowSpace + 40, CHART_MAX_HEIGHT)
+  return CHART_MAX_HEIGHT
 })
 
 function fmtDate(dateStr) {

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -110,39 +110,44 @@
         >Clear</button>
       </div>
 
-      <!-- Countdown cards -->
-      <div v-if="upcomingMilestoneCards.length" class="flex gap-4 mb-6 flex-wrap">
+      <!-- Milestone cards: upcoming countdowns, or the most recent past milestones
+           when only already-released versions are selected (never hidden). -->
+      <div v-if="milestoneCards.length" class="flex gap-4 mb-6 flex-wrap">
         <div
-          v-for="card in upcomingMilestoneCards"
+          v-for="card in milestoneCards"
           :key="card.releaseName + '-' + card.type"
           data-testid="milestone-countdown-card"
           class="flex-1 min-w-[140px] bg-white dark:bg-gray-800 border rounded-lg text-center py-5 px-4 transition-all hover:shadow-md"
-          :class="card.days <= 7
-            ? 'border-blue-300 dark:border-blue-600'
-            : 'border-gray-200 dark:border-gray-700'"
+          :class="card.na || card.past
+            ? 'border-gray-200 dark:border-gray-700 opacity-75'
+            : card.days <= 7
+              ? 'border-blue-300 dark:border-blue-600'
+              : 'border-gray-200 dark:border-gray-700'"
         >
           <div
             class="text-[42px] font-bold leading-none tabular-nums"
-            :class="card.days <= 7
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-gray-900 dark:text-gray-100'"
+            :class="card.na || card.past
+              ? 'text-gray-400 dark:text-gray-500'
+              : card.days <= 7
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-900 dark:text-gray-100'"
           >
-            {{ card.days === 0 ? 'Today' : card.days }}
+            {{ card.na ? 'N/A' : card.past ? Math.abs(card.days) : (card.days === 0 ? 'Today' : card.days) }}
           </div>
           <div
-            v-if="card.days !== 0"
+            v-if="!card.na && (card.past || card.days !== 0)"
             class="text-[11px] font-medium uppercase tracking-wider mt-1"
-            :class="card.days <= 7
+            :class="!card.past && card.days <= 7
               ? 'text-blue-400 dark:text-blue-500'
               : 'text-gray-400 dark:text-gray-500'"
-          >days</div>
+          >{{ card.past ? 'days ago' : 'days' }}</div>
           <div class="text-[13px] font-semibold text-gray-700 dark:text-gray-300 mt-2">
             {{ card.releaseName }}
           </div>
           <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
-            {{ card.label }} · {{ formatShort(card.date) }}
+            {{ card.label }}<template v-if="card.date"> · {{ formatShort(card.date) }}</template>
           </div>
-          <div v-if="card.days <= 7" class="flex justify-center mt-2">
+          <div v-if="!card.na && !card.past && card.days <= 7" class="flex justify-center mt-2">
             <span class="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse"></span>
           </div>
         </div>
@@ -275,10 +280,22 @@ function toggleProduct(p) {
   }
 }
 
+function versionHasReleased(v) {
+  return releases.value.some(function (r) {
+    return versionLabel(r) === v && isReleased(r)
+  })
+}
+
 function toggleVersion(v) {
   var idx = selectedVersions.value.indexOf(v)
   if (idx === -1) {
     selectedVersions.value = selectedVersions.value.concat(v)
+    // Selecting an already-released version implies the user wants to see it —
+    // auto-untick "Hide released" so the view isn't emptied out. Kept truthful:
+    // the checkbox reflects that released versions are now shown.
+    if (hideReleased.value && versionHasReleased(v)) {
+      hideReleased.value = false
+    }
   } else {
     selectedVersions.value = selectedVersions.value.filter(function (x) { return x !== v })
   }
@@ -408,27 +425,48 @@ const MILESTONE_TYPES = [
   { key: 'ga', label: 'Release Date' }
 ]
 
-const upcomingMilestoneCards = computed(() => {
-  const candidates = []
+const milestoneCards = computed(() => {
+  const upcoming = []
+  const past = []
   for (let i = 0; i < allSortedReleases.value.length; i++) {
     const r = allSortedReleases.value[i]
     const ms = r.milestones || {}
     for (let j = 0; j < MILESTONE_TYPES.length; j++) {
       const mt = MILESTONE_TYPES[j]
       const days = daysFromNow(ms[mt.key])
-      if (days !== null && days >= 0) {
-        candidates.push({
-          releaseName: r.displayName || r.id,
-          label: mt.label,
-          type: mt.key,
-          date: ms[mt.key],
-          days
-        })
+      if (days === null) continue
+      const card = {
+        releaseName: r.displayName || r.id,
+        label: mt.label,
+        type: mt.key,
+        date: ms[mt.key],
+        days,
+        past: days < 0
       }
+      if (days >= 0) upcoming.push(card)
+      else past.push(card)
     }
   }
-  candidates.sort((a, b) => a.days - b.days)
-  return candidates.slice(0, 4)
+  // Prefer upcoming milestone countdowns (nearest first).
+  if (upcoming.length) {
+    upcoming.sort((a, b) => a.days - b.days)
+    return upcoming.slice(0, 4)
+  }
+  // No upcoming milestones (e.g. an already-released version is selected):
+  // keep the tiles visible showing the most recent past milestones (least days ago first).
+  if (past.length) {
+    past.sort((a, b) => b.days - a.days)
+    return past.slice(0, 4)
+  }
+  // No dated milestones at all — surface an N/A tile per release so the row never disappears.
+  return allSortedReleases.value.slice(0, 4).map(r => ({
+    releaseName: r.displayName || r.id,
+    label: 'Release Date',
+    type: 'ga',
+    date: null,
+    days: null,
+    na: true
+  }))
 })
 
 function isReleased(release) {


### PR DESCRIPTION
## Summary

Fixes UX regressions in the Release Schedule view when an already-released version (e.g. `3.5 EA1`/`EA2`) is selected:

- **Milestone countdown tiles no longer disappear** for already-released versions. `ScheduleView` now uses a three-tier `milestoneCards` fallback: upcoming countdowns → most-recent past milestones (muted, "days ago") → per-release N/A tiles. Previously the row was hidden entirely, breaking the top-of-page UX.
- **Timeline height is now stable** — `ReleaseTimeline` uses a fixed `chartHeight` (`CHART_MAX_HEIGHT = 450`) instead of scaling with visible node count, so selecting/deselecting versions no longer resizes the box (content is already pre-shrunk to fit the cap).
- **Auto-unticks "Hide released"** when a released version pill is selected, so the view doesn't collapse to "No releases match the current filters". The checkbox stays truthful (visibly toggles) rather than silently overriding the filter.
- **Demo fixtures** shifted so `3.5 EA1`/`EA2` are in the past and `3.5 GA` is soon-ish, exercising the released-version paths.

## Tests

- `release-timeline.test.js`: constant chart height regardless of node count / zoom / `hidePast`.
- `schedule-view.test.js`: tiles stay visible for released versions; N/A tile fallback; auto-untick on released pill; no untick for unreleased selection.

Full releases suite green.

## Plan / references

- Plan doc: `~/.claude/plans/plan-for-this-enhancement-groovy-rose.md`
- Jira: RHOAIENG-84746 (https://redhat.atlassian.net/browse/RHOAIENG-84746)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
