### PR TITLE
fix(releases): sort version chips by freeze date, align feature counts across tabs

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1400,7 +1400,7 @@ Gear settings for the Execute workspace: portfolio version names, per-product Ji
 ```
 
 **Notes:**
-- Keys under `releases` are portfolio versions shown as Execute version chips.
+- Keys under `releases` are portfolio versions shown as Execute version chips, ordered by planning freeze date (earliest first). User `planningFreezeOverride` wins over Product Pages.
 - `products` maps family (`rhoai` / `rhelai` / `rhaii`) to the Jira fixVersion name used for hygiene and execution lookups.
 - `planningFreezeOverride` is an optional `YYYY-MM-DD` date; when set it wins over Product Pages.
 

--- a/modules/releases/__tests__/client/execute/merge-execute-features.test.js
+++ b/modules/releases/__tests__/client/execute/merge-execute-features.test.js
@@ -78,7 +78,7 @@ describe('mergeExecuteFeatures', function () {
     expect(result.groups[0].features[0].key).toBe('RHAISTRAT-1')
   })
 
-  it('keeps hygiene-only and execution-only records', function () {
+  it('omits hygiene-only and execution-only records', function () {
     var result = mergeExecuteFeatures({
       trackingGroups: [],
       hygieneFeatures: {
@@ -87,14 +87,8 @@ describe('mergeExecuteFeatures', function () {
       executionFeatures: [execFeature({ key: 'EXE-1', summary: 'Exec only' })]
     })
 
-    var keys = result.features.map(function (f) { return f.key }).sort()
-    expect(keys).toEqual(['EXE-1', 'HYG-1'])
-    var hyg = result.features.find(function (f) { return f.key === 'HYG-1' })
-    expect(hyg.violations).toHaveLength(1)
-    expect(hyg.completionPct).toBe(null)
-    var exe = result.features.find(function (f) { return f.key === 'EXE-1' })
-    expect(exe.completionPct).toBe(40)
-    expect(exe.violations).toEqual([])
+    expect(result.features).toEqual([])
+    expect(result.groups).toEqual([])
   })
 
   it('filters tracking groups to selected families', function () {
@@ -120,7 +114,7 @@ describe('mergeExecuteFeatures', function () {
     expect(result.groups.map(function (g) { return g.product })).toEqual(['rhoai'])
   })
 
-  it('marks blocked when any source reports a blocker', function () {
+  it('marks blocked when tracking or an overlay on a tracking key reports a blocker', function () {
     var fromTracking = mergeExecuteFeatures({
       trackingGroups: [{
         product: 'rhoai',
@@ -131,15 +125,25 @@ describe('mergeExecuteFeatures', function () {
     })
     expect(fromTracking.features[0].isBlocked).toBe(true)
 
-    var fromExec = mergeExecuteFeatures({
+    var fromExecOverlay = mergeExecuteFeatures({
+      trackingGroups: [{
+        product: 'rhoai',
+        features: [trackingFeature({ key: 'RHAISTRAT-1', isBlocked: false })]
+      }],
+      hygieneFeatures: {},
+      executionFeatures: [execFeature({ key: 'RHAISTRAT-1', blockerCount: 2 })]
+    })
+    expect(fromExecOverlay.features[0].isBlocked).toBe(true)
+
+    var execOnly = mergeExecuteFeatures({
       trackingGroups: [],
       hygieneFeatures: {},
       executionFeatures: [execFeature({ blockerCount: 2 })]
     })
-    expect(fromExec.features[0].isBlocked).toBe(true)
+    expect(execOnly.features).toEqual([])
   })
 
-  it('appends leftover hygiene features onto the matching product group', function () {
+  it('does not append leftover hygiene features onto the matching product group', function () {
     var result = mergeExecuteFeatures({
       trackingGroups: [{
         product: 'rhoai',
@@ -153,7 +157,9 @@ describe('mergeExecuteFeatures', function () {
     })
 
     expect(result.groups).toHaveLength(1)
-    var keys = result.groups[0].features.map(function (f) { return f.key }).sort()
-    expect(keys).toEqual(['H-1', 'T-1'])
+    var keys = result.groups[0].features.map(function (f) { return f.key })
+    expect(keys).toEqual(['T-1'])
+    expect(result.features.map(function (f) { return f.key })).toEqual(['T-1'])
+    expect(result.groups[0].featureCount).toBe(1)
   })
 })

--- a/modules/releases/__tests__/client/execute/signal-groups.test.js
+++ b/modules/releases/__tests__/client/execute/signal-groups.test.js
@@ -201,6 +201,15 @@ describe('categorizeFeatures', () => {
     const groups = categorizeFeatures(features);
     expect(findGroup(groups, 'complete').features).toHaveLength(1);
   });
+
+  it('excludes dropped features from signal buckets when live features exist', () => {
+    const groups = categorizeFeatures([
+      { key: 'LIVE', completionPct: 40, health: 'GREEN', statusCategory: 'In Progress' },
+      { key: 'GONE', scopeChange: 'dropped', completionPct: 0, health: 'RED', blockerCount: 2 }
+    ]);
+    expect(findGroup(groups, 'on-track').features.map(function (f) { return f.key })).toEqual(['LIVE']);
+    expect(findGroup(groups, 'blocked')).toBeUndefined();
+  });
 });
 
 describe('isFeatureCompleteForSignals', () => {
@@ -315,5 +324,26 @@ describe('summarizeSignalFeatures', () => {
     expect(stats.totalEpics).toBe(4)
     expect(stats.totalIssues).toBe(8)
     expect(stats.avgCompletion).toBe(10)
+  })
+
+  it('excludes dropped features from the live total', () => {
+    const stats = summarizeSignalFeatures([
+      { key: 'LIVE', statusCategory: 'In Progress', completionPct: 50, epicCount: 1, issueCount: 2, blockerCount: 1 },
+      { key: 'GONE', scopeChange: 'dropped', statusCategory: 'To Do', completionPct: 0, epicCount: 9, issueCount: 9, blockerCount: 9 }
+    ])
+    expect(stats.total).toBe(1)
+    expect(stats.inProgress).toBe(1)
+    expect(stats.todo).toBe(0)
+    expect(stats.totalEpics).toBe(1)
+    expect(stats.totalIssues).toBe(2)
+    expect(stats.blockers).toBe(1)
+  })
+
+  it('keeps dropped rows when the list is dropped-only', () => {
+    const stats = summarizeSignalFeatures([
+      { key: 'GONE', scopeChange: 'dropped', statusCategory: 'To Do' }
+    ])
+    expect(stats.total).toBe(1)
+    expect(stats.todo).toBe(1)
   })
 })

--- a/modules/releases/__tests__/client/execute/tracking-picker.test.js
+++ b/modules/releases/__tests__/client/execute/tracking-picker.test.js
@@ -24,10 +24,38 @@ function sampleConfig() {
 }
 
 describe('listTrackingVersions', function () {
-  it('returns gear keys newest-first and ignores empty keys', function () {
+  it('returns gear keys newest-first when freeze dates are unknown', function () {
     expect(listTrackingVersions(sampleConfig())).toEqual(['3.7', '3.6', '3.5.EA1'])
     expect(listTrackingVersions({ releases: {} })).toEqual([])
     expect(listTrackingVersions(null)).toEqual([])
+  })
+
+  it('sorts by planning freeze date earliest first', function () {
+    expect(listTrackingVersions(sampleConfig(), {
+      '3.7': '2026-10-01',
+      '3.6': '2026-06-15',
+      '3.5.EA1': '2026-03-01'
+    })).toEqual(['3.5.EA1', '3.6', '3.7'])
+  })
+
+  it('uses gear overrides over API freeze dates and puts undated versions last', function () {
+    var config = {
+      releases: {
+        '3.6.EA2': { products: {}, planningFreezeOverride: '2026-08-01' },
+        '3.6.EA1': { products: {} },
+        '3.6': { products: {} },
+        '3.5.EA2': { products: {}, planningFreezeOverride: '2026-03-01' },
+        '3.5.EA1': { products: {} },
+        '3.5': { products: {} }
+      }
+    }
+    expect(listTrackingVersions(config, {
+      '3.6.EA2': '2099-01-01',
+      '3.6.EA1': '2026-05-01',
+      '3.6': '2026-09-01',
+      '3.5.EA1': '2026-02-01',
+      '3.5': '2026-04-01'
+    })).toEqual(['3.5.EA1', '3.5.EA2', '3.5', '3.6.EA1', '3.6.EA2', '3.6'])
   })
 })
 
@@ -91,6 +119,17 @@ describe('reconcileSelection', function () {
     expect(reconcileSelection(sampleConfig(), {})).toEqual({
       version: '3.7',
       products: ['rhoai', 'rhaii']
+    })
+  })
+
+  it('defaults to the earliest freeze date when dates are known', function () {
+    expect(reconcileSelection(sampleConfig(), {}, {
+      '3.7': '2026-10-01',
+      '3.6': '2026-06-15',
+      '3.5.EA1': '2026-03-01'
+    })).toEqual({
+      version: '3.5.EA1',
+      products: ['rhoai']
     })
   })
 

--- a/modules/releases/client/execute/helpers/merge-execute-features.js
+++ b/modules/releases/client/execute/helpers/merge-execute-features.js
@@ -1,9 +1,10 @@
 /**
  * Join tracking, hygiene, and execution feature records by Jira key.
  *
- * Missing overlays are left empty (null / [] / 0) so Table, Board, and Signals
- * can share one feature list without dropping records that exist in only one
- * source.
+ * Membership is tracking-only (current Features plus dropped). Hygiene and
+ * execution are overlays on those keys. Missing overlays are left empty
+ * (null / [] / 0). Rows that exist only in hygiene or execution are omitted
+ * so Table, Board, and Signals share one list that matches tracking JQL.
  */
 
 var OTHER_PRODUCT = 'other'
@@ -66,12 +67,6 @@ function mergeOne(tracking, hygiene, execution, product) {
   }
 }
 
-function familyOf(hygiene, trackingProduct) {
-  if (trackingProduct) return String(trackingProduct).toLowerCase()
-  if (hygiene && hygiene._family) return String(hygiene._family).toLowerCase()
-  return null
-}
-
 /**
  * @param {object} opts
  * @param {object[]} [opts.trackingGroups]
@@ -114,28 +109,15 @@ export function mergeExecuteFeatures(opts) {
     }
   }
 
-  var allKeys = {}
-  var hk = Object.keys(hygieneByKey)
-  for (var hi = 0; hi < hk.length; hi++) allKeys[hk[hi]] = true
-  var tk = Object.keys(trackingByKey)
-  for (var ti = 0; ti < tk.length; ti++) allKeys[tk[ti]] = true
-  var ek = Object.keys(execByKey)
-  for (var ei = 0; ei < ek.length; ei++) allKeys[ek[ei]] = true
-
   var mergedByKey = {}
-  var keys = Object.keys(allKeys)
+  var keys = Object.keys(trackingByKey)
   for (var ki = 0; ki < keys.length; ki++) {
     var key = keys[ki]
     var hy = hygieneByKey[key] || null
-    var fam = familyOf(hy, trackingProductByKey[key])
-    if (hasFamilyFilter && hy && fam && !familySet[fam] && !trackingByKey[key] && !execByKey[key]) {
-      continue
-    }
-    var mergedProduct = trackingProductByKey[key] || (hy && hy._family) || OTHER_PRODUCT
+    var mergedProduct = trackingProductByKey[key] || OTHER_PRODUCT
     mergedByKey[key] = mergeOne(trackingByKey[key], hy, execByKey[key], String(mergedProduct).toLowerCase())
   }
 
-  var used = {}
   var groups = []
   for (var gi = 0; gi < keptTrackingGroups.length; gi++) {
     var src = keptTrackingGroups[gi]
@@ -145,7 +127,6 @@ export function mergeExecuteFeatures(opts) {
       var srcKey = srcFeats[sj] && srcFeats[sj].key
       if (!srcKey || !mergedByKey[srcKey]) continue
       mergedFeats.push(mergedByKey[srcKey])
-      used[srcKey] = true
     }
     var liveCount = 0
     for (var lc = 0; lc < mergedFeats.length; lc++) {
@@ -159,52 +140,6 @@ export function mergeExecuteFeatures(opts) {
       featureCount: liveCount,
       features: mergedFeats
     })
-  }
-
-  var leftoversByProduct = {}
-  var leftoverKeys = Object.keys(mergedByKey)
-  for (var li = 0; li < leftoverKeys.length; li++) {
-    var lkey = leftoverKeys[li]
-    if (used[lkey]) continue
-    var leftover = mergedByKey[lkey]
-    var lp = leftover.product || OTHER_PRODUCT
-    if (!leftoversByProduct[lp]) leftoversByProduct[lp] = []
-    leftoversByProduct[lp].push(leftover)
-  }
-
-  var leftoverProducts = Object.keys(leftoversByProduct)
-  leftoverProducts.sort()
-  for (var lpIdx = 0; lpIdx < leftoverProducts.length; lpIdx++) {
-    var p = leftoverProducts[lpIdx]
-    var extra = leftoversByProduct[p]
-    var existing = null
-    for (var eg = 0; eg < groups.length; eg++) {
-      if (groups[eg].product === p) {
-        existing = groups[eg]
-        break
-      }
-    }
-    if (existing) {
-      existing.features = existing.features.concat(extra)
-      var extraLive = 0
-      for (var el = 0; el < extra.length; el++) {
-        if (extra[el].scopeChange !== 'dropped') extraLive++
-      }
-      existing.featureCount += extraLive
-    } else {
-      var newLive = 0
-      for (var nl = 0; nl < extra.length; nl++) {
-        if (extra[nl].scopeChange !== 'dropped') newLive++
-      }
-      groups.push({
-        label: p === OTHER_PRODUCT ? 'Other' : p.toUpperCase(),
-        product: p,
-        releaseNumber: '',
-        planningFreezeDate: null,
-        featureCount: newLive,
-        features: extra
-      })
-    }
   }
 
   var features = Object.keys(mergedByKey).map(function (k) { return mergedByKey[k] })

--- a/modules/releases/client/execute/helpers/signal-groups.js
+++ b/modules/releases/client/execute/helpers/signal-groups.js
@@ -56,8 +56,24 @@ export function signalIdForFeature(f) {
   return null
 }
 
+/**
+ * Live tracking Features (excludes dropped). If the list is dropped-only
+ * (Dropped KPI filter), keep those rows so the view is not emptied.
+ *
+ * @param {object[]} features
+ * @returns {object[]}
+ */
+export function liveExecuteFeatures(features) {
+  var all = features || []
+  var live = []
+  for (var i = 0; i < all.length; i++) {
+    if (all[i] && all[i].scopeChange !== 'dropped') live.push(all[i])
+  }
+  return live.length > 0 ? live : all
+}
+
 export function categorizeFeatures(features) {
-  const all = features || []
+  const all = liveExecuteFeatures(features)
   // Jira done-delivery or pipeline 100% — stale pipeline health should not override.
   const complete = all.filter(f => signalIdForFeature(f) === 'complete')
   const blocked = all.filter(f => signalIdForFeature(f) === 'blocked')
@@ -163,7 +179,7 @@ export function effectiveHealth(f) {
  * }}
  */
 export function summarizeSignalFeatures(features) {
-  var all = features || []
+  var all = liveExecuteFeatures(features)
   var total = all.length
   var done = 0
   var inProgress = 0

--- a/modules/releases/client/execute/helpers/tracking-picker.js
+++ b/modules/releases/client/execute/helpers/tracking-picker.js
@@ -38,12 +38,35 @@ function filledProducts(config, version) {
   return ordered
 }
 
-export function listTrackingVersions(config) {
+function versionNameDesc(a, b) {
+  return String(b).localeCompare(String(a), undefined, { numeric: true })
+}
+
+function freezeDateForVersion(config, version, freezeDates) {
+  var entry = config && config.releases && config.releases[version]
+  if (entry && entry.planningFreezeOverride) return entry.planningFreezeOverride
+  if (freezeDates && freezeDates[version]) return freezeDates[version]
+  return null
+}
+
+/**
+ * Gear version keys ordered by planning freeze date, earliest first.
+ * User override wins over Product Pages / API dates; undated versions sort last.
+ *
+ * @param {object} config
+ * @param {Record<string, string|null>} [freezeDates]
+ */
+export function listTrackingVersions(config, freezeDates) {
   var releases = (config && config.releases) || {}
   return Object.keys(releases)
     .filter(function (k) { return String(k).trim() })
     .sort(function (a, b) {
-      return String(b).localeCompare(String(a), undefined, { numeric: true })
+      var da = freezeDateForVersion(config, a, freezeDates)
+      var db = freezeDateForVersion(config, b, freezeDates)
+      if (da && db) return da.localeCompare(db)
+      if (da && !db) return -1
+      if (!da && db) return 1
+      return versionNameDesc(a, b)
     })
 }
 
@@ -78,11 +101,12 @@ function specsForVersion(config, version, productFilter) {
 /**
  * @param {object} config tracking config `{ releases: { [version]: { products } } }`
  * @param {{ version?: string, products?: string[] }} selection
+ * @param {Record<string, string|null>} [freezeDates]
  * @returns {{ portfolioVersion: string, family: string|null, jiraName: string|null }[]}
  */
-export function buildReleaseSpecs(config, selection) {
+export function buildReleaseSpecs(config, selection, freezeDates) {
   var sel = selection || {}
-  var versions = listTrackingVersions(config)
+  var versions = listTrackingVersions(config, freezeDates)
   var version = sel.version
   if (!version || versions.indexOf(version) < 0) return []
   return specsForVersion(config, version, sel.products)
@@ -99,11 +123,13 @@ export function parseProductsFromParams(productsParam, familiesParam) {
 
 /**
  * Drop deleted versions / products and fill defaults from gear config.
+ * Default version is the earliest planning freeze when dates are known.
  * @param {object} config
  * @param {{ version?: string, products?: string[] }} stored
+ * @param {Record<string, string|null>} [freezeDates]
  */
-export function reconcileSelection(config, stored) {
-  var versions = listTrackingVersions(config)
+export function reconcileSelection(config, stored, freezeDates) {
+  var versions = listTrackingVersions(config, freezeDates)
   stored = stored || {}
   if (versions.length === 0) {
     return { version: '', products: [] }

--- a/modules/releases/client/execute/views/ExecuteWorkspaceView.vue
+++ b/modules/releases/client/execute/views/ExecuteWorkspaceView.vue
@@ -310,7 +310,7 @@ function currentSpecs() {
   return buildReleaseSpecs(trackingConfig.value, {
     version: selectedVersion.value,
     products: selectedProducts.value
-  })
+  }, freezeDatesByVersion.value)
 }
 
 function persistSelection() {

--- a/modules/releases/client/execute/views/ExecuteWorkspaceView.vue
+++ b/modules/releases/client/execute/views/ExecuteWorkspaceView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, inject, nextTick } from 'vue'
 import { apiRequest, getApiBase } from '@shared/client/services/api.js'
 import { useReportFilters } from '../../reports/composables/useReportFilters.js'
 import { useExecuteWorkspace } from '../composables/useExecuteWorkspace.js'
-import { signalIdForFeature } from '../helpers/signal-groups.js'
+import { signalIdForFeature, liveExecuteFeatures } from '../helpers/signal-groups.js'
 import {
   STORAGE_KEY as PICKER_STORAGE_KEY,
   listTrackingVersions,
@@ -60,7 +60,8 @@ const refreshing = ref(false)
 const settingsOpen = ref(false)
 const trackingConfig = ref({ releases: {} })
 
-const trackingVersions = computed(() => listTrackingVersions(trackingConfig.value))
+const freezeDatesByVersion = ref({})
+const trackingVersions = computed(() => listTrackingVersions(trackingConfig.value, freezeDatesByVersion.value))
 const availableProducts = computed(() => productsForVersion(trackingConfig.value, selectedVersion.value))
 const hasSelection = computed(() => !!selectedVersion.value && trackingVersions.value.indexOf(selectedVersion.value) >= 0)
 
@@ -170,6 +171,8 @@ const overlayFilteredFeatures = computed(() => {
   }
   return list
 })
+
+const liveOverlayFeatures = computed(() => liveExecuteFeatures(overlayFilteredFeatures.value))
 
 const filteredKeySet = computed(() => {
   const set = {}
@@ -348,7 +351,7 @@ function restoreSelection() {
   if (params.products || params.families) {
     stored.products = parseProductsFromParams(params.products, params.families)
   }
-  applySelection(reconcileSelection(trackingConfig.value, stored))
+  applySelection(reconcileSelection(trackingConfig.value, stored, freezeDatesByVersion.value))
 }
 
 async function reload(opts) {
@@ -396,8 +399,23 @@ async function fetchTrackingConfig() {
   } catch (e) { void e }
 }
 
+async function fetchFreezeDates() {
+  try {
+    const data = await apiRequest('/modules/releases/execution/tracking/versions')
+    const map = {}
+    const rows = (data && data.versions) || []
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]
+      if (row && row.version) map[row.version] = row.planningFreezeDate || null
+    }
+    freezeDatesByVersion.value = map
+  } catch {
+    freezeDatesByVersion.value = {}
+  }
+}
+
 onMounted(async () => {
-  await fetchTrackingConfig()
+  await Promise.all([fetchTrackingConfig(), fetchFreezeDates()])
   restoreSelection()
   persistSelection()
   await reload()
@@ -418,10 +436,11 @@ async function handleRefresh() {
 async function onSettingsSaved(newConfig) {
   trackingConfig.value = newConfig
   settingsOpen.value = false
+  await fetchFreezeDates()
   applySelection(reconcileSelection(newConfig, {
     version: selectedVersion.value,
     products: selectedProducts.value
-  }))
+  }, freezeDatesByVersion.value))
   persistSelection()
   await reload({ refreshTracking: true })
 }
@@ -516,7 +535,7 @@ onMounted(loadRuleCategories)
             :data-testid="'execute-view-' + mode.id"
             class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
             :class="viewMode === mode.id
-              ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+              ? 'bg-orange-500 dark:bg-orange-600 text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
             @click="setViewMode(mode.id)"
           >{{ mode.label }}</button>
@@ -722,13 +741,13 @@ onMounted(loadRuleCategories)
 
       <KanbanBoard
         v-else-if="viewMode === 'board'"
-        :features="overlayFilteredFeatures"
+        :features="liveOverlayFeatures"
         @feature-click="handleFeatureClick"
       />
 
       <FeatureSignalsBoard
         v-else-if="viewMode === 'signals'"
-        :features="overlayFilteredFeatures"
+        :features="liveOverlayFeatures"
         :selected-signals="[]"
         @select="handleFeatureClick"
       />

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1700,6 +1700,46 @@ test.describe('Feature Execution workspace @releases', () => {
     expect(unexpectedDemoResourceErrors(page)).toHaveLength(0);
   });
 
+  test('version chips are ordered by planning freeze date earliest first', async ({ page, request }) => {
+    await page.goto('/#/releases/execute');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await dismissHygieneWelcome(page);
+
+    const chips = page.locator('[data-testid="hygiene-release-selector"] button');
+    await expect(chips.first()).toBeVisible();
+    const labels = (await chips.allTextContents()).map((t) => t.trim()).filter(Boolean);
+
+    const [configRes, versionsRes] = await Promise.all([
+      request.get('/api/modules/releases/execution/tracking/config'),
+      request.get('/api/modules/releases/execution/tracking/versions')
+    ]);
+    const config = await configRes.json();
+    const versionRows = (await versionsRes.json()).versions || [];
+    const apiDates = {};
+    for (const row of versionRows) {
+      if (row && row.version) apiDates[row.version] = row.planningFreezeDate || null;
+    }
+    function freezeFor(version) {
+      const entry = config.releases && config.releases[version];
+      if (entry && entry.planningFreezeOverride) return entry.planningFreezeOverride;
+      return apiDates[version] || null;
+    }
+    const expected = Object.keys(config.releases || {})
+      .filter((k) => String(k).trim())
+      .sort((a, b) => {
+        const da = freezeFor(a);
+        const db = freezeFor(b);
+        if (da && db) return da.localeCompare(db);
+        if (da && !db) return -1;
+        if (!da && db) return 1;
+        return String(b).localeCompare(String(a), undefined, { numeric: true });
+      });
+    expect(labels).toEqual(expected);
+
+    expect(unexpectedDemoResourceErrors(page)).toHaveLength(0);
+  });
+
   test('hygiene rules modal is reachable from the toolbar', async ({ page }) => {
     await page.goto('/#/releases/execute?tab=feature-status');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

- **Version chip ordering**: Execute workspace version chips are now sorted by planning freeze date (earliest first). Gear `planningFreezeOverride` takes priority over Product Pages dates; undated versions sort last by name.
- **Tracking-only membership**: Feature counts now match the tracking JQL (`issuetype = Feature AND fixVersion IN (...)`). Hygiene and execution data are overlays on tracking keys only — they no longer inflate the FEATURES card with Initiatives, Target-Version-only records, or bugs.
- **Consistent counts across tabs**: Kanban and Signals now exclude dropped features, matching the Table view's live count. All three tabs show the same feature total for a given release.
- **Toggle styling**: Table / Kanban / Signals toggle uses orange for the active state.

## Test plan

- [x] Unit tests: `tracking-picker`, `merge-execute-features`, `signal-groups`, `FeatureSignalsBoard` — all passing
- [x] Integration test: version chips are ordered by planning freeze date earliest first
- [ ] Visual: Execute page shows version chips in freeze-date order
- [ ] Visual: FEATURES card matches Jira Feature + fixVersion count (no hygiene/execution inflation)
- [ ] Visual: Switching Table → Kanban → Signals shows the same feature count
- [ ] Visual: Active toggle tab is orange

Made with [Cursor](https://cursor.com)