### PR TITLE
feat(releases): auto-fit timeline to a selected version (released or upcoming)

### DIFF
--- a/modules/releases/__tests__/client/release-timeline.test.js
+++ b/modules/releases/__tests__/client/release-timeline.test.js
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 
 vi.mock('@shared/client/services/api.js', () => ({
   apiRequest: vi.fn()
+}))
+
+// Stub the Chart.js canvas component: jsdom has no layout engine, so Chart.js
+// resize (triggered by prop updates via setProps) reads `ownerDocument` off a
+// detached canvas and throws. Tests assert on `vm.chartData`/`vm.xRange`
+// computeds, not on rendered chart pixels, so a no-op render is sufficient.
+vi.mock('vue-chartjs', () => ({
+  Scatter: { name: 'Scatter', props: ['data', 'options'], render: () => null }
 }))
 
 import ReleaseTimeline from '../../client/components/ReleaseTimeline.vue'
@@ -264,16 +272,175 @@ describe('ReleaseTimeline', () => {
     }
   })
 
-  it('visibleDays never exceeds MAX_VISIBLE_DAYS (90)', () => {
+  it('visibleDays never exceeds MAX_VISIBLE_DAYS (180)', () => {
     // Even with releases spanning 6+ months, defaultRange caps at 29 days
-    // and fullRange would be larger, but zoom is capped at 90 days
+    // and fullRange would be larger, but zoom is capped at 180 days
     var releases = [
       makeRelease('rhoai-3.5', { displayName: 'rhoai-3.5', shortname: 'rhoai', ga: '2090-06-17' }),
       makeRelease('rhoai-3.9', { displayName: 'rhoai-3.9', shortname: 'rhoai', ga: '2090-12-17' })
     ]
     var wrapper = mount(ReleaseTimeline, { props: { releases } })
     // Default view is 29 days
-    expect(wrapper.vm.visibleDays).toBeLessThanOrEqual(90)
+    expect(wrapper.vm.visibleDays).toBeLessThanOrEqual(180)
+  })
+
+  describe('auto-fit to focused version', () => {
+    var DAY_MS = 86400000
+    function ts(str) { return new Date(str + 'T00:00:00').getTime() }
+
+    // A released version (all milestones in the past) plus a future release so the
+    // timeline spans today. Today is faked to 2026-08-27.
+    function fitReleases() {
+      return [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: 'rhoai-3.5.EA1', shortname: 'rhoai',
+          planningFreeze: '2026-05-01', featureFreeze: '2026-06-01',
+          codeFreeze: '2026-06-20', ga: '2026-07-14'
+        }),
+        makeRelease('rhoai-3.6', {
+          displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-11-15'
+        })
+      ]
+    }
+
+    it('fits the view to a focused past version while keeping the today marker in frame', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-27T00:00:00'))
+      try {
+        var wrapper = mount(ReleaseTimeline, {
+          props: { releases: fitReleases(), hidePast: false, focusReleaseIds: [] }
+        })
+        // Default today-anchored window does not include the past EA1 milestones.
+        expect(wrapper.vm.isZoomed).toBe(false)
+
+        await wrapper.setProps({ focusReleaseIds: ['rhoai-3.5-ea1'] })
+        await flushPromises()
+
+        expect(wrapper.vm.isZoomed).toBe(true)
+        var r = wrapper.vm.xRange
+        var gaTs = ts('2026-07-14')
+        var planTs = ts('2026-05-01')
+        var todayTs = ts('2026-08-27')
+        // The whole past cluster is visible.
+        expect(planTs).toBeGreaterThanOrEqual(r.min)
+        expect(gaTs).toBeLessThanOrEqual(r.max)
+        // Today is still in view — it's the latest point, anchored near the right edge.
+        expect(todayTs).toBeGreaterThanOrEqual(r.min)
+        expect(todayTs).toBeLessThanOrEqual(r.max)
+        expect(r.max - todayTs).toBeLessThanOrEqual(5 * DAY_MS)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not move the view when a focused version already has cards visible', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-27T00:00:00'))
+      try {
+        var releases = [
+          makeRelease('rhoai-3.5-ea1', {
+            displayName: 'rhoai-3.5.EA1', shortname: 'rhoai',
+            codeFreeze: '2026-08-20', ga: '2026-08-25' // within the default window
+          }),
+          makeRelease('rhoai-3.6', {
+            displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-11-15'
+          })
+        ]
+        var wrapper = mount(ReleaseTimeline, {
+          props: { releases, hidePast: false, focusReleaseIds: [] }
+        })
+        await wrapper.setProps({ focusReleaseIds: ['rhoai-3.5-ea1'] })
+        await flushPromises()
+        // Cards already visible → no fit.
+        expect(wrapper.vm.isZoomed).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('leaves the view untouched when focus is cleared', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-27T00:00:00'))
+      try {
+        var wrapper = mount(ReleaseTimeline, {
+          props: { releases: fitReleases(), hidePast: false, focusReleaseIds: [] }
+        })
+        await wrapper.setProps({ focusReleaseIds: ['rhoai-3.5-ea1'] })
+        await flushPromises()
+        expect(wrapper.vm.isZoomed).toBe(true)
+        var before = wrapper.vm.xRange
+
+        await wrapper.setProps({ focusReleaseIds: [] })
+        await flushPromises()
+        // Deselect leaves the current (fitted) view as-is.
+        expect(wrapper.vm.isZoomed).toBe(true)
+        expect(wrapper.vm.xRange.min).toBe(before.min)
+        expect(wrapper.vm.xRange.max).toBe(before.max)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not fit on mount even if focusReleaseIds is provided', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-27T00:00:00'))
+      try {
+        var wrapper = mount(ReleaseTimeline, {
+          props: { releases: fitReleases(), hidePast: false, focusReleaseIds: ['rhoai-3.5-ea1'] }
+        })
+        // Flush the microtask queue: were the watcher `immediate`, its nextTick fit
+        // would have run by now. Non-immediate → the default window is preserved.
+        await flushPromises()
+        expect(wrapper.vm.isZoomed).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('fits the view to a focused upcoming version whose milestones are far in the future', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-27T00:00:00'))
+      try {
+        // 3.9 is a far-future version: all milestones months past the default window,
+        // off-screen to the RIGHT of "YOU ARE HERE".
+        var releases = [
+          makeRelease('rhoai-3.6', {
+            displayName: 'rhoai-3.6', shortname: 'rhoai', ga: '2026-09-10'
+          }),
+          makeRelease('rhoai-3.9', {
+            displayName: 'rhoai-3.9', shortname: 'rhoai',
+            planningFreeze: '2027-04-01', featureFreeze: '2027-05-01',
+            codeFreeze: '2027-05-20', ga: '2027-06-15'
+          })
+        ]
+        var wrapper = mount(ReleaseTimeline, {
+          props: { releases, hidePast: false, focusReleaseIds: [] }
+        })
+        expect(wrapper.vm.isZoomed).toBe(false)
+        var todayTs = ts('2026-08-27')
+
+        await wrapper.setProps({ focusReleaseIds: ['rhoai-3.9'] })
+        await flushPromises()
+
+        expect(wrapper.vm.isZoomed).toBe(true)
+        var r = wrapper.vm.xRange
+        var gaTs = ts('2027-06-15')
+        var planTs = ts('2027-04-01')
+        // The future cluster is fully in view, GA near the right edge.
+        expect(planTs).toBeGreaterThanOrEqual(r.min)
+        expect(gaTs).toBeGreaterThanOrEqual(r.min)
+        expect(gaTs).toBeLessThanOrEqual(r.max)
+        expect(r.max - gaTs).toBeLessThanOrEqual(5 * DAY_MS)
+        // Today stays in frame even though the version is ~10 months out — the fit
+        // widens the window rather than dropping the "YOU ARE HERE" marker. Today is
+        // the earliest point here, anchored near the left edge.
+        expect(todayTs).toBeGreaterThanOrEqual(r.min)
+        expect(todayTs).toBeLessThanOrEqual(r.max)
+        expect(todayTs - r.min).toBeLessThanOrEqual(10 * DAY_MS)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   it('shows zoom hint text when not zoomed', () => {

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -11,7 +11,7 @@ import ScheduleView from '../../client/views/ScheduleView.vue'
 function localDateStr(date) {
   return date.getFullYear() + '-' + String(date.getMonth() + 1).padStart(2, '0') + '-' + String(date.getDate()).padStart(2, '0')
 }
-const ReleaseTimelineStub = { template: '<div class="timeline-stub"></div>', props: ['releases'] }
+const ReleaseTimelineStub = { template: '<div class="timeline-stub"></div>', props: ['releases', 'focusReleaseIds'] }
 
 function makeRelease(id, opts = {}) {
   return {
@@ -522,5 +522,121 @@ describe('ScheduleView', () => {
     await clearBtn.trigger('click')
     var timeline = wrapper.findComponent(ReleaseTimelineStub)
     expect(timeline.props('releases').length).toBe(2)
+  })
+
+  it('passes focusReleaseIds to the timeline when the newest selected version is released', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 30)
+    const pastStr = localDateStr(past)
+    const future = new Date()
+    future.setDate(future.getDate() + 60)
+    const futureStr = localDateStr(future)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: pastStr
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: futureStr
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    const ea1 = wrapper.findAll('button').find(b => b.text().trim() === '3.5 EA1')
+    await ea1.trigger('click')
+    await flushPromises()
+
+    const timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('focusReleaseIds')).toEqual(['rhoai-3.5-ea1'])
+  })
+
+  it('passes focusReleaseIds for an upcoming newest selected version too', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 30)
+    const pastStr = localDateStr(past)
+    const future = new Date()
+    future.setDate(future.getDate() + 60)
+    const futureStr = localDateStr(future)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: pastStr
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: futureStr
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    // Select both: the newest selected version overall (3.6, upcoming) drives the fit —
+    // its future milestones sit off-screen to the right, so the timeline should focus it.
+    const ea1 = wrapper.findAll('button').find(b => b.text().trim() === '3.5 EA1')
+    await ea1.trigger('click')
+    const ea6 = wrapper.findAll('button').find(b => b.text().trim() === '3.6 EA1')
+    await ea6.trigger('click')
+    await flushPromises()
+
+    const timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('focusReleaseIds')).toEqual(['rhoai-3.6-ea1'])
+  })
+
+  it('focusReleaseIds is empty when no version is selected', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2020-06-10'
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: '2028-09-15'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    const timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('focusReleaseIds')).toEqual([])
+  })
+
+  it('does not re-fit (clears focusReleaseIds) when the newest selected version is deselected', async () => {
+    const past1 = new Date()
+    past1.setDate(past1.getDate() - 60)
+    const past2 = new Date()
+    past2.setDate(past2.getDate() - 30)
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5-ea1', {
+          displayName: '3.5 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: localDateStr(past1)
+        }),
+        makeRelease('rhoai-3.6-ea1', {
+          displayName: '3.6 EA1 RHOAI RELEASE', shortname: 'rhoai', ga: localDateStr(past2)
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView, { global: { stubs: { ReleaseTimeline: ReleaseTimelineStub } } })
+    await flushPromises()
+
+    // Select both released versions; newest (3.6) drives the focus.
+    const ea1 = wrapper.findAll('button').find(b => b.text().trim() === '3.5 EA1')
+    await ea1.trigger('click')
+    const ea6 = wrapper.findAll('button').find(b => b.text().trim() === '3.6 EA1')
+    await ea6.trigger('click')
+    await flushPromises()
+    const timeline = wrapper.findComponent(ReleaseTimelineStub)
+    expect(timeline.props('focusReleaseIds')).toEqual(['rhoai-3.6-ea1'])
+
+    // Deselect the newest — a deselection must NOT re-fit, even though 3.5 (older,
+    // released) is still selected. Leaves focus empty so the view stays put.
+    const ea6Again = wrapper.findAll('button').find(b => b.text().trim() === '3.6 EA1')
+    await ea6Again.trigger('click')
+    await flushPromises()
+    expect(timeline.props('focusReleaseIds')).toEqual([])
   })
 })

--- a/modules/releases/client/components/ReleaseTimeline.vue
+++ b/modules/releases/client/components/ReleaseTimeline.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
+import { computed, ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { Scatter } from 'vue-chartjs'
 import { Chart as ChartJS, LinearScale, PointElement, Tooltip } from 'chart.js'
 import { parseReleaseName, extractCycle, productLabel } from '../composables/useReleaseFamily.js'
@@ -13,7 +13,11 @@ var FONT = 'Inter var, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFo
 
 const props = defineProps({
   releases: { type: Array, required: true },
-  hidePast: { type: Boolean, default: false }
+  hidePast: { type: Boolean, default: false },
+  // IDs of the release(s) the user just focused (newest selected version, released or upcoming).
+  // When set and none of their milestones are in the current view, the timeline
+  // fits the view to them (GA near the right edge). Empty = no focus.
+  focusReleaseIds: { type: Array, default: function () { return [] } }
 })
 
 var MILESTONE_KEYS = [
@@ -415,7 +419,15 @@ var fullRange = computed(function () {
 
 var DAY_MS = 86400000
 var DEFAULT_WINDOW_DAYS = 29
-var MAX_VISIBLE_DAYS = 90
+// Max manual zoom-out window (scroll wheel / pinch). Wide enough to comfortably
+// take in a whole release cluster (planning freeze through GA) at once. The
+// auto-fit is deliberately NOT bound by this — it must be free to widen the view
+// far enough to keep both the focused version and the today marker on screen.
+var MAX_VISIBLE_DAYS = 180
+// Padding for the auto-fit-to-focused-version window: GA sits FOCUS_FIT_RIGHT_PAD_DAYS
+// from the right edge; earlier milestones get FOCUS_FIT_LEFT_PAD_DAYS of breathing room.
+var FOCUS_FIT_RIGHT_PAD_DAYS = 3
+var FOCUS_FIT_LEFT_PAD_DAYS = 7
 
 function capRange(range, full) {
   var maxSpan = MAX_VISIBLE_DAYS * DAY_MS
@@ -492,6 +504,79 @@ function resetZoom() {
 }
 
 watch(function () { return props.hidePast }, resetZoom)
+
+// ── Auto-fit to a focused (newest selected) version ──
+// Milestone timestamps of the currently-rendered nodes that belong to a focused release.
+function focusTimestamps() {
+  var ids = props.focusReleaseIds
+  if (!ids || !ids.length) return []
+  var idSet = {}
+  for (var i = 0; i < ids.length; i++) idSet[ids[i]] = true
+  var out = []
+  var n = nodes.value
+  for (var j = 0; j < n.length; j++) {
+    var rels = n[j].releases || []
+    var match = false
+    for (var k = 0; k < rels.length; k++) {
+      if (rels[k] && idSet[rels[k].id]) { match = true; break }
+    }
+    if (!match) continue
+    var d = parseDate(n[j].date)
+    if (d) out.push(d.getTime())
+  }
+  return out
+}
+
+// How many of the focused version's milestone cards fall inside the current view.
+function focusVisibleCount() {
+  var ts = focusTimestamps()
+  var r = xRange.value
+  var count = 0
+  for (var i = 0; i < ts.length; i++) {
+    if (ts[i] >= r.min && ts[i] <= r.max) count++
+  }
+  return count
+}
+
+// Fit the view to the focused version's milestones while ALWAYS keeping the
+// "YOU ARE HERE" (today) marker in frame, so the user never loses their bearings.
+// The window spans both the focused cluster and today: for a future version today
+// anchors the left side and GA sits near the right edge; for an already-released
+// version the cluster sits on the left and today anchors the right edge. Because
+// today and a far-off cluster can be more than MAX_VISIBLE_DAYS apart, this fit is
+// NOT width-capped — capping would drop either the version or the today marker.
+function fitToFocus() {
+  var ts = focusTimestamps()
+  if (!ts.length) return
+  ts.sort(function (a, b) { return a - b })
+  var today = new Date()
+  today.setHours(0, 0, 0, 0)
+  var todayTs = today.getTime()
+  var full = fullRange.value
+  var rightPad = FOCUS_FIT_RIGHT_PAD_DAYS * DAY_MS
+  var leftPad = FOCUS_FIT_LEFT_PAD_DAYS * DAY_MS
+  var lo = Math.min(ts[0], todayTs) // earliest of the cluster and today
+  var hi = Math.max(ts[ts.length - 1], todayTs) // latest of GA and today
+  var min = lo - leftPad
+  var max = hi + rightPad
+  if (max > full.max) max = full.max
+  if (min < full.min) min = full.min
+  if (max <= min) return
+  zoomMin.value = min
+  zoomMax.value = max
+}
+
+// When the user focuses a version (released or upcoming) and none of its cards are
+// visible in the current view (default or manually zoomed/panned), fit the view to it.
+// Clearing the focus leaves the current view untouched. Runs after the reactive flush
+// so hidePast / nodes / xRange reflect the new selection first.
+watch(function () { return props.focusReleaseIds.slice().join(',') }, function (val) {
+  if (!val) return
+  nextTick(function () {
+    if (!props.focusReleaseIds.length) return
+    if (focusVisibleCount() === 0) fitToFocus()
+  })
+})
 
 var _chartInstance = null
 

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -162,7 +162,7 @@
       </div>
 
       <!-- Release Timeline -->
-      <ReleaseTimeline v-if="allSortedReleases.length" :releases="baseFilteredReleases" :hide-past="hideReleased" />
+      <ReleaseTimeline v-if="allSortedReleases.length" :releases="baseFilteredReleases" :hide-past="hideReleased" :focus-release-ids="focusReleaseIds" />
 
       <!-- Releases table -->
       <div v-if="allSortedReleases.length" class="bg-white dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
@@ -219,7 +219,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, h } from 'vue'
+import { ref, computed, watch, onMounted, h } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 import {
   parseDate, daysFromNow, formatShort as formatShortBase,
@@ -382,6 +382,39 @@ const baseFilteredReleases = computed(() => {
     })
   }
   return list
+})
+
+// Release IDs the timeline should auto-fit into view. Populated only when the user
+// ADDS a version to the selection — then it holds the IDs of the newest selected
+// version's releases, whether that version is already released (milestones in the
+// past, off-screen to the left) or still upcoming (milestones in the future,
+// off-screen to the right). Either way the timeline shifts its window to bring the
+// cards into view. A deselection never repopulates it (set to []), so removing a
+// pill leaves the timeline view untouched.
+const focusReleaseIds = ref([])
+
+// IDs of the newest selected version's releases, or [] when nothing is selected.
+function newestSelectionIds() {
+  if (selectedVersions.value.length === 0) return []
+  let newest = null
+  for (let i = 0; i < availableVersions.value.length; i++) {
+    if (selectedVersions.value.indexOf(availableVersions.value[i]) !== -1) {
+      newest = availableVersions.value[i]
+      break
+    }
+  }
+  if (!newest) return []
+  const ids = []
+  for (let j = 0; j < baseFilteredReleases.value.length; j++) {
+    const r = baseFilteredReleases.value[j]
+    if (versionLabel(r) === newest) ids.push(r.id)
+  }
+  return ids
+}
+
+watch(selectedVersions, (curr, prev) => {
+  const added = curr.some(v => !prev || prev.indexOf(v) === -1)
+  focusReleaseIds.value = added ? newestSelectionIds() : []
 })
 
 const filteredReleases = computed(() => {

--- a/tests/integration/release-timeline.spec.js
+++ b/tests/integration/release-timeline.spec.js
@@ -371,4 +371,64 @@ test.describe('Release Timeline @release-timeline @releases', () => {
 
     expect(page.errors).toHaveLength(0);
   });
+
+  // Auto-fit: selecting a version whose milestones all sit off-screen — a released
+  // version to the LEFT of "YOU ARE HERE", or a far-future version to the RIGHT —
+  // shifts the timeline window so its cards become visible. The window shift sets a
+  // zoom override, which surfaces "Reset zoom". Version pills render most-recent-first,
+  // so the LAST pill is the oldest (released, milestones well before the default
+  // today-anchored window) and the FIRST pill is the newest (in the fixtures an
+  // upcoming version whose milestones fall after the default window).
+  test('selecting a released version auto-fits the timeline into view', async ({ page }) => {
+    await page.goto('/#/releases/schedule');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Default view is not zoomed → no Reset zoom button yet.
+    var resetBtn = page.locator('text=Reset zoom');
+    await expect(resetBtn).toHaveCount(0);
+
+    var versionPills = page.locator('button').filter({ hasText: /^\d+\.\d+\s+(EA\d+|GA)$/ });
+    var pillCount = await versionPills.count();
+    expect(pillCount).toBeGreaterThan(0);
+
+    // Oldest version pill = released, milestones off-screen → should trigger a fit.
+    await versionPills.nth(pillCount - 1).click();
+    await page.waitForTimeout(800);
+
+    // The auto-fit set a zoom window, so the reset control appears.
+    await expect(resetBtn).toBeVisible();
+
+    // The "YOU ARE HERE" marker must remain in frame after the fit.
+    await expect(page.locator('.animate-ping')).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('selecting an upcoming version auto-fits the timeline into view', async ({ page }) => {
+    await page.goto('/#/releases/schedule');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Default view is not zoomed → no Reset zoom button yet.
+    var resetBtn = page.locator('text=Reset zoom');
+    await expect(resetBtn).toHaveCount(0);
+
+    var versionPills = page.locator('button').filter({ hasText: /^\d+\.\d+\s+(EA\d+|GA)$/ });
+    var pillCount = await versionPills.count();
+    expect(pillCount).toBeGreaterThan(0);
+
+    // Newest version pill = upcoming in the fixtures, with milestones after the default
+    // window (off-screen to the right) → the timeline shifts forward to bring them in.
+    await versionPills.first().click();
+    await page.waitForTimeout(800);
+
+    // The auto-fit set a zoom window, so the reset control appears.
+    await expect(resetBtn).toBeVisible();
+
+    // The "YOU ARE HERE" marker must remain in frame after the fit.
+    await expect(page.locator('.animate-ping')).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

On the **Release Schedule** view, selecting a version pill narrowed the timeline to that release but left the view window anchored to *today* — so if the selected version's milestones were all off-screen, the user saw empty timeline. This change auto-fits the timeline's view window to the selected version's milestone cards, with **GA anchored near the right edge**, for both **already-released** versions (milestones in the past, off-screen left) and **upcoming/far-future** versions (milestones months ahead, off-screen right) — while **always keeping the "YOU ARE HERE" (today) marker in frame** as the orientation anchor.

## Behavior (locked decisions)

- **Any selected version** — released *or* upcoming — triggers a fit when its cards are off-screen. (A far-future selection like `3.6 GA` used to leave the user staring at a bare "YOU ARE HERE".)
- **The today marker is always visible after a fit.** The window spans both the version cluster and today: today anchors the left edge for a future version (GA near the right) and the right edge for a past one (cluster on the left).
- **Newest selected version overall** is the fit target.
- **Only when zero cards are visible** — respects manual zoom/pan and the default window.
- **Deselect leaves the view untouched** — the fit is triggered only on *addition* of a version.
- **Manual zoom-out widened 90 → 180 days** for a comfortable single-cluster view. The auto-fit itself is *not* width-capped — it widens as needed to keep both the version and today on screen (they can be more than 180 days apart).

## Implementation

- `ScheduleView.vue` exposes `focusReleaseIds` (all releases of the newest **added** version, released or upcoming) to `ReleaseTimeline`.
- `ReleaseTimeline.vue`'s `fitToFocus()` spans `[min(clusterLo, today) − leftPad, max(GA, today) + rightPad]`, clamped into `fullRange` (which already includes today). Symmetric: a past cluster shifts the window left, a future one right; today never falls out. `defaultRange` is untouched, so pinned default-window tests stay green.

## Testing

- **Unit**: `schedule-view.test.js` + `release-timeline.test.js` — fit/no-fit/visible/deselect/mount cases plus past-version and future-version (~10 months out) fit cases that assert the today marker stays in view. Releases suite: 3072 pass, lint clean.
- **Playwright**: `tests/integration/release-timeline.spec.js` (`@release-timeline`) — selecting an oldest (released, off-screen-left) pill **and** the newest (upcoming, off-screen-right) pill both surface "Reset zoom" and keep the `.animate-ping` today marker visible. Ran locally: 14 passed, 1 pre-existing fixme skipped.

Jira: [RHOAIENG-89504](https://redhat.atlassian.net/browse/RHOAIENG-89504)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
