### PR TITLE
test(releases): pin clock in date-dependent freeze tests

### DIFF
--- a/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
+++ b/modules/releases/__tests__/server/pm-hub/canonical-load.test.js
@@ -1,7 +1,7 @@
 /**
  * Unit tests for PM Hub canonical Component Release Load grouping.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const {
   canonicalToLoadRow,
@@ -28,6 +28,17 @@ function feature(overrides) {
 }
 
 describe('canonical-load', function() {
+  // Freeze-date classification compares against "now". Pin the clock so tests
+  // that assert past-vs-future planning-freeze dates stay deterministic
+  // regardless of the calendar date the suite runs on.
+  beforeEach(function() {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T00:00:00Z'))
+  })
+  afterEach(function() {
+    vi.useRealTimers()
+  })
+
   it('maps canonical feature to load row', function() {
     var row = canonicalToLoadRow(feature({
       deliveryOwner: 'Alice',

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const {
   normVer,
@@ -395,6 +395,17 @@ describe('extractProduct', () => {
 // ---------------------------------------------------------------------------
 
 describe('isReleaseFrozen', () => {
+  // isReleaseFrozen compares freeze/GA dates against "now". Pin the clock so the
+  // "past" (2026-06-01) / "future" (2026-09-01) fixtures stay deterministic
+  // regardless of the calendar date the suite runs on.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns true when planning freeze is in the past', () => {
     const releaseDates = {
       'rhoai-3.5': { planningFreezeDate: '2026-06-01', dueDate: '2026-08-01' },
@@ -448,6 +459,16 @@ describe('isReleaseFrozen', () => {
 // ---------------------------------------------------------------------------
 
 describe('categoryForLaterFixVersion', () => {
+  // Depends on isReleaseFrozen, which compares against "now". Pin the clock so
+  // the "past"/"future" freeze fixtures stay deterministic across run dates.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns after_requested when Fix Version freeze has not passed', () => {
     const releaseDates = {
       'rhoai-3.6': { planningFreezeDate: '2026-09-01' },


### PR DESCRIPTION
## Summary

Fixes date-dependent unit tests in the releases module that started failing in CI once the calendar reached **2026-09-01**.

Unit test broken example - https://github.com/red-hat-data-services/rhai-org-pulse/actions/runs/33509853296/job/99862676502 

Several tests hardcoded `2026-09-01` as a "future" freeze/GA date and `2026-06-01` as "past". The production code (`isReleaseFrozen`, `categoryForLaterFixVersion`, `buildComponentReleaseLoadGroups`) compares these dates against the current time (`freezeDate <= now`). When the run date caught up to `2026-09-01`, the "future" fixtures became today/past and the assertions flipped:

- `modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js` — `isReleaseFrozen` (`expected true to be false`) and `categoryForLaterFixVersion` (`expected 'aligned_late' to be 'after_requested'`)
- `modules/releases/__tests__/server/pm-hub/canonical-load.test.js` — `stamps planningFrozen from Fix Version freeze dates` (`expected true to be false`)

These are pre-existing time-bombs unrelated to any feature work — they fail on `main` as of today.

## Fix

Pin the system clock to `2026-07-15` in the affected `describe` blocks using `vi.useFakeTimers()` / `vi.setSystemTime()` (matching the existing fake-timer pattern in the client timeline tests), so the past (`2026-06-01`) / future (`2026-09-01`) fixtures stay deterministic regardless of the run date. `afterEach` restores real timers.

Scope is limited to the boundary-crossing describes; sibling tests whose assertions don't depend on the freeze boundary flipping are left untouched.

## Testing

- `npx vitest run` on both files → **154 passed**
- `npx eslint` on both files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
