### PR TITLE
feat: update AI Planner to SHA 57588c5 (EA1 calibration + llm-d data)

### DIFF
--- a/modules/releases/client/plan/views/AIPlanner.vue
+++ b/modules/releases/client/plan/views/AIPlanner.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Pinned to specific commit — update via PR to rhai-org-pulse
-const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/d7cb2869d5a99b9ba3be3c9a69ddfcb1e73a4807/index.html'
+const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/57588c5/index.html'
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- Updates pinned commit SHA for the AI-First Release Planner iframe (`AIPlanner.vue`)
- Previous SHA: `d7cb2869` → New SHA: `57588c5`

## What's new in this snapshot

- **EA1 A/B calibration results**: 56/59 TP, **94.9% recall**, F1 67.1% — model correctly placed 56 of 59 EA1 committed features. Only 3 misses (AIPCC hardware partnership commits: Intel Gaudi, AMD ROCm, CUDA 12.9 — strategic commits outside FPDoR readiness signal, expected blind spot)
- **EA1 vs EA2 comparison**: EA1 recall is 2.4× better than EA2 (94.9% vs 39.8%) — confirms model is strongest for features further along in readiness
- **Steps 1–4 of A/B checklist marked complete** in the dashboard Next Steps panel
- **Tiffany's llm-d AI Adoption data** added to Field & BU Feedback section: +1733% throughput, `component_ai_adoption_rate` queued as v11 training signal; TEAM_CAP stale flag for llm-d noted
- Fix to `ab_calibration.py`: `target_phase` arg now wires through full comparison logic (EA1 and GA calibrations now work correctly in addition to EA2)

## Test plan

- [ ] Open the Releases → Plan → AI Planner tab in Org Pulse
- [ ] Confirm iframe loads the dashboard (EA1 calibration panel visible in Data Appendix)
- [ ] Confirm Field & BU Feedback section shows llm-d AI Adoption note
- [ ] Confirm A/B steps 1–4 show as complete (strikethrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)