### PR TITLE
Update AI Planner SHA to d37fb41

### DIFF
--- a/modules/releases/client/plan/views/AIPlanner.vue
+++ b/modules/releases/client/plan/views/AIPlanner.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Pinned to specific commit — update via PR to rhai-org-pulse
-const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/57588c5/index.html'
+const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/d37fb41/index.html'
 </script>
 
 <template>

--- a/modules/releases/client/plan/views/AIPlanner.vue
+++ b/modules/releases/client/plan/views/AIPlanner.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Pinned to specific commit — update via PR to rhai-org-pulse
-const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/d7cb2869d5a99b9ba3be3c9a69ddfcb1e73a4807/index.html'
+const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/57588c5/index.html'
 </script>
 
 <template>


### PR DESCRIPTION
## What changed
Bumps the pinned SHA in `AIPlanner.vue` from `57588c5` → `d37fb41`.

## Included in this SHA
From 4 commits since the previous PR (#1506):
- **Collapsible 40/40/20 panel** — collapsed by default (Jenny Yi feedback: declutter main view)
- **Column tooltips** — PATH ⓘ, AI SDLC ⓘ, PLACEMENT ⓘ with plain-English explanations
- **Below-cut clarification** — PLACEMENT filter now shows "No (Below cut)" with tooltip
- **Score column hidden** by default with opt-in checkbox
- **Editable planning banner** — click-to-edit in browser, persists via localStorage
- **FPDoR risk bug fix** — 17/17 items passing no longer incorrectly shows HIGH risk
- **EA1 calibration results** — TP=56, FP=52, FN=3, Recall=94.9%
- **llm-d AI Adoption data** — Tiffany's +1733% throughput signal added to Field & BU Feedback

## Testing
No Org Pulse logic changes — one-line SHA swap in `AIPlanner.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)