### PR TITLE
fix(releases/quality): align bug count header with post-release chart data

### DIFF
--- a/modules/releases/__tests__/server/delivery/quality-data-fetcher.test.js
+++ b/modules/releases/__tests__/server/delivery/quality-data-fetcher.test.js
@@ -285,35 +285,58 @@ describe('fetchBugCounts', () => {
     { name: 'rhoai-3.4', releaseDate: '2026-03-20', project: 'RHOAIENG' }
   ]
 
-  it('queries Jira per project and counts bugs by affected version', async () => {
+  it('queries Jira per project and counts only post-release bugs by affected version', async () => {
     const mockFetchAll = vi.fn()
       .mockResolvedValueOnce([
-        { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-3.3' }] } },
-        { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }, { name: 'rhoai-3.4' }] } },
-        { key: 'RHOAIENG-3', fields: { versions: [{ name: 'rhoai-3.4' }] } }
+        // Post-release for rhoai-3.3 (released 2026-01-15)
+        { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-17T10:00:00.000Z' } },
+        // Post-release for both versions
+        { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }, { name: 'rhoai-3.4' }], created: '2026-03-22T10:00:00.000Z' } },
+        // Post-release for rhoai-3.4 (released 2026-03-20)
+        { key: 'RHOAIENG-3', fields: { versions: [{ name: 'rhoai-3.4' }], created: '2026-03-25T10:00:00.000Z' } }
       ])
       .mockResolvedValueOnce([
-        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+        // Post-release for rhoai-3.3
+        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-20T10:00:00.000Z' } }
       ])
 
     const counts = await fetchBugCounts(['RHOAIENG', 'AIPCC'], mockVersions, { jiraFetchAll: mockFetchAll })
 
     expect(mockFetchAll).toHaveBeenCalledTimes(2)
 
-    const [, jql1] = mockFetchAll.mock.calls[0]
+    const [, jql1, fields1] = mockFetchAll.mock.calls[0]
     expect(jql1).toContain('project = RHOAIENG')
     expect(jql1).toContain('issuetype = Bug')
     expect(jql1).toContain('affectedVersion is not EMPTY')
+    expect(fields1).toContain('created')
 
     expect(counts.get('rhoai-3.3')).toBe(3)
     expect(counts.get('rhoai-3.4')).toBe(2)
+  })
+
+  it('excludes bugs created before the version release date', async () => {
+    const mockFetchAll = vi.fn().mockResolvedValue([
+      // Pre-release bug for rhoai-3.3 (released 2026-01-15)
+      { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-10T10:00:00.000Z' } },
+      // Post-release bug for rhoai-3.3
+      { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-17T10:00:00.000Z' } },
+      // Pre-release bug for rhoai-3.4 but post-release for rhoai-3.3
+      { key: 'RHOAIENG-3', fields: { versions: [{ name: 'rhoai-3.3' }, { name: 'rhoai-3.4' }], created: '2026-02-01T10:00:00.000Z' } }
+    ])
+
+    const counts = await fetchBugCounts(['RHOAIENG'], mockVersions, { jiraFetchAll: mockFetchAll })
+
+    // rhoai-3.3: RHOAIENG-2 (post-release) + RHOAIENG-3 (post-release) = 2
+    expect(counts.get('rhoai-3.3')).toBe(2)
+    // rhoai-3.4: RHOAIENG-3 is pre-release (created 2026-02-01 < released 2026-03-20) = 0
+    expect(counts.get('rhoai-3.4')).toBe(0)
   })
 
   it('returns 0 for projects that fail to fetch', async () => {
     const mockFetchAll = vi.fn()
       .mockRejectedValueOnce(new Error('Jira timeout'))
       .mockResolvedValueOnce([
-        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-20T10:00:00.000Z' } }
       ])
 
     const counts = await fetchBugCounts(['RHOAIENG', 'AIPCC'], mockVersions, { jiraFetchAll: mockFetchAll })
@@ -324,8 +347,8 @@ describe('fetchBugCounts', () => {
 
   it('ignores affected versions not in the versions list', async () => {
     const mockFetchAll = vi.fn().mockResolvedValue([
-      { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-99.0' }] } },
-      { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+      { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-99.0' }], created: '2026-01-20T10:00:00.000Z' } },
+      { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }], created: '2026-01-20T10:00:00.000Z' } }
     ])
 
     const counts = await fetchBugCounts(['RHOAIENG'], mockVersions, { jiraFetchAll: mockFetchAll })

--- a/modules/releases/server/delivery/quality/data-fetcher.js
+++ b/modules/releases/server/delivery/quality/data-fetcher.js
@@ -106,9 +106,10 @@ async function fetchBugs(project, versions, { jiraFetchAll } = {}) {
 
 /**
  * Fetch total bug count per version by querying all bugs across projects
- * and counting locally. Equivalent to: issuetype = Bug AND affectedVersion = "x"
+ * and counting locally. Only counts bugs created on or after the version's
+ * release date to stay consistent with the cumulative chart (post-release defects).
  * @param {string[]} projects - Jira project keys
- * @param {Array} versions - Version objects with name field
+ * @param {Array} versions - Version objects with name and releaseDate fields
  * @param {Object} [options]
  * @param {Function} [options.jiraFetchAll] - Injectable fetchAllJqlResults for testing
  * @returns {Promise<Map<string, number>>} - Map of version name to total bug count
@@ -116,19 +117,26 @@ async function fetchBugs(project, versions, { jiraFetchAll } = {}) {
 async function fetchBugCounts(projects, versions, { jiraFetchAll } = {}) {
   const fetchAll = jiraFetchAll || jira.fetchAllJqlResults;
   const counts = new Map();
+  const versionReleaseMap = new Map();
   for (const v of versions) {
     counts.set(v.name, 0);
+    if (v.releaseDate) {
+      versionReleaseMap.set(v.name, new Date(v.releaseDate).getTime());
+    }
   }
 
   for (const project of projects) {
     try {
       const jql = `project = ${project} AND issuetype = Bug AND affectedVersion is not EMPTY AND created >= -730d`;
-      const issues = await fetchAll(jira.jiraRequest, jql, 'versions');
+      const issues = await fetchAll(jira.jiraRequest, jql, 'versions,created');
 
       for (const issue of issues) {
         const affectedVersions = (issue.fields.versions || []).map(v => v.name);
+        const createdMs = new Date(issue.fields.created).getTime();
         for (const vName of affectedVersions) {
-          if (counts.has(vName)) {
+          if (!counts.has(vName)) continue;
+          const releaseDateMs = versionReleaseMap.get(vName);
+          if (releaseDateMs && createdMs >= releaseDateMs) {
             counts.set(vName, counts.get(vName) + 1);
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,25 +1063,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -4644,9 +4658,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5061,9 +5075,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -7304,12 +7318,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7600,14 +7615,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7619,13 +7634,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -110,7 +110,7 @@ export const viewOwners = {
   'releases/plan/bu-feedback':                     'Saiesh Prabhu',
   'releases/plan/feature-readiness':               'Erle Marion',
   'releases/plan/outcomes':                        'Erle Marion',
-  'releases/plan/pm-hub':                          'Yuval Luria',
+  'releases/plan/pm-hub':                          'yuvalluria',
 
   // releases > registry
   'releases/registry/hygiene':                     'Alex Corvin',

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -138,7 +138,6 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
-  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }


### PR DESCRIPTION
## Problem

The version selector header showed **696 bugs** for `3.5 GA RHOAI RELEASE`, but the cumulative chart and summary table only showed **83 bugs** (8 days tracked).

## Root Cause

Two functions count bugs with different filters:

- **`fetchBugCounts()`** (header): counted **all** bugs with a matching `affectedVersion`, regardless of creation date
- **`fetchBugs()`** (chart data): only included bugs created **on or after** the release date

The 613 extra bugs were filed during development/testing before the GA date and tagged with the affected version — they aren't post-release defects.

## Fix

Updated `fetchBugCounts()` to:
1. Build a version → release-date map from the versions array
2. Fetch the `created` field alongside `versions` from Jira
3. Only count a bug if `bug.created >= version.releaseDate`

This makes the header count consistent with the chart — both now show post-release defects only.

## Testing

- Updated `fetchBugCounts` tests to verify post-release filtering
- Added a dedicated test for excluding pre-release bugs
- All 27 quality tests pass

Made with [Cursor](https://cursor.com)