### PR TITLE
AIPCC-31301: Show all base image releases

### DIFF
--- a/modules/product-builds/__tests__/client/ProductView.test.js
+++ b/modules/product-builds/__tests__/client/ProductView.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import ProductView from '../../client/views/ProductView.vue'
+
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: vi.fn(),
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useScroll: () => ({ arrivedState: { bottom: false } }),
+}))
+
+const { apiRequest } = await import('@shared/client/services/api')
+
+describe('ProductView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.location.hash = '#/product-builds/base-images'
+    apiRequest.mockImplementation((path) => {
+      if (path.endsWith('/products/base-images')) {
+        return Promise.resolve({ key: 'base-images', product_name: 'Base Images', short_name: 'Base Images' })
+      }
+      if (path.includes('/drops?')) {
+        const drops = [{
+          key: 'base-images-3.6-ga',
+          name: 'Base Images 3.6 GA',
+          product_version: '3.6',
+          environments: ['production'],
+          created_at: '2026-10-01T12:00:00Z',
+        }, {
+          key: 'base-images-3.6-ea1',
+          name: 'Base Images 3.6-EA1',
+          product_version: '3.6-EA1',
+          environments: ['production'],
+          created_at: '2026-08-01T12:00:00Z',
+        }, {
+          key: 'base-images-3.6-ea2',
+          name: 'Base Images 3.6-EA2',
+          product_version: '3.6-EA2',
+          environments: ['stage'],
+          created_at: '2026-09-01T12:00:00Z',
+        }]
+        return Promise.resolve(path.includes('artifact_type=') ? drops.slice(2) : drops)
+      }
+      if (path.includes('/series?')) return Promise.resolve(['3.6', '3.6-EA2', '3.6-EA1'])
+      if (path.includes('/artifacts?')) {
+        if (!path.includes('type=base-images')) return Promise.resolve([])
+        return Promise.resolve([{
+          key: 'base-image-artifact-3.6-ea2',
+          type: 'base-images',
+          variant: 'cpu',
+          archs: ['x86_64'],
+          environments: ['stage'],
+        }])
+      }
+      return Promise.resolve([])
+    })
+  })
+
+  it('shows base-image drops across releases without artifact subtype filtering', async () => {
+    const wrapper = mount(ProductView, {
+      global: { provide: { moduleNav: { navigateTo: vi.fn() } } },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Base Images 3.6 GA')
+    expect(wrapper.text()).toContain('Base Images 3.6-EA1')
+    expect(wrapper.text()).toContain('Base Images 3.6-EA2')
+  })
+
+  it('keeps Base Images series navigation enabled', async () => {
+    const navigateTo = vi.fn()
+    const wrapper = mount(ProductView, {
+      global: { provide: { moduleNav: { navigateTo } } },
+    })
+    await flushPromises()
+
+    const seriesHeading = wrapper.findAll('h3').find(heading => heading.text() === '3.6-EA2')
+    await seriesHeading.trigger('click')
+
+    expect(navigateTo).toHaveBeenCalledWith('series-detail', { series: '3.6-EA2', product: 'base-images' })
+  })
+
+  it('loads Base Images artifacts with their precise artifact type', async () => {
+    const wrapper = mount(ProductView, {
+      global: { provide: { moduleNav: { navigateTo: vi.fn() } } },
+    })
+    await flushPromises()
+
+    await wrapper.findAll('button').find(button => button.text() === 'Artifacts').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('base-image-artifact-3.6-ea2')
+  })
+})

--- a/modules/product-builds/client/views/ProductView.vue
+++ b/modules/product-builds/client/views/ProductView.vue
@@ -9,10 +9,10 @@ import TestsSummary from '../components/TestsSummary.vue'
 import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const PRODUCT_CONFIGS = {
-  'rhaiis':            { key: 'rhaiis',        artifactType: 'containers' },
-  'rhel-ai':           { key: 'rhel-ai',       artifactType: 'containers' },
-  'base-images':       { key: 'base-images',   artifactType: 'containers' },
-  'builder-images':    { key: 'builder-images', artifactType: 'containers' },
+  'rhaiis':            { key: 'rhaiis',        artifactType: 'containers',  hasSeriesTimeline: true },
+  'rhel-ai':           { key: 'rhel-ai',       artifactType: 'containers',  hasSeriesTimeline: true },
+  'base-images':       { key: 'base-images',   artifactType: 'base-images', hasSeriesTimeline: true },
+  'builder-images':    { key: 'builder-images', artifactType: 'containers',  hasSeriesTimeline: true },
   'wheel-collections': { key: 'rhai',          artifactType: 'wheels-collections', label: 'Wheel Collections' },
 }
 function getConfigFromHash() {
@@ -34,13 +34,14 @@ const selectedSeries = ref('')
 const productConfig = ref(getConfigFromHash())
 const productKey = computed(() => productConfig.value.key)
 const artifactTypeFilter = computed(() => productConfig.value.artifactType)
+const dropArtifactTypeFilter = computed(() => productKey.value === 'base-images' ? undefined : artifactTypeFilter.value)
 
 async function load() {
   activeTab.value = 'series'
   selectedSeries.value = ''
   resetArtifacts()
   artifactOffset.value = 0
-  const filters = { limit: 1000, artifact_type: artifactTypeFilter.value }
+  const filters = { limit: 1000, artifact_type: dropArtifactTypeFilter.value }
   await Promise.all([
     loadProduct(productKey.value),
     loadDrops(productKey.value, filters),
@@ -64,7 +65,7 @@ onUnmounted(() => window.removeEventListener('hashchange', onHashChange))
 watch(productConfig, () => load())
 
 watch(selectedSeries, (val) => {
-  const filters = { series: val || undefined, limit: 1000, artifact_type: artifactTypeFilter.value }
+  const filters = { series: val || undefined, limit: 1000, artifact_type: dropArtifactTypeFilter.value }
   loadDrops(productKey.value, filters)
 })
 
@@ -95,7 +96,7 @@ watch(activeTab, (tab) => {
   }
 })
 
-const hasSeriesTimeline = computed(() => productConfig.value.artifactType === 'containers')
+const hasSeriesTimeline = computed(() => productConfig.value.hasSeriesTimeline === true)
 
 function navigateToSeries(seriesName) {
   if (!hasSeriesTimeline.value) return

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -52,6 +52,70 @@ test.describe('Product Builds Module @product-builds', () => {
     expect(appErrors).toHaveLength(0);
   });
 
+  test('should show 3.6-EA2 drops in the Base Images view', async ({ page }) => {
+    // Register the catch-all first because Playwright gives later routes priority.
+    await page.route('**/api/**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    }));
+    await page.route('**/api/modules/product-builds/products/base-images', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ key: 'base-images', product_name: 'Base Images', short_name: 'Base Images' }),
+    }));
+    await page.route('**/api/modules/product-builds/series?product_key=base-images', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['3.6', '3.6-EA2', '3.6-EA1']),
+    }));
+    await page.route('**/api/modules/product-builds/drops?**', route => {
+      const artifactType = new URL(route.request().url()).searchParams.get('artifact_type');
+      const drops = [{
+        key: 'base-images-3.6-ga',
+        name: 'Base Images 3.6 GA',
+        product_version: '3.6',
+        environments: ['production'],
+        created_at: '2026-10-01T12:00:00Z',
+      }, {
+        key: 'base-images-3.6-ea1',
+        name: 'Base Images 3.6-EA1',
+        product_version: '3.6-EA1',
+        environments: ['production'],
+        created_at: '2026-08-01T12:00:00Z',
+      }, {
+        key: 'base-images-3.6-ea2',
+        name: 'Base Images 3.6-EA2',
+        product_version: '3.6-EA2',
+        environments: ['stage'],
+        created_at: '2026-09-01T12:00:00Z',
+      }];
+      const result = artifactType ? drops.slice(2) : drops;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    });
+    await page.route('**/api/modules/product-builds/artifacts?**', route => {
+      const artifactType = new URL(route.request().url()).searchParams.get('type');
+      const artifacts = artifactType === 'base-images' ? [{
+        key: 'base-image-artifact-3.6-ea2',
+        type: 'base-images',
+        variant: 'cpu',
+        archs: ['x86_64'],
+        environments: ['stage'],
+      }] : [];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(artifacts) });
+    });
+
+    await page.goto('/#/product-builds/base-images');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Base Images 3.6 GA')).toBeVisible();
+    await expect(page.getByText('Base Images 3.6-EA1')).toBeVisible();
+    await expect(page.getByText('Base Images 3.6-EA2')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Artifacts' }).click();
+    await expect(page.getByText('base-image-artifact-3.6-ea2')).toBeVisible();
+  });
+
   test('should show CHI column header in artifacts tab', async ({ page }) => {
     await page.goto('/#/product-builds/rhaiis');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

- show Base Images artifacts using the `base-images` artifact classification
- list Base Images drops by product without subtype filtering, preserving legacy and current releases
- keep series timeline navigation independent from artifact classification
- add unit and integration coverage for GA, EA1, EA2, series navigation, and artifact loading

## Testing

- `npm test` — 5,597 passed, 11 skipped
- `npm run lint`
- `npm run build`
- `npx playwright test tests/integration/product-builds.spec.js --grep 'should show 3.6-EA2 drops'`

Jira: https://redhat.atlassian.net/browse/AIPCC-31301
