### PR TITLE
fix: add missing demo-mode fixtures for field-options and readiness

### DIFF
--- a/fixtures/releases/release-readiness/rhoai-3.5.EA1.json
+++ b/fixtures/releases/release-readiness/rhoai-3.5.EA1.json
@@ -1,0 +1,72 @@
+{
+  "version": "rhoai-3.5.EA1",
+  "generated_at": "2026-05-15T10:00:00Z",
+  "summary": {
+    "total_work": 100,
+    "work_done": 100,
+    "work_in_progress": 0,
+    "work_remaining": 0,
+    "progress_pct": 100
+  },
+  "release_schedule": {
+    "code_freeze_date": "2026-04-20",
+    "ga_date": "2026-05-01",
+    "status": "Released"
+  },
+  "director_summary": {
+    "overall_pct": 100,
+    "gate_statuses": [
+      { "gate": "Product Sign Off", "done": 10, "total": 10, "pct": 100, "rag": "GREEN" },
+      { "gate": "Test Execution", "done": 24, "total": 24, "pct": 100, "rag": "GREEN", "initiative_key": "RHOAIENG-60001" }
+    ],
+    "test_timeline": [
+      { "epic_key": "RHOAIENG-60101", "name": "Nightly", "done": 12, "total": 12, "pct": 100, "rag": "GREEN" },
+      { "epic_key": "RHOAIENG-60102", "name": "RC1", "done": 12, "total": 12, "pct": 100, "rag": "GREEN" }
+    ]
+  },
+  "component_readiness": {
+    "all_components": ["TestOps", "ModelServing", "Dashboard"],
+    "phases": [
+      {
+        "phase": "Nightly",
+        "tiles": [
+          {
+            "component": "TestOps",
+            "tfa": { "done": 10, "total": 10 },
+            "execution": { "done": 22, "total": 22, "done_pct": 100, "jql_url": "https://redhat.atlassian.net/issues/?jql=parent%3DRHOAIENG-60001" },
+            "failed_breakdown": { "new": 0, "in_progress": 0, "done": 3, "total": 3 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 0, "in_progress": 0, "done": 2, "total": 2 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          },
+          {
+            "component": "ModelServing",
+            "tfa": { "done": 5, "total": 5 },
+            "execution": { "done": 10, "total": 10, "done_pct": 100 },
+            "failed_breakdown": { "new": 0, "in_progress": 0, "done": 1, "total": 1 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 0, "in_progress": 0, "done": 0, "total": 0 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          },
+          {
+            "component": "Dashboard",
+            "tfa": { "done": 4, "total": 4 },
+            "execution": { "done": 8, "total": 8, "done_pct": 100 },
+            "failed_breakdown": { "new": 0, "in_progress": 0, "done": 0, "total": 0 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 0, "in_progress": 0, "done": 0, "total": 0 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          }
+        ]
+      }
+    ]
+  },
+  "product_blockers": {
+    "total_open": 0,
+    "issues": [],
+    "components": []
+  },
+  "tfa_signoff_done": 19,
+  "tfa_signoff_total": 19,
+  "breakdowns": {}
+}

--- a/fixtures/releases/release-readiness/rhoai-3.6.EA1.json
+++ b/fixtures/releases/release-readiness/rhoai-3.6.EA1.json
@@ -1,0 +1,70 @@
+{
+  "version": "rhoai-3.6.EA1",
+  "generated_at": "2026-08-28T10:00:00Z",
+  "summary": {
+    "total_work": 80,
+    "work_done": 20,
+    "work_in_progress": 30,
+    "work_remaining": 30,
+    "progress_pct": 25
+  },
+  "release_schedule": {
+    "code_freeze_date": "2026-11-01",
+    "ga_date": "2026-11-15",
+    "status": "Planning"
+  },
+  "director_summary": {
+    "overall_pct": 20,
+    "gate_statuses": [
+      { "gate": "Product Sign Off", "done": 2, "total": 10, "pct": 20, "rag": "RED" },
+      { "gate": "Test Execution", "done": 5, "total": 24, "pct": 21, "rag": "RED", "initiative_key": "RHOAIENG-90001" }
+    ],
+    "test_timeline": [
+      { "epic_key": "RHOAIENG-90101", "name": "Nightly", "done": 5, "total": 12, "pct": 42, "rag": "AMBER" },
+      { "epic_key": "RHOAIENG-90102", "name": "RC1", "done": 0, "total": 12, "pct": 0, "rag": "RED" }
+    ]
+  },
+  "component_readiness": {
+    "all_components": ["TestOps", "ModelServing", "Dashboard"],
+    "phases": [
+      {
+        "phase": "Nightly",
+        "tiles": [
+          {
+            "component": "TestOps",
+            "tfa": { "done": 3, "total": 12 },
+            "execution": { "done": 5, "total": 22, "done_pct": 23, "jql_url": "https://redhat.atlassian.net/issues/?jql=parent%3DRHOAIENG-90001" },
+            "failed_breakdown": { "new": 4, "in_progress": 2, "done": 1, "total": 7 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 2, "in_progress": 1, "done": 0, "total": 3 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          },
+          {
+            "component": "ModelServing",
+            "tfa": { "done": 1, "total": 5 },
+            "failed_breakdown": { "new": 2, "in_progress": 0, "done": 0, "total": 2 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 0, "in_progress": 0, "done": 0, "total": 0 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          },
+          {
+            "component": "Dashboard",
+            "tfa": { "done": 0, "total": 4 },
+            "failed_breakdown": { "new": 1, "in_progress": 0, "done": 0, "total": 1 },
+            "failed_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG",
+            "skipped_breakdown": { "new": 0, "in_progress": 0, "done": 0, "total": 0 },
+            "skipped_jql_url": "https://redhat.atlassian.net/issues/?jql=project%3DRHOAIENG"
+          }
+        ]
+      }
+    ]
+  },
+  "product_blockers": {
+    "total_open": 0,
+    "issues": [],
+    "components": []
+  },
+  "tfa_signoff_done": 4,
+  "tfa_signoff_total": 21,
+  "breakdowns": {}
+}

--- a/fixtures/team-data/field-options/jiraTeam.json
+++ b/fixtures/team-data/field-options/jiraTeam.json
@@ -1,0 +1,13 @@
+{
+  "name": "jiraTeam",
+  "label": "Jira Team",
+  "values": [
+    "AI Platform Core",
+    "Model Serving",
+    "Data Science Pipelines",
+    "Dashboard",
+    "ODH Operator"
+  ],
+  "updatedAt": "2026-03-24T12:00:00Z",
+  "updatedBy": "admin@example.com"
+}

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -138,6 +138,7 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }


### PR DESCRIPTION
## Summary
- Add `jiraTeam.json` fixture so the Capacity Commitment report renders in demo mode instead of showing "field option set not found" error
- Add `rhoai-3.5.EA1.json` and `rhoai-3.6.EA1.json` release-readiness fixtures so the new multi-select filter (#1521) has multiple versions/phases to demonstrate

Fixes #1522

## Test plan
- [x] Run `DEMO_MODE=true npm run dev:full` and open Capacity Commitment report — confirm it loads without errors
- [x] Open Release Readiness Director — confirm selector shows multiple versions (3.5, 3.6) and phases (EA1, EA2)


🤖 Generated with [Claude Code](https://claude.com/claude-code)