### PR TITLE
(feat) Restore Product Builds package request workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,16 @@ GITHUB_TOKEN=your-github-pat
 # AIPCC Dashboard API base URL (can also be configured via Settings UI)
 # PRODUCT_BUILDS_API_URL=
 
+# Jira project that receives package request Epics (defaults to AIPCC).
+# Point at a test project to exercise the Request Package form locally.
+# PACKAGE_REQUEST_JIRA_PROJECT=AIPCC
+
+# GitLab PAT with `api` scope and Developer access to
+# redhat/rhel-ai/core/package-onboarding. Triggers the onboarding pipeline
+# after a package request Epic is filed. The read-only GITLAB_TOKEN cannot
+# create pipelines and is not used as a fallback.
+# PACKAGE_ONBOARDING_GITLAB_TOKEN=
+
 # ══════════════════════════════════════════════════════════════════════
 # Module: customer-insights
 # ══════════════════════════════════════════════════════════════════════

--- a/deploy/openshift/overlays/ai-eng/backend-secrets-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng/backend-secrets-patch.yaml
@@ -34,6 +34,12 @@ spec:
                   name: team-tracker-secrets
                   key: FEATURE_TRAFFIC_GITLAB_TOKEN
                   optional: true
+            - name: PACKAGE_ONBOARDING_GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: team-tracker-secrets
+                  key: PACKAGE_ONBOARDING_GITLAB_TOKEN
+                  optional: true
             - name: GITLAB_CEE_REDHAT_DOCS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/modules/product-builds/__tests__/client/RequestPackageView.test.js
+++ b/modules/product-builds/__tests__/client/RequestPackageView.test.js
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import RequestPackageView from '../../client/views/RequestPackageView.vue'
+
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: vi.fn()
+}))
+
+vi.mock('@shared/client/composables/useAuth', () => ({
+  useAuth: () => ({
+    user: { value: { email: 'jane@redhat.com', displayName: 'Jane Doe' } }
+  })
+}))
+
+const { apiRequest } = await import('@shared/client/services/api')
+
+function futureDate(days = 30) {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+async function fillValidForm(wrapper) {
+  await wrapper.find('#req-team').setValue('Platform')
+  await wrapper.find('#req-package-name').setValue('vllm')
+  await wrapper.find('#req-extras').setValue('cu12, dev')
+  await wrapper.find('#req-jira-id').setValue('AIPCC-42')
+  await wrapper.find('#req-justification').setValue('Needed for CUDA wheel builds')
+  await wrapper.find('#req-delivery-timeline').setValue(futureDate())
+  await wrapper.find('#req-hardware-ack').setValue(true)
+  await wrapper.find('#req-testing-ack').setValue(true)
+}
+
+function successResponse() {
+  return {
+    status: 'created',
+    requester: 'jane@redhat.com',
+    summary: 'vllm[cu12,dev] package update request',
+    jira: {
+      key: 'AIPCC-999',
+      url: 'https://redhat.atlassian.net/browse/AIPCC-999'
+    },
+    pipeline: {
+      triggered: true,
+      web_url: 'https://gitlab.com/redhat/rhel-ai/core/package-onboarding/-/pipelines/777'
+    }
+  }
+}
+
+describe('RequestPackageView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiRequest.mockReset()
+    apiRequest.mockResolvedValue(successResponse())
+  })
+
+  it('renders the form and authenticated identity', () => {
+    const wrapper = mount(RequestPackageView)
+    expect(wrapper.text()).toContain('Request Package')
+    expect(wrapper.text()).toContain('Jane Doe')
+    expect(wrapper.find('#req-team').exists()).toBe(true)
+    expect(wrapper.find('#req-package-name').exists()).toBe(true)
+    expect(wrapper.find('#req-jira-id').exists()).toBe(true)
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Submit request')
+  })
+
+  it('shows required validation without submitting', async () => {
+    const wrapper = mount(RequestPackageView)
+    await wrapper.find('form').trigger('submit')
+
+    expect(apiRequest).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Team is required')
+    expect(wrapper.text()).toContain('Package name must start with a letter')
+    expect(wrapper.text()).toContain('Business justification is required')
+    expect(wrapper.text()).toContain('Provide hardware details')
+    expect(wrapper.text()).toContain('Provide testing requirements')
+  })
+
+  it('requires a URL only for git and other sources', async () => {
+    const wrapper = mount(RequestPackageView)
+    expect(wrapper.find('#req-source-url').exists()).toBe(false)
+
+    await wrapper.find('input[value="git"]').setChecked()
+    expect(wrapper.find('#req-source-url').exists()).toBe(true)
+    await fillValidForm(wrapper)
+    await wrapper.find('form').trigger('submit')
+    expect(wrapper.text()).toContain('Source URL is required for git and other package sources')
+
+    await wrapper.find('#req-source-url').setValue('ftp://example.com/repo')
+    await wrapper.find('form').trigger('submit')
+    expect(wrapper.text()).toContain('Source URL must be an HTTP or HTTPS URL')
+  })
+
+  it('accepts hardware and testing acknowledgements', async () => {
+    const wrapper = mount(RequestPackageView)
+    await wrapper.find('#req-team').setValue('Platform')
+    await wrapper.find('#req-package-name').setValue('vllm')
+    await wrapper.find('#req-jira-id').setValue('AIPCC-42')
+    await wrapper.find('#req-justification').setValue('Needed')
+    await wrapper.find('#req-delivery-timeline').setValue(futureDate())
+
+    await wrapper.find('#req-hardware-ack').setValue(true)
+    await wrapper.find('#req-testing-ack').setValue(true)
+    await wrapper.find('form').trigger('submit')
+
+    expect(wrapper.text()).not.toContain('Provide hardware details or acknowledge')
+    expect(wrapper.text()).not.toContain('Provide testing requirements or acknowledge')
+    expect(apiRequest).toHaveBeenCalled()
+  })
+
+  it('submits the backend payload without a requester field', async () => {
+    const wrapper = mount(RequestPackageView)
+    await fillValidForm(wrapper)
+    await wrapper.find('#req-version').setValue('2.5.1')
+    await wrapper.find('#req-release-target').setValue('3.4, 3.5')
+    await wrapper.find('#req-backport-versions').setValue('2.4.0')
+    await wrapper.find('#req-release-commitment').setValue('3.4 GA')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    const options = apiRequest.mock.calls[0][1]
+    const payload = JSON.parse(options.body)
+    expect(apiRequest.mock.calls[0][0]).toBe('/modules/product-builds/package-requests')
+    expect(payload).toMatchObject({
+      team: 'Platform',
+      package_name: 'vllm',
+      extras: ['cu12', 'dev'],
+      package_source: 'pypi',
+      source_url: null,
+      version: '2.5.1',
+      jira_id: 'AIPCC-42',
+      delivery_timeline: futureDate(),
+      release_target: ['3.4', '3.5'],
+      backport_versions: ['2.4.0']
+    })
+    expect(payload).not.toHaveProperty('requester')
+    expect(wrapper.text()).toContain('Package request submitted')
+    expect(wrapper.text()).toContain('AIPCC-999')
+    expect(wrapper.text()).toContain('View pipeline')
+  })
+
+  it('offers an explicit retry for a production warning', async () => {
+    apiRequest
+      .mockResolvedValueOnce({
+        status: 'warning',
+        package_name: 'vllm',
+        message: 'Review the production package before continuing.',
+        found_in: [{ product_version: '3.4', variant: 'cuda-ubi9', index_url: 'https://packages.example/simple/', files: ['vllm-2.5.1.whl'] }]
+      })
+      .mockResolvedValueOnce(successResponse())
+
+    const wrapper = mount(RequestPackageView)
+    await fillValidForm(wrapper)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('already present in production')
+    expect(wrapper.text()).toContain('3.4 / cuda-ubi9')
+    const retryButton = wrapper.findAll('button').find(button => button.text() === 'Submit anyway')
+    await retryButton.trigger('click')
+    await flushPromises()
+
+    expect(apiRequest).toHaveBeenCalledTimes(2)
+    const retryPayload = JSON.parse(apiRequest.mock.calls[1][1].body)
+    expect(retryPayload.skip_production_check).toBe(true)
+    expect(wrapper.text()).toContain('Package request submitted')
+  })
+
+  it('shows duplicate tickets and backend field errors', async () => {
+    const duplicate = Object.assign(new Error('Duplicate request'), {
+      status: 409,
+      data: { error: 'Duplicate request', existing_tickets: [{ key: 'AIPCC-100', url: 'https://redhat.atlassian.net/browse/AIPCC-100', summary: 'vllm package update request', status: 'To Do' }] }
+    })
+    apiRequest.mockRejectedValueOnce(duplicate)
+
+    const wrapper = mount(RequestPackageView)
+    await fillValidForm(wrapper)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.text()).toContain('AIPCC-100')
+    expect(wrapper.text()).toContain('vllm package update request')
+
+    const validation = Object.assign(new Error('Validation failed'), {
+      status: 422,
+      data: { error: 'Validation failed', fields: { jira_id: 'Related Jira issue was not found' } }
+    })
+    apiRequest.mockRejectedValueOnce(validation)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Related Jira issue was not found')
+  })
+
+  it('shows rate limit and network errors', async () => {
+    const rateLimit = Object.assign(new Error('Rate limited: one package request per user per 60 seconds'), {
+      status: 429,
+      data: { retry_after_seconds: 42 }
+    })
+    apiRequest.mockRejectedValueOnce(rateLimit)
+
+    const wrapper = mount(RequestPackageView)
+    await fillValidForm(wrapper)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.text()).toContain('42 seconds')
+
+    apiRequest.mockRejectedValueOnce(new Error('Failed to fetch'))
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Could not reach the server')
+  })
+})

--- a/modules/product-builds/__tests__/client/RequestPackageView.test.js
+++ b/modules/product-builds/__tests__/client/RequestPackageView.test.js
@@ -13,6 +13,9 @@ vi.mock('@shared/client/composables/useAuth', () => ({
 }))
 
 const { apiRequest } = await import('@shared/client/services/api')
+const submitRequest = vi.fn()
+const fetchTeams = vi.fn()
+const teamOptions = [{ value: 'Platform', label: 'Platform' }, { value: 'Agentic', label: 'Agentic' }]
 
 function futureDate(days = 30) {
   const date = new Date()
@@ -22,6 +25,7 @@ function futureDate(days = 30) {
 }
 
 async function fillValidForm(wrapper) {
+  await flushPromises()
   await wrapper.find('#req-team').setValue('Platform')
   await wrapper.find('#req-package-name').setValue('vllm')
   await wrapper.find('#req-extras').setValue('cu12, dev')
@@ -51,8 +55,12 @@ function successResponse() {
 describe('RequestPackageView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    apiRequest.mockReset()
-    apiRequest.mockResolvedValue(successResponse())
+    submitRequest.mockReset()
+    submitRequest.mockResolvedValue(successResponse())
+    fetchTeams.mockReset().mockResolvedValue(teamOptions)
+    apiRequest.mockImplementation((url, options) => options?.method === 'POST'
+      ? submitRequest(url, options)
+      : fetchTeams(url))
   })
 
   it('renders the form and authenticated identity', () => {
@@ -65,11 +73,79 @@ describe('RequestPackageView', () => {
     expect(wrapper.find('button[type="submit"]').text()).toContain('Submit request')
   })
 
+  it('loads team choices and submits only a selected option', async () => {
+    const wrapper = mount(RequestPackageView)
+    expect(wrapper.find('#req-team').element.tagName).toBe('SELECT')
+    expect(wrapper.find('#req-team').element.disabled).toBe(true)
+    await flushPromises()
+    expect(fetchTeams).toHaveBeenCalledWith('/modules/product-builds/package-requests/teams?project=RHAISTRAT')
+    expect(wrapper.findAll('#req-team option').map(option => option.text())).toEqual(['Select a team', 'Platform', 'Agentic'])
+    await fillValidForm(wrapper)
+    await wrapper.find('#req-team').setValue('Free text')
+    await wrapper.find('form').trigger('submit')
+    expect(submitRequest).not.toHaveBeenCalled()
+  })
+
+  it('clears the selection and ignores stale team loads when the project changes', async () => {
+    const wrapper = mount(RequestPackageView)
+    await flushPromises()
+    await wrapper.find('#req-team').setValue('Platform')
+    let finishOldLoad
+    fetchTeams.mockImplementationOnce(() => new Promise(resolve => { finishOldLoad = resolve }))
+    await wrapper.find('#req-team-project').setValue('AIPCC')
+    expect(wrapper.find('#req-team').element.value).toBe('')
+    expect(wrapper.find('#req-team').element.disabled).toBe(true)
+    fetchTeams.mockResolvedValueOnce([{ value: 'Agentic', label: 'Agentic' }])
+    await wrapper.find('#req-team-project').setValue('RHAISTRAT')
+    await flushPromises()
+    finishOldLoad([{ value: 'Accelerator Enablement', label: 'Accelerator Enablement' }])
+    await flushPromises()
+    expect(wrapper.findAll('#req-team option').map(option => option.text())).toEqual(['Select a team', 'Agentic'])
+    expect(fetchTeams).toHaveBeenCalledWith('/modules/product-builds/package-requests/teams?project=AIPCC')
+    await wrapper.find('#req-team-project').setValue('RHAI')
+    await flushPromises()
+    expect(fetchTeams).toHaveBeenCalledWith('/modules/product-builds/package-requests/teams?project=RHAI')
+  })
+
+  it('resets the team project and selection to the original defaults', async () => {
+    const wrapper = mount(RequestPackageView)
+    await flushPromises()
+    await wrapper.find('#req-team-project').setValue('RHAI')
+    await flushPromises()
+    await wrapper.find('#req-team').setValue('Platform')
+    await wrapper.findAll('button').find(button => button.text() === 'Reset').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('#req-team-project').element.value).toBe('RHAISTRAT')
+    expect(wrapper.find('#req-team').element.value).toBe('')
+    expect(fetchTeams).toHaveBeenLastCalledWith('/modules/product-builds/package-requests/teams?project=RHAISTRAT')
+  })
+
+  it('keeps submission disabled on team load failure and supports retry', async () => {
+    fetchTeams.mockRejectedValueOnce(new Error('Unavailable'))
+    const wrapper = mount(RequestPackageView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Could not load teams')
+    expect(wrapper.find('button[type="submit"]').element.disabled).toBe(true)
+    await wrapper.findAll('button').find(button => button.text() === 'Retry loading teams').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Could not load teams')
+    expect(wrapper.find('#req-team').element.disabled).toBe(false)
+  })
+
+  it('explains an empty team list without allowing free text', async () => {
+    fetchTeams.mockResolvedValueOnce([])
+    const wrapper = mount(RequestPackageView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('No teams are available for this project')
+    expect(wrapper.find('#req-team').element.disabled).toBe(true)
+    expect(wrapper.find('button[type="submit"]').element.disabled).toBe(true)
+  })
+
   it('shows required validation without submitting', async () => {
     const wrapper = mount(RequestPackageView)
     await wrapper.find('form').trigger('submit')
 
-    expect(apiRequest).not.toHaveBeenCalled()
+    expect(submitRequest).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('Team is required')
     expect(wrapper.text()).toContain('Package name must start with a letter')
     expect(wrapper.text()).toContain('Business justification is required')
@@ -94,6 +170,7 @@ describe('RequestPackageView', () => {
 
   it('accepts hardware and testing acknowledgements', async () => {
     const wrapper = mount(RequestPackageView)
+    await flushPromises()
     await wrapper.find('#req-team').setValue('Platform')
     await wrapper.find('#req-package-name').setValue('vllm')
     await wrapper.find('#req-jira-id').setValue('AIPCC-42')
@@ -106,7 +183,7 @@ describe('RequestPackageView', () => {
 
     expect(wrapper.text()).not.toContain('Provide hardware details or acknowledge')
     expect(wrapper.text()).not.toContain('Provide testing requirements or acknowledge')
-    expect(apiRequest).toHaveBeenCalled()
+    expect(submitRequest).toHaveBeenCalled()
   })
 
   it('submits the backend payload without a requester field', async () => {
@@ -119,9 +196,9 @@ describe('RequestPackageView', () => {
     await wrapper.find('form').trigger('submit')
     await flushPromises()
 
-    const options = apiRequest.mock.calls[0][1]
+    const options = submitRequest.mock.calls[0][1]
     const payload = JSON.parse(options.body)
-    expect(apiRequest.mock.calls[0][0]).toBe('/modules/product-builds/package-requests')
+    expect(submitRequest.mock.calls[0][0]).toBe('/modules/product-builds/package-requests')
     expect(payload).toMatchObject({
       team: 'Platform',
       package_name: 'vllm',
@@ -141,7 +218,7 @@ describe('RequestPackageView', () => {
   })
 
   it('offers an explicit retry for a production warning', async () => {
-    apiRequest
+    submitRequest
       .mockResolvedValueOnce({
         status: 'warning',
         package_name: 'vllm',
@@ -161,8 +238,8 @@ describe('RequestPackageView', () => {
     await retryButton.trigger('click')
     await flushPromises()
 
-    expect(apiRequest).toHaveBeenCalledTimes(2)
-    const retryPayload = JSON.parse(apiRequest.mock.calls[1][1].body)
+    expect(submitRequest).toHaveBeenCalledTimes(2)
+    const retryPayload = JSON.parse(submitRequest.mock.calls[1][1].body)
     expect(retryPayload.skip_production_check).toBe(true)
     expect(wrapper.text()).toContain('Package request submitted')
   })
@@ -172,7 +249,7 @@ describe('RequestPackageView', () => {
       status: 409,
       data: { error: 'Duplicate request', existing_tickets: [{ key: 'AIPCC-100', url: 'https://redhat.atlassian.net/browse/AIPCC-100', summary: 'vllm package update request', status: 'To Do' }] }
     })
-    apiRequest.mockRejectedValueOnce(duplicate)
+    submitRequest.mockRejectedValueOnce(duplicate)
 
     const wrapper = mount(RequestPackageView)
     await fillValidForm(wrapper)
@@ -185,7 +262,7 @@ describe('RequestPackageView', () => {
       status: 422,
       data: { error: 'Validation failed', fields: { jira_id: 'Related Jira issue was not found' } }
     })
-    apiRequest.mockRejectedValueOnce(validation)
+    submitRequest.mockRejectedValueOnce(validation)
     await wrapper.find('form').trigger('submit')
     await flushPromises()
     expect(wrapper.text()).toContain('Related Jira issue was not found')
@@ -196,7 +273,7 @@ describe('RequestPackageView', () => {
       status: 429,
       data: { retry_after_seconds: 42 }
     })
-    apiRequest.mockRejectedValueOnce(rateLimit)
+    submitRequest.mockRejectedValueOnce(rateLimit)
 
     const wrapper = mount(RequestPackageView)
     await fillValidForm(wrapper)
@@ -204,7 +281,7 @@ describe('RequestPackageView', () => {
     await flushPromises()
     expect(wrapper.text()).toContain('42 seconds')
 
-    apiRequest.mockRejectedValueOnce(new Error('Failed to fetch'))
+    submitRequest.mockRejectedValueOnce(new Error('Failed to fetch'))
     await wrapper.find('form').trigger('submit')
     await flushPromises()
     expect(wrapper.text()).toContain('Could not reach the server')

--- a/modules/product-builds/__tests__/server/package-requests.test.js
+++ b/modules/product-builds/__tests__/server/package-requests.test.js
@@ -1,0 +1,811 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const registerPackageRequestRoutes = require('../../server/package-requests')
+const {
+  validateRequest,
+  isAtLeastDaysFromToday,
+  buildEpicSummary,
+  buildEpicName,
+  sanitizeTeamLabel,
+  buildAdfDescription,
+  buildEpicFields,
+  buildDuplicateJql,
+  buildPipelineVariables,
+  checkPypiPackage,
+  getGitlabToken,
+  checkRateLimit,
+  recordSubmission,
+  _lastSubmission,
+  AIPCC_PROJECT,
+  SECURITY_NAME,
+  COMPONENT_NAME,
+  EPIC_NAME_FIELD
+} = registerPackageRequestRoutes._testExports
+
+// --- Test helpers ---
+
+function makeRouter() {
+  const routes = { get: {}, post: {} }
+  return {
+    get: vi.fn(function (path, ...handlers) {
+      routes.get[path] = handlers
+    }),
+    post: vi.fn(function (path, ...handlers) {
+      routes.post[path] = handlers
+    }),
+    _routes: routes
+  }
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: null,
+    status(code) { res._status = code; return res },
+    json(data) { res._json = data; return res }
+  }
+  return res
+}
+
+function isoDaysFromNow(days) {
+  const d = new Date()
+  d.setUTCHours(0, 0, 0, 0)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+function validBody(overrides = {}) {
+  return {
+    team: 'Platform',
+    package_name: 'vllm',
+    extras: ['cu12'],
+    package_source: 'pypi',
+    source_url: 'https://pypi.org/project/vllm/',
+    version: '2.5.1',
+    other_hardware: '',
+    hardware_defaults_acknowledged: true,
+    jira_id: 'AIPCC-42',
+    justification: 'Needed for CUDA wheel builds',
+    delivery_timeline: isoDaysFromNow(30),
+    release_target: ['3.4'],
+    release_commitment: '3.4 GA',
+    testing_requirements: '',
+    testing_defaults_acknowledged: true,
+    backport_versions: null,
+    ...overrides
+  }
+}
+
+function makeJira(overrides = {}) {
+  const base = {
+    JIRA_HOST: 'https://redhat.atlassian.net',
+    jiraRequest: vi.fn(async (path, opts = {}) => {
+      const method = (opts.method || 'GET').toUpperCase()
+      if (path.startsWith('/rest/api/3/user/search')) {
+        return { users: [{ accountId: 'acc-1', email: 'jane@redhat.com' }] }
+      }
+      if (path === '/rest/api/3/issue' && method === 'POST') {
+        return { key: 'AIPCC-999', id: '10999' }
+      }
+      if (method === 'PUT') {
+        return {}
+      }
+      if (path.startsWith('/rest/api/3/issue/') && path.includes('fields=summary')) {
+        const key = path.split('/').pop().split('?')[0]
+        return { key, fields: { summary: 'Related issue summary' } }
+      }
+      throw new Error('Unexpected jiraRequest in mock: ' + method + ' ' + path)
+    }),
+    fetchAllJqlResults: vi.fn(async () => [])
+  }
+  return { ...base, ...overrides }
+}
+
+function makeFetch(impl) {
+  return vi.fn(impl || (async (url, opts = {}) => {
+    const method = (opts.method || 'GET').toUpperCase()
+    if (String(url).startsWith('https://pypi.org/pypi/')) {
+      return { ok: true, status: 200, json: async () => ({ name: 'vllm' }) }
+    }
+    if (String(url).includes('/api/v4/projects/') && method === 'POST') {
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 777, web_url: 'https://gitlab.com/test/proj/-/pipelines/777' })
+      }
+    }
+    return { ok: false, status: 500, text: async () => 'unexpected fetch: ' + url }
+  }))
+}
+
+function makeContext(overrides = {}) {
+  return {
+    secrets: {
+      JIRA_EMAIL: 'svc@redhat.com',
+      JIRA_TOKEN: 'jira-token',
+      GITLAB_TOKEN: 'gitlab-token'
+    },
+    resolveSecret: vi.fn(() => null),
+    requireAuth: vi.fn(function (_req, _res, next) { next() }),
+    ...overrides
+  }
+}
+
+function register(deps = {}, contextOverrides = {}) {
+  const router = makeRouter()
+  const context = makeContext(contextOverrides)
+  registerPackageRequestRoutes(router, context, deps)
+  return { router, context }
+}
+
+async function callHandler(router, req) {
+  const handlers = router._routes.post['/package-requests']
+  const handler = handlers[handlers.length - 1]
+  const res = makeRes()
+  await handler(req, res)
+  return res
+}
+
+function adfTextOf(node) {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (node.type === 'text') return node.text || ''
+  if (Array.isArray(node.content)) return node.content.map(adfTextOf).join('')
+  return ''
+}
+
+function epicPostCall(jira) {
+  return jira.jiraRequest.mock.calls.find(
+    c => c[0] === '/rest/api/3/issue' && c[1] && c[1].method === 'POST'
+  )
+}
+
+describe('package-requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _lastSubmission.clear()
+    delete process.env.DEMO_MODE
+  })
+
+  describe('route registration and OpenAPI', () => {
+    it('registers POST /package-requests with requireAuth as the first middleware', () => {
+      const { router, context } = register()
+      const handlers = router._routes.post['/package-requests']
+      expect(handlers).toBeDefined()
+      expect(handlers[0]).toBe(context.requireAuth)
+      expect(typeof handlers[handlers.length - 1]).toBe('function')
+    })
+
+    it('includes a complete @openapi annotation for the endpoint', () => {
+      const source = readFileSync(require.resolve('../../server/package-requests.js'), 'utf8')
+      expect(source).toContain('@openapi')
+      expect(source).toContain('/api/modules/product-builds/package-requests:')
+      expect(source).toMatch(/post:/)
+      for (const field of [
+        'team', 'package_name', 'extras', 'package_source', 'source_url', 'version',
+        'other_hardware', 'hardware_defaults_acknowledged', 'jira_id', 'justification',
+        'delivery_timeline', 'release_target', 'release_commitment',
+        'testing_requirements', 'testing_defaults_acknowledged', 'backport_versions'
+      ]) {
+        expect(source).toContain(field)
+      }
+      for (const status of ['200', '201', '400', '401', '409', '422', '429', '502', '503']) {
+        expect(source).toContain(status + ':')
+      }
+    })
+  })
+
+  describe('identity derivation', () => {
+    it('rejects unauthenticated requests with 401', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, { body: validBody() })
+      expect(res._status).toBe(401)
+    })
+
+    it('rejects requests with an empty email string with 401', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, { userEmail: '   ', body: validBody() })
+      expect(res._status).toBe(401)
+    })
+
+    it('derives the requester from req.userEmail', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'Jane@RedHat.com',
+        body: validBody()
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.requester).toBe('jane@redhat.com')
+    })
+
+    it('falls back to req.user.email when req.userEmail is absent', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        user: { email: 'bob@redhat.com' },
+        body: validBody()
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.requester).toBe('bob@redhat.com')
+    })
+
+    it('ignores a requester value in the JSON body', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ requester: 'evil@example.com' })
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.requester).toBe('jane@redhat.com')
+      expect(JSON.stringify(res._json)).not.toContain('evil@example.com')
+    })
+  })
+
+  describe('validation', () => {
+    async function expect422(body, field) {
+      const { router } = register({ jiraClient: makeJira(), fetch: makeFetch() })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body })
+      expect(res._status).toBe(422)
+      expect(res._json.fields).toHaveProperty(field)
+      return res
+    }
+
+    it('returns 400 when the body is not a JSON object', async () => {
+      const { router } = register()
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: 'not-an-object' })
+      expect(res._status).toBe(400)
+    })
+
+    it('rejects package names that do not match the pattern', async () => {
+      await expect422(validBody({ package_name: '1bad' }), 'package_name')
+      await expect422(validBody({ package_name: '' }), 'package_name')
+      await expect422(validBody({ package_name: 'has space' }), 'package_name')
+    })
+
+    it('rejects extras with unsafe identifiers', async () => {
+      await expect422(validBody({ extras: ['cu 12'] }), 'extras')
+      await expect422(validBody({ extras: ['cu/12'] }), 'extras')
+    })
+
+    it('rejects duplicate extras', async () => {
+      await expect422(validBody({ extras: ['cu12', 'CU12'] }), 'extras')
+    })
+
+    it('requires a source URL for git and other sources', async () => {
+      await expect422(validBody({ package_source: 'git', source_url: null }), 'source_url')
+      await expect422(validBody({ package_source: 'git', source_url: 'ftp://example.com/repo' }), 'source_url')
+      await expect422(validBody({ package_source: 'other', source_url: '' }), 'source_url')
+    })
+
+    it('rejects invalid package sources', async () => {
+      await expect422(validBody({ package_source: 'cargo' }), 'package_source')
+    })
+
+    it('rejects invalid Jira keys', async () => {
+      await expect422(validBody({ jira_id: 'aipcc-42' }), 'jira_id')
+      await expect422(validBody({ jira_id: 'A-42' }), 'jira_id')
+      await expect422(validBody({ jira_id: 'AIPCC-42-' }), 'jira_id')
+      await expect422(validBody({ jira_id: '' }), 'jira_id')
+    })
+
+    it('requires a non-empty justification', async () => {
+      await expect422(validBody({ justification: '   ' }), 'justification')
+    })
+
+    it('requires the delivery timeline to be at least 8 calendar days out', async () => {
+      await expect422(validBody({ delivery_timeline: isoDaysFromNow(7) }), 'delivery_timeline')
+      await expect422(validBody({ delivery_timeline: 'not-a-date' }), 'delivery_timeline')
+    })
+
+    it('accepts a delivery timeline exactly 8 days out', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ delivery_timeline: isoDaysFromNow(8) })
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.demo).toBe(true)
+    })
+
+    it('requires hardware details or the hardware acknowledgement', async () => {
+      await expect422(
+        validBody({ other_hardware: '', hardware_defaults_acknowledged: false }),
+        'other_hardware'
+      )
+    })
+
+    it('accepts hardware defaults via the acknowledgement flag', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ other_hardware: '', hardware_defaults_acknowledged: true })
+      })
+      expect(res._status).toBe(200)
+    })
+
+    it('accepts hardware details without the acknowledgement flag', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ other_hardware: '2x H100', hardware_defaults_acknowledged: false })
+      })
+      expect(res._status).toBe(200)
+    })
+
+    it('requires testing requirements or the testing acknowledgement', async () => {
+      await expect422(
+        validBody({ testing_requirements: '', testing_defaults_acknowledged: false }),
+        'testing_requirements'
+      )
+    })
+
+    it('accepts testing requirements without the acknowledgement flag', async () => {
+      const { router } = register({ isDemoMode: true })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ testing_requirements: 'Run full wheel test suite', testing_defaults_acknowledged: false })
+      })
+      expect(res._status).toBe(200)
+    })
+
+    it('collects multiple field errors at once', async () => {
+      const res = await expect422(
+        validBody({ package_name: '1bad', justification: '', jira_id: 'nope' }),
+        'package_name'
+      )
+      expect(res._json.fields).toHaveProperty('justification')
+      expect(res._json.fields).toHaveProperty('jira_id')
+    })
+  })
+
+  describe('demo mode', () => {
+    it('returns a deterministic demo success and makes no external calls', async () => {
+      const jira = makeJira()
+      const fetchMock = makeFetch()
+      const fetchIndex = vi.fn(async () => ({ found: false, files: [] }))
+      const { router } = register({ jiraClient: jira, fetch: fetchMock, fetchIndex })
+
+      process.env.DEMO_MODE = 'true'
+      const req = { userEmail: 'jane@redhat.com', body: validBody() }
+      const first = await callHandler(router, req)
+      const second = await callHandler(router, req)
+
+      expect(first._status).toBe(200)
+      expect(first._json).toEqual({
+        status: 'created',
+        demo: true,
+        requester: 'jane@redhat.com',
+        summary: 'vllm[cu12] package update request',
+        jira: { key: 'AIPCC-DEMO', url: null },
+        pipeline: { triggered: false, reason: 'demo mode' }
+      })
+      // Rate limited on the immediate second submission (still no external calls).
+      expect(second._status).toBe(429)
+      expect(jira.jiraRequest).not.toHaveBeenCalled()
+      expect(jira.fetchAllJqlResults).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(fetchIndex).not.toHaveBeenCalled()
+    })
+
+    it('produces identical demo responses for the same input', async () => {
+      const { router } = register({ isDemoMode: true })
+      const req = { userEmail: 'jane@redhat.com', body: validBody() }
+      _lastSubmission.clear()
+      const a = await callHandler(router, req)
+      _lastSubmission.clear()
+      const b = await callHandler(router, req)
+      expect(a._json).toEqual(b._json)
+    })
+  })
+
+  describe('duplicate detection (409)', () => {
+    it('returns 409 with existing tickets when a recent duplicate Epic exists', async () => {
+      const jira = makeJira({
+        fetchAllJqlResults: vi.fn(async (jql) => {
+          expect(jql).toContain('project = AIPCC')
+          expect(jql).toContain('issuetype = Epic')
+          return [{
+            key: 'AIPCC-100',
+            fields: {
+              summary: 'vllm[cu12] package update request',
+              status: { name: 'To Do' },
+              created: '2026-06-01T00:00:00.000Z'
+            }
+          }]
+        })
+      })
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(409)
+      expect(res._json.existing_tickets).toEqual([
+        {
+          key: 'AIPCC-100',
+          summary: 'vllm[cu12] package update request',
+          status: 'To Do',
+          created: '2026-06-01T00:00:00.000Z',
+          url: 'https://redhat.atlassian.net/browse/AIPCC-100'
+        }
+      ])
+      expect(epicPostCall(jira)).toBeUndefined()
+    })
+
+    it('proceeds when the duplicate search fails (fail open)', async () => {
+      const jira = makeJira({
+        fetchAllJqlResults: vi.fn(async () => {
+          throw new Error('search exploded')
+        })
+      })
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(201)
+    })
+
+    it('returns 422 when the related Jira issue cannot be verified', async () => {
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path) => {
+          if (path.startsWith('/rest/api/3/issue/') && path.includes('fields=summary')) {
+            throw new Error('Jira API error (404): not found')
+          }
+          throw new Error('Unexpected jiraRequest in mock: ' + path)
+        })
+      })
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(422)
+      expect(res._json.fields.jira_id).toContain('AIPCC-42')
+    })
+  })
+
+  describe('production index warning', () => {
+    it('returns a 200 warning and does not create an Epic when the package is in production', async () => {
+      const fetchIndex = vi.fn(async (url) => url.includes('/3.4/')
+        ? { indexExists: true, found: true, files: [{ filename: 'vllm-2.5.1-cp312-none-any.whl', url: 'x' }] }
+        : { indexExists: true, found: false, files: [] })
+      const jira = makeJira()
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex })
+
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(200)
+      expect(res._json.status).toBe('warning')
+      expect(res._json.warning).toBe('package_already_in_production')
+      expect(res._json.package_name).toBe('vllm')
+      expect(res._json.found_in).toHaveLength(1)
+      expect(res._json.found_in[0].product_version).toBe('3.4')
+      expect(res._json.found_in[0].files).toContain('vllm-2.5.1-cp312-none-any.whl')
+      expect(epicPostCall(jira)).toBeUndefined()
+    })
+
+    it('does not consume the rate-limit slot for a warning, so an immediate skip retry succeeds', async () => {
+      const fetchIndex = vi.fn(async (url) => url.includes('/3.4/')
+        ? { indexExists: true, found: true, files: [{ filename: 'vllm-2.5.1-cp312-none-any.whl', url: 'x' }] }
+        : { indexExists: true, found: false, files: [] })
+      const jira = makeJira()
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex })
+
+      const first = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(first._status).toBe(200)
+      expect(first._json.status).toBe('warning')
+
+      // Immediate retry with the explicit acknowledgement must not hit the 60s rate limit.
+      const retry = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ skip_production_check: true })
+      })
+      expect(retry._status).toBe(201)
+      expect(retry._json.jira.key).toBe('AIPCC-999')
+    })
+
+    it('skips the production check when skip_production_check is true', async () => {
+      const fetchIndex = vi.fn(async () => ({ found: false, files: [] }))
+      const { router } = register({
+        jiraClient: makeJira(),
+        fetch: makeFetch(),
+        fetchIndex
+      })
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody({ skip_production_check: true })
+      })
+      expect(res._status).toBe(201)
+      expect(fetchIndex).not.toHaveBeenCalled()
+    })
+
+    it('returns 422 when a pypi source package is not found on PyPI', async () => {
+      const fetchMock = makeFetch(async (url) => {
+        if (String(url).startsWith('https://pypi.org/pypi/')) {
+          return { ok: false, status: 404, text: async () => 'not found' }
+        }
+        return { ok: true, status: 200, json: async () => ({}) }
+      })
+      const { router } = register({ jiraClient: makeJira(), fetch: fetchMock, fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(422)
+      expect(res._json.fields.package_source).toContain('not found on PyPI')
+    })
+  })
+
+  describe('successful creation', () => {
+    it('creates the AIPCC Epic, sets release target, and triggers the pipeline', async () => {
+      const jira = makeJira()
+      const fetchMock = makeFetch()
+      const fetchIndex = vi.fn(async () => ({ found: false, files: [] }))
+      const { router } = register({ jiraClient: jira, fetch: fetchMock, fetchIndex })
+
+      const res = await callHandler(router, {
+        userEmail: 'jane@redhat.com',
+        body: validBody()
+      })
+
+      expect(res._status).toBe(201)
+      expect(res._json.status).toBe('created')
+      expect(res._json.requester).toBe('jane@redhat.com')
+      expect(res._json.jira).toEqual({
+        key: 'AIPCC-999',
+        id: '10999',
+        url: 'https://redhat.atlassian.net/browse/AIPCC-999',
+        summary: 'vllm[cu12] package update request'
+      })
+      expect(res._json.release_target_set).toBe(true)
+      expect(res._json.pipeline).toEqual({
+        triggered: true,
+        pipeline_id: 777,
+        web_url: 'https://gitlab.com/test/proj/-/pipelines/777'
+      })
+
+      // Epic creation payload
+      const post = epicPostCall(jira)
+      expect(post).toBeDefined()
+      const fields = post[1].body.fields
+      expect(fields.project).toEqual({ key: AIPCC_PROJECT })
+      expect(fields.issuetype).toEqual({ name: 'Epic' })
+      expect(fields.summary).toBe('vllm[cu12] package update request')
+      expect(fields.labels).toContain('package')
+      expect(fields.labels).toContain('dashboard-filed')
+      expect(fields.labels).toContain('team-platform')
+      expect(fields.duedate).toBe(isoDaysFromNow(30))
+      expect(fields.security).toEqual({ name: SECURITY_NAME })
+      expect(fields.components).toEqual([{ name: COMPONENT_NAME }])
+      expect(fields[EPIC_NAME_FIELD]).toBe('vllm package update request')
+      expect(fields[EPIC_NAME_FIELD]).not.toBe('Platform')
+      expect(fields.reporter).toEqual({ accountId: 'acc-1' })
+
+      // ADF description contains every request field
+      const descText = adfTextOf(fields.description)
+      expect(descText).toContain('Team: Platform')
+      expect(descText).toContain('Package: vllm[cu12] 2.5.1')
+      expect(descText).toContain('Requester: jane@redhat.com')
+      expect(descText).toContain('Package source: pypi')
+      expect(descText).toContain('https://pypi.org/project/vllm/')
+      expect(descText).toContain('Hardware defaults acknowledged: yes')
+      expect(descText).toContain('Justification: Needed for CUDA wheel builds')
+      expect(descText).toContain('Target Date: ' + isoDaysFromNow(30))
+      expect(descText).toContain('Related Jira Ticket: AIPCC-42')
+      expect(descText).toContain('Release Commitment: 3.4 GA')
+      expect(descText).toContain('Testing requirements: N/A')
+      expect(descText).toContain('Testing defaults acknowledged: yes')
+      expect(descText).toContain('Release target: 3.4')
+
+      // Release target custom field update (non-fatal path succeeded)
+      const put = jira.jiraRequest.mock.calls.find(
+        c => c[0] === '/rest/api/3/issue/AIPCC-999' && c[1] && c[1].method === 'PUT'
+      )
+      expect(put).toBeDefined()
+      expect(put[1].body.fields).toEqual({
+        customfield_10855: [{ name: '3.4' }]
+      })
+
+      // Pipeline trigger used the GitLab token and carried the request variables
+      const pipelineCall = fetchMock.mock.calls.find(
+        c => String(c[0]).includes('/api/v4/projects/') && (c[1].method || 'GET') === 'POST'
+      )
+      expect(pipelineCall).toBeDefined()
+      expect(String(pipelineCall[0])).toContain('/projects/redhat%2Frhel-ai%2Fcore%2Fpackage-onboarding/pipelines')
+      expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('gitlab-token')
+      const pipelineBody = JSON.parse(pipelineCall[1].body)
+      expect(pipelineBody.variables.PACKAGE_NAME).toBe('vllm[cu12]')
+      expect(pipelineBody.variables.JIRA_TICKET_ID).toBe('AIPCC-999')
+      expect(pipelineBody.variables.PACKAGE_VERSION).toBe('2.5.1')
+      expect(pipelineBody.variables.PACKAGE_REQUEST_EPIC).toBeUndefined()
+    })
+
+    it('still succeeds when the pipeline trigger fails (non-fatal)', async () => {
+      const fetchMock = makeFetch(async (url, opts = {}) => {
+        if (String(url).includes('/api/v4/projects/') && (opts.method || 'GET') === 'POST') {
+          return { ok: false, status: 500, text: async () => 'pipeline exploded' }
+        }
+        return { ok: true, status: 200, json: async () => ({}) }
+      })
+      const jira = makeJira()
+      const { router } = register({ jiraClient: jira, fetch: fetchMock, fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(201)
+      expect(res._json.jira.key).toBe('AIPCC-999')
+      expect(res._json.pipeline.triggered).toBe(false)
+      expect(res._json.pipeline.error).toContain('500')
+      expect(epicPostCall(jira)).toBeDefined()
+    })
+
+    it('reports the pipeline as skipped when no GitLab token is configured', async () => {
+      const { router } = register(
+        { jiraClient: makeJira(), fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) },
+        { secrets: { JIRA_EMAIL: 'svc@redhat.com', JIRA_TOKEN: 'jira-token' } }
+      )
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(201)
+      expect(res._json.pipeline).toEqual({ triggered: false, reason: 'gitlab_token_not_configured' })
+    })
+
+    it('uses the nightly pipeline token as a fallback', async () => {
+      const fetchMock = makeFetch()
+      const { router } = register(
+        { jiraClient: makeJira(), fetch: fetchMock, fetchIndex: vi.fn(async () => ({ found: false, files: [] })) },
+        { secrets: { JIRA_EMAIL: 'svc@redhat.com', JIRA_TOKEN: 'jira-token', NIGHTLY_PIPELINE_GITLAB_TOKEN: 'nightly-token' } }
+      )
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(201)
+      expect(res._json.pipeline.triggered).toBe(true)
+      const pipelineCall = fetchMock.mock.calls.find(
+        c => String(c[0]).includes('/api/v4/projects/') && (c[1].method || 'GET') === 'POST'
+      )
+      expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('nightly-token')
+    })
+
+    it('returns 503 when Jira is not configured', async () => {
+      const { router } = register({}, { secrets: {} })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(503)
+    })
+  })
+
+  describe('rate limiting (429)', () => {
+    it('allows one submission per user per 60 seconds', async () => {
+      const deps = {
+        jiraClient: makeJira(),
+        fetch: makeFetch(),
+        fetchIndex: vi.fn(async () => ({ found: false, files: [] }))
+      }
+      const { router } = register(deps)
+      const first = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(first._status).toBe(201)
+
+      const second = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(second._status).toBe(429)
+      expect(second._json.retry_after_seconds).toBeGreaterThanOrEqual(1)
+      expect(second._json.retry_after_seconds).toBeLessThanOrEqual(60)
+
+      // A different user is not blocked
+      const third = await callHandler(router, { userEmail: 'other@redhat.com', body: validBody() })
+      expect(third._status).toBe(201)
+    })
+  })
+
+  describe('helper functions', () => {
+    it('validateRequest normalizes the request', () => {
+      const { valid, errors, request } = validateRequest(validBody(), {
+        now: new Date()
+      })
+      expect(valid).toBe(true)
+      expect(errors).toEqual({})
+      expect(request.packageName).toBe('vllm')
+      expect(request.extras).toEqual(['cu12'])
+      expect(request.source).toBe('pypi')
+      expect(request.hardwareAck).toBe(true)
+      expect(request.testingAck).toBe(true)
+      expect(request.releaseTarget).toEqual(['3.4'])
+      expect(request.backportVersions).toBeNull()
+      expect(request.skipProductionCheck).toBe(false)
+    })
+
+    it('validateRequest accepts explicit hardware and testing text without flags', () => {
+      const { valid } = validateRequest(validBody({
+        other_hardware: '2x H100',
+        hardware_defaults_acknowledged: false,
+        testing_requirements: 'Full suite',
+        testing_defaults_acknowledged: false
+      }))
+      expect(valid).toBe(true)
+    })
+
+    it('isAtLeastDaysFromToday uses calendar days', () => {
+      const now = new Date('2026-01-10T12:00:00Z')
+      expect(isAtLeastDaysFromToday('2026-01-18', 8, now)).toBe(true)
+      expect(isAtLeastDaysFromToday('2026-01-17', 8, now)).toBe(false)
+      expect(isAtLeastDaysFromToday('2026-01-10', 8, now)).toBe(false)
+    })
+
+    it('buildEpicSummary formats the summary', () => {
+      expect(buildEpicSummary('vllm', ['cu12'])).toBe('vllm[cu12] package update request')
+      expect(buildEpicSummary('vllm', ['cu12', 'dev'])).toBe('vllm[cu12,dev] package update request')
+      expect(buildEpicSummary('vllm', null)).toBe('vllm package update request')
+      expect(buildEpicSummary('vllm', [])).toBe('vllm package update request')
+    })
+
+    it('sanitizeTeamLabel produces safe Jira labels', () => {
+      expect(sanitizeTeamLabel('Platform Eng')).toBe('team-platform-eng')
+      expect(sanitizeTeamLabel('AI-ML')).toBe('team-ai-ml')
+      expect(sanitizeTeamLabel('!!!')).toBe('team-unknown')
+    })
+
+    it('buildAdfDescription states explicit hardware/testing acknowledgements', () => {
+      const base = validateRequest(validBody()).request
+      const acked = adfTextOf(buildAdfDescription(base, 'j@r.com', 'https://redhat.atlassian.net'))
+      expect(acked).toContain('Hardware defaults acknowledged: yes')
+      expect(acked).toContain('Testing defaults acknowledged: yes')
+
+      const explicit = validateRequest(validBody({
+        other_hardware: '2x H100',
+        hardware_defaults_acknowledged: false,
+        testing_requirements: 'Full suite',
+        testing_defaults_acknowledged: false
+      })).request
+      const explicitText = adfTextOf(buildAdfDescription(explicit, 'j@r.com', 'https://redhat.atlassian.net'))
+      expect(explicitText).toContain('Other hardware: 2x H100')
+      expect(explicitText).toContain('Hardware defaults acknowledged: no')
+      expect(explicitText).toContain('Testing requirements: Full suite')
+      expect(explicitText).toContain('Testing defaults acknowledged: no')
+    })
+
+    it('buildEpicFields sets Epic Name and omits reporter when the accountId is unknown', () => {
+      const request = validateRequest(validBody()).request
+      const fields = buildEpicFields(request, 'j@r.com', { jiraHost: 'https://redhat.atlassian.net' })
+      expect(fields.reporter).toBeUndefined()
+      expect(fields[EPIC_NAME_FIELD]).toBe('vllm package update request')
+      expect(fields.labels).toEqual(['package', 'dashboard-filed', 'team-platform'])
+    })
+
+    it('buildEpicName matches the legacy Epic Name template', () => {
+      expect(buildEpicName('vllm')).toBe('vllm package update request')
+    })
+
+    it('buildDuplicateJql targets recent AIPCC package Epics', () => {
+      const jql = buildDuplicateJql('vllm')
+      expect(jql).toContain('project = AIPCC')
+      expect(jql).toContain('issuetype = Epic')
+      expect(jql).toContain('"package", "dashboard-filed"')
+      expect(jql).toContain('summary ~ "*vllm*"')
+      expect(jql).toContain('created >= -30d')
+    })
+
+    it('buildPipelineVariables carries the request into pipeline variables', () => {
+      const request = validateRequest(validBody()).request
+      const vars = buildPipelineVariables(request, 'AIPCC-999')
+      expect(vars).toEqual({
+        PACKAGE_NAME: 'vllm[cu12]',
+        JIRA_TICKET_ID: 'AIPCC-999',
+        PACKAGE_VERSION: '2.5.1'
+      })
+    })
+
+    it('getGitlabToken prefers GITLAB_TOKEN over the nightly fallback', () => {
+      expect(getGitlabToken({ GITLAB_TOKEN: 'a', NIGHTLY_PIPELINE_GITLAB_TOKEN: 'b' })).toBe('a')
+      expect(getGitlabToken({ NIGHTLY_PIPELINE_GITLAB_TOKEN: 'b' })).toBe('b')
+      expect(getGitlabToken({})).toBeNull()
+    })
+
+    it('checkPypiPackage reports found/missing and throws on API errors', async () => {
+      const okFetch = vi.fn(async () => ({ ok: true, status: 200 }))
+      await expect(checkPypiPackage('vllm', okFetch)).resolves.toEqual({ found: true })
+      expect(okFetch.mock.calls[0][0]).toBe('https://pypi.org/pypi/vllm/json')
+
+      const notFound = vi.fn(async () => ({ ok: false, status: 404 }))
+      await expect(checkPypiPackage('vllm', notFound)).resolves.toEqual({ found: false })
+
+      const broken = vi.fn(async () => ({ ok: false, status: 500 }))
+      await expect(checkPypiPackage('vllm', broken)).rejects.toThrow('HTTP 500')
+    })
+
+    it('checkRateLimit and recordSubmission enforce the 60 second window', () => {
+      const t0 = 1_000_000
+      expect(checkRateLimit('a@b.com', t0)).toEqual({ allowed: true, retryAfterSeconds: 0 })
+
+      recordSubmission('a@b.com', t0)
+      const blocked = checkRateLimit('A@B.COM', t0 + 30_000)
+      expect(blocked.allowed).toBe(false)
+      expect(blocked.retryAfterSeconds).toBe(30)
+
+      expect(checkRateLimit('a@b.com', t0 + 61_000).allowed).toBe(true)
+    })
+  })
+})

--- a/modules/product-builds/__tests__/server/package-requests.test.js
+++ b/modules/product-builds/__tests__/server/package-requests.test.js
@@ -12,11 +12,14 @@ const {
   buildEpicFields,
   buildDuplicateJql,
   buildPipelineVariables,
+  getTeamOptions,
   checkPypiPackage,
   getGitlabToken,
   checkRateLimit,
   recordSubmission,
   _lastSubmission,
+  _pendingSubmissions,
+  _teamOptionsCache,
   AIPCC_PROJECT,
   SECURITY_NAME,
   COMPONENT_NAME,
@@ -83,7 +86,10 @@ function makeJira(overrides = {}) {
     jiraRequest: vi.fn(async (path, opts = {}) => {
       const method = (opts.method || 'GET').toUpperCase()
       if (path.startsWith('/rest/api/3/user/search')) {
-        return { users: [{ accountId: 'acc-1', email: 'jane@redhat.com' }] }
+        return [{ accountId: 'acc-1', emailAddress: 'jane@redhat.com' }]
+      }
+      if (path.startsWith('/rest/api/3/project/') && path.endsWith('/components')) {
+        return [{ id: '2', name: 'Vision' }, { id: '1', name: 'AI Core Platform' }]
       }
       if (path === '/rest/api/3/issue' && method === 'POST') {
         return { key: 'AIPCC-999', id: '10999' }
@@ -147,6 +153,14 @@ async function callHandler(router, req) {
   return res
 }
 
+async function callTeamsHandler(router, req = {}) {
+  const handlers = router._routes.get['/package-requests/teams']
+  const handler = handlers[handlers.length - 1]
+  const res = makeRes()
+  await handler({ query: {}, ...req }, res)
+  return res
+}
+
 function adfTextOf(node) {
   if (!node) return ''
   if (typeof node === 'string') return node
@@ -165,6 +179,8 @@ describe('package-requests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     _lastSubmission.clear()
+    _pendingSubmissions.clear()
+    _teamOptionsCache.clear()
     delete process.env.DEMO_MODE
   })
 
@@ -177,10 +193,19 @@ describe('package-requests', () => {
       expect(typeof handlers[handlers.length - 1]).toBe('function')
     })
 
+    it('registers GET /package-requests/teams with requireAuth as the first middleware', () => {
+      const { router, context } = register()
+      const handlers = router._routes.get['/package-requests/teams']
+      expect(handlers).toBeDefined()
+      expect(handlers[0]).toBe(context.requireAuth)
+      expect(typeof handlers[handlers.length - 1]).toBe('function')
+    })
+
     it('includes a complete @openapi annotation for the endpoint', () => {
       const source = readFileSync(require.resolve('../../server/package-requests.js'), 'utf8')
       expect(source).toContain('@openapi')
       expect(source).toContain('/api/modules/product-builds/package-requests:')
+      expect(source).toContain('/api/modules/product-builds/package-requests/teams:')
       expect(source).toMatch(/post:/)
       for (const field of [
         'team', 'package_name', 'extras', 'package_source', 'source_url', 'version',
@@ -193,6 +218,103 @@ describe('package-requests', () => {
       for (const status of ['200', '201', '400', '401', '409', '422', '429', '502', '503']) {
         expect(source).toContain(status + ':')
       }
+    })
+  })
+
+  describe('team options', () => {
+    it('defaults to RHAISTRAT and returns sorted unique Jira components', async () => {
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path) => {
+          expect(path).toBe('/rest/api/3/project/RHAISTRAT/components')
+          return [
+            { id: '3', name: 'Vision' },
+            { id: '1', name: 'AIPCC Ecosystems' },
+            { id: '2', name: 'Vision' },
+            { id: '4', name: '  ' }
+          ]
+        })
+      })
+      const { router } = register({ jiraClient: jira })
+
+      const res = await callTeamsHandler(router)
+
+      expect(res._status).toBe(200)
+      expect(res._json).toEqual([
+        { value: 'AIPCC Ecosystems', label: 'AIPCC Ecosystems' },
+        { value: 'Vision', label: 'Vision' }
+      ])
+    })
+
+    it('supports AIPCC and RHAI and caches each project independently', async () => {
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path) => {
+          const project = path.split('/')[5]
+          return [{ name: project + ' component' }]
+        })
+      })
+      const { router } = register({ jiraClient: jira })
+
+      const aipcc = await callTeamsHandler(router, { query: { project: 'AIPCC' } })
+      const rhai = await callTeamsHandler(router, { query: { project: 'RHAI' } })
+      const cachedAipcc = await callTeamsHandler(router, { query: { project: 'AIPCC' } })
+
+      expect(aipcc._json).toEqual([{ value: 'AIPCC component', label: 'AIPCC component' }])
+      expect(rhai._json).toEqual([{ value: 'RHAI component', label: 'RHAI component' }])
+      expect(cachedAipcc._json).toEqual(aipcc._json)
+      expect(jira.jiraRequest).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns deterministic demo options for every supported project', async () => {
+      const jira = makeJira()
+      const { router } = register({ jiraClient: jira, isDemoMode: true })
+
+      const rhaistrat = await callTeamsHandler(router)
+      const aipcc = await callTeamsHandler(router, { query: { project: 'AIPCC' } })
+      const rhai = await callTeamsHandler(router, { query: { project: 'RHAI' } })
+
+      expect(rhaistrat._json).toContainEqual({ value: 'AI Core Platform', label: 'AI Core Platform' })
+      expect(aipcc._json).toContainEqual({ value: 'AIPCC Ecosystems', label: 'AIPCC Ecosystems' })
+      expect(rhai._json).toContainEqual({ value: 'AIPCC Ecosystems', label: 'AIPCC Ecosystems' })
+      expect(jira.jiraRequest).not.toHaveBeenCalled()
+    })
+
+    it('rejects unsupported projects before calling Jira', async () => {
+      const jira = makeJira()
+      const { router } = register({ jiraClient: jira })
+
+      const res = await callTeamsHandler(router, { query: { project: 'RHOAIENG' } })
+
+      expect(res._status).toBe(400)
+      expect(res._json.message).toContain('RHAISTRAT, AIPCC, RHAI')
+      expect(jira.jiraRequest).not.toHaveBeenCalled()
+    })
+
+    it('returns 503 when Jira is not configured and 502 when Jira fails', async () => {
+      const unconfigured = register({}, { secrets: {} })
+      const missing = await callTeamsHandler(unconfigured.router)
+      expect(missing._status).toBe(503)
+
+      const jira = makeJira({
+        jiraRequest: vi.fn(async () => { throw new Error('Jira unavailable') })
+      })
+      const configured = register({ jiraClient: jira })
+      const failed = await callTeamsHandler(configured.router)
+      expect(failed._status).toBe(502)
+      expect(failed._json.error).toBe('Failed to fetch teams from Jira')
+    })
+
+    it('refreshes cached Jira components after the cache TTL', async () => {
+      const jira = makeJira({
+        jiraRequest: vi.fn(async () => [{ name: 'AIPCC Ecosystems' }])
+      })
+      const first = await getTeamOptions(jira, 'RHAI', 1_000)
+      const cached = await getTeamOptions(jira, 'RHAI', 1_000 + 299_999)
+      const refreshed = await getTeamOptions(jira, 'RHAI', 1_000 + 300_000)
+
+      expect(first).toEqual([{ value: 'AIPCC Ecosystems', label: 'AIPCC Ecosystems' }])
+      expect(cached).toBe(first)
+      expect(refreshed).not.toBe(first)
+      expect(jira.jiraRequest).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -600,13 +722,18 @@ describe('package-requests', () => {
         c => String(c[0]).includes('/api/v4/projects/') && (c[1].method || 'GET') === 'POST'
       )
       expect(pipelineCall).toBeDefined()
-      expect(String(pipelineCall[0])).toContain('/projects/redhat%2Frhel-ai%2Fcore%2Fpackage-onboarding/pipelines')
+      expect(String(pipelineCall[0])).toContain('/projects/redhat%2Frhel-ai%2Fcore%2Fpackage-onboarding/pipeline')
+      expect(String(pipelineCall[0])).not.toContain('/pipelines')
       expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('gitlab-token')
       const pipelineBody = JSON.parse(pipelineCall[1].body)
-      expect(pipelineBody.variables.PACKAGE_NAME).toBe('vllm[cu12]')
-      expect(pipelineBody.variables.JIRA_TICKET_ID).toBe('AIPCC-999')
-      expect(pipelineBody.variables.PACKAGE_VERSION).toBe('2.5.1')
-      expect(pipelineBody.variables.PACKAGE_REQUEST_EPIC).toBeUndefined()
+      expect(pipelineBody).toEqual({
+        ref: 'main',
+        variables: [
+          { key: 'PACKAGE_NAME', value: 'vllm[cu12]' },
+          { key: 'JIRA_TICKET_ID', value: 'AIPCC-999' },
+          { key: 'PACKAGE_VERSION', value: '2.5.1' }
+        ]
+      })
     })
 
     it('still succeeds when the pipeline trigger fails (non-fatal)', async () => {
@@ -625,6 +752,85 @@ describe('package-requests', () => {
       expect(res._json.pipeline.triggered).toBe(false)
       expect(res._json.pipeline.error).toContain('500')
       expect(epicPostCall(jira)).toBeDefined()
+
+      const retry = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(retry._status).toBe(429)
+    })
+
+    it('allows an immediate retry after Jira Epic creation fails', async () => {
+      let createAttempts = 0
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path, opts = {}) => {
+          const method = (opts.method || 'GET').toUpperCase()
+          if (path.startsWith('/rest/api/3/user/search')) {
+            return [{ accountId: 'acc-1', emailAddress: 'jane@redhat.com' }]
+          }
+          if (path === '/rest/api/3/issue' && method === 'POST') {
+            createAttempts += 1
+            if (createAttempts === 1) throw new Error('temporary Jira failure')
+            return { key: 'AIPCC-999', id: '10999' }
+          }
+          if (method === 'PUT') return {}
+          if (path.startsWith('/rest/api/3/issue/') && path.includes('fields=summary')) {
+            return { key: 'AIPCC-42', fields: { summary: 'Related issue summary' } }
+          }
+          throw new Error('Unexpected jiraRequest in mock: ' + method + ' ' + path)
+        })
+      })
+      const { router } = register({
+        jiraClient: jira,
+        fetch: makeFetch(),
+        fetchIndex: vi.fn(async () => ({ found: false, files: [] }))
+      })
+
+      const failed = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      const retry = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+
+      expect(failed._status).toBe(502)
+      expect(retry._status).toBe(201)
+      expect(createAttempts).toBe(2)
+    })
+
+    it('prevents concurrent requests from the same user from creating duplicate Epics', async () => {
+      let markPostStarted
+      let finishPost
+      const postStarted = new Promise(resolve => { markPostStarted = resolve })
+      const postResult = new Promise(resolve => { finishPost = resolve })
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path, opts = {}) => {
+          const method = (opts.method || 'GET').toUpperCase()
+          if (path.startsWith('/rest/api/3/user/search')) {
+            return [{ accountId: 'acc-1', emailAddress: 'jane@redhat.com' }]
+          }
+          if (path === '/rest/api/3/issue' && method === 'POST') {
+            markPostStarted()
+            return postResult
+          }
+          if (method === 'PUT') return {}
+          if (path.startsWith('/rest/api/3/issue/') && path.includes('fields=summary')) {
+            return { key: 'AIPCC-42', fields: { summary: 'Related issue summary' } }
+          }
+          throw new Error('Unexpected jiraRequest in mock: ' + method + ' ' + path)
+        })
+      })
+      const { router } = register({
+        jiraClient: jira,
+        fetch: makeFetch(),
+        fetchIndex: vi.fn(async () => ({ found: false, files: [] }))
+      })
+
+      const firstPromise = callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      await postStarted
+      const concurrent = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      finishPost({ key: 'AIPCC-999', id: '10999' })
+      const first = await firstPromise
+
+      expect(first._status).toBe(201)
+      expect(concurrent._status).toBe(429)
+      expect(concurrent._json.error).toContain('already being processed')
+      expect(jira.jiraRequest.mock.calls.filter(
+        c => c[0] === '/rest/api/3/issue' && c[1] && c[1].method === 'POST'
+      )).toHaveLength(1)
     })
 
     it('reports the pipeline as skipped when no GitLab token is configured', async () => {

--- a/modules/product-builds/__tests__/server/package-requests.test.js
+++ b/modules/product-builds/__tests__/server/package-requests.test.js
@@ -11,16 +11,18 @@ const {
   buildAdfDescription,
   buildEpicFields,
   buildDuplicateJql,
+  normalizeRequestSummary,
   buildPipelineVariables,
   getTeamOptions,
   checkPypiPackage,
   getGitlabToken,
+  resolveJiraProject,
   checkRateLimit,
   recordSubmission,
   _lastSubmission,
   _pendingSubmissions,
   _teamOptionsCache,
-  AIPCC_PROJECT,
+  DEFAULT_JIRA_PROJECT,
   SECURITY_NAME,
   COMPONENT_NAME,
   EPIC_NAME_FIELD
@@ -130,7 +132,7 @@ function makeContext(overrides = {}) {
     secrets: {
       JIRA_EMAIL: 'svc@redhat.com',
       JIRA_TOKEN: 'jira-token',
-      GITLAB_TOKEN: 'gitlab-token'
+      PACKAGE_ONBOARDING_GITLAB_TOKEN: 'onboarding-token'
     },
     resolveSecret: vi.fn(() => null),
     requireAuth: vi.fn(function (_req, _res, next) { next() }),
@@ -498,7 +500,7 @@ describe('package-requests', () => {
         demo: true,
         requester: 'jane@redhat.com',
         summary: 'vllm[cu12] package update request',
-        jira: { key: 'AIPCC-DEMO', url: null },
+        jira: { key: 'AIPCC-DEMO', url: null, project: 'AIPCC' },
         pipeline: { triggered: false, reason: 'demo mode' }
       })
       // Rate limited on the immediate second submission (still no external calls).
@@ -550,6 +552,56 @@ describe('package-requests', () => {
         }
       ])
       expect(epicPostCall(jira)).toBeUndefined()
+    })
+
+    function jiraWithExistingEpics(summaries) {
+      return makeJira({
+        fetchAllJqlResults: vi.fn(async () => summaries.map((summary, i) => ({
+          key: 'AIPCC-' + (100 + i),
+          fields: { summary, status: { name: 'To Do' }, created: '2026-06-01T00:00:00.000Z' }
+        })))
+      })
+    }
+
+    async function submitAgainst(summaries, bodyOverrides) {
+      const jira = jiraWithExistingEpics(summaries)
+      const { router } = register({ jiraClient: jira, fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) })
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody(bodyOverrides) })
+      return { res, jira }
+    }
+
+    it('treats different extras of the same package as separate requests', async () => {
+      const { res, jira } = await submitAgainst(
+        ['torch[rocm] package update request'],
+        { package_name: 'torch', extras: ['cuda'] }
+      )
+      expect(res._status).toBe(201)
+      expect(epicPostCall(jira)).toBeDefined()
+    })
+
+    it('does not treat a bare package as a duplicate of one with extras', async () => {
+      const { res } = await submitAgainst(
+        ['torch[cuda] package update request'],
+        { package_name: 'torch', extras: null }
+      )
+      expect(res._status).toBe(201)
+    })
+
+    it('does not treat a package as a duplicate of a longer package name', async () => {
+      const { res } = await submitAgainst(
+        ['torchvision package update request'],
+        { package_name: 'torch', extras: null }
+      )
+      expect(res._status).toBe(201)
+    })
+
+    it('still flags duplicates when extras differ only in case or order', async () => {
+      const { res } = await submitAgainst(
+        ['torch[ROCm,cuda] package update request', 'unrelated Epic'],
+        { package_name: 'torch', extras: ['cuda', 'rocm'] }
+      )
+      expect(res._status).toBe(409)
+      expect(res._json.existing_tickets.map(t => t.key)).toEqual(['AIPCC-100'])
     })
 
     it('proceeds when the duplicate search fails (fail open)', async () => {
@@ -666,7 +718,8 @@ describe('package-requests', () => {
         key: 'AIPCC-999',
         id: '10999',
         url: 'https://redhat.atlassian.net/browse/AIPCC-999',
-        summary: 'vllm[cu12] package update request'
+        summary: 'vllm[cu12] package update request',
+        project: 'AIPCC'
       })
       expect(res._json.release_target_set).toBe(true)
       expect(res._json.pipeline).toEqual({
@@ -679,7 +732,8 @@ describe('package-requests', () => {
       const post = epicPostCall(jira)
       expect(post).toBeDefined()
       const fields = post[1].body.fields
-      expect(fields.project).toEqual({ key: AIPCC_PROJECT })
+      expect(fields.project).toEqual({ key: DEFAULT_JIRA_PROJECT })
+      expect(res._json.jira.project).toBe('AIPCC')
       expect(fields.issuetype).toEqual({ name: 'Epic' })
       expect(fields.summary).toBe('vllm[cu12] package update request')
       expect(fields.labels).toContain('package')
@@ -724,7 +778,7 @@ describe('package-requests', () => {
       expect(pipelineCall).toBeDefined()
       expect(String(pipelineCall[0])).toContain('/projects/redhat%2Frhel-ai%2Fcore%2Fpackage-onboarding/pipeline')
       expect(String(pipelineCall[0])).not.toContain('/pipelines')
-      expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('gitlab-token')
+      expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('onboarding-token')
       const pipelineBody = JSON.parse(pipelineCall[1].body)
       expect(pipelineBody).toEqual({
         ref: 'main',
@@ -843,25 +897,70 @@ describe('package-requests', () => {
       expect(res._json.pipeline).toEqual({ triggered: false, reason: 'gitlab_token_not_configured' })
     })
 
-    it('uses the nightly pipeline token as a fallback', async () => {
+    it('does not fall back to read-only platform or nightly GitLab tokens', async () => {
       const fetchMock = makeFetch()
       const { router } = register(
         { jiraClient: makeJira(), fetch: fetchMock, fetchIndex: vi.fn(async () => ({ found: false, files: [] })) },
-        { secrets: { JIRA_EMAIL: 'svc@redhat.com', JIRA_TOKEN: 'jira-token', NIGHTLY_PIPELINE_GITLAB_TOKEN: 'nightly-token' } }
+        { secrets: {
+          JIRA_EMAIL: 'svc@redhat.com',
+          JIRA_TOKEN: 'jira-token',
+          GITLAB_TOKEN: 'read-only-token',
+          NIGHTLY_PIPELINE_GITLAB_TOKEN: 'nightly-token'
+        } }
       )
       const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
       expect(res._status).toBe(201)
-      expect(res._json.pipeline.triggered).toBe(true)
+      expect(res._json.pipeline).toEqual({ triggered: false, reason: 'gitlab_token_not_configured' })
       const pipelineCall = fetchMock.mock.calls.find(
         c => String(c[0]).includes('/api/v4/projects/') && (c[1].method || 'GET') === 'POST'
       )
-      expect(pipelineCall[1].headers['PRIVATE-TOKEN']).toBe('nightly-token')
+      expect(pipelineCall).toBeUndefined()
     })
 
     it('returns 503 when Jira is not configured', async () => {
       const { router } = register({}, { secrets: {} })
       const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
       expect(res._status).toBe(503)
+    })
+  })
+
+  describe('configurable Jira project', () => {
+    const overrideSecrets = {
+      secrets: {
+        JIRA_EMAIL: 'svc@redhat.com',
+        JIRA_TOKEN: 'jira-token',
+        PACKAGE_ONBOARDING_GITLAB_TOKEN: 'onboarding-token',
+        PACKAGE_REQUEST_JIRA_PROJECT: 'TESTPROJ'
+      }
+    }
+
+    it('files the Epic and searches duplicates in PACKAGE_REQUEST_JIRA_PROJECT', async () => {
+      const jira = makeJira({
+        jiraRequest: vi.fn(async (path, opts = {}) => {
+          const method = (opts.method || 'GET').toUpperCase()
+          if (path.startsWith('/rest/api/3/user/search')) return []
+          if (path === '/rest/api/3/issue' && method === 'POST') return { key: 'TESTPROJ-7', id: '7' }
+          if (method === 'PUT') return {}
+          if (path.startsWith('/rest/api/3/issue/')) return { key: 'AIPCC-42', fields: { summary: 'Related' } }
+          throw new Error('Unexpected ' + method + ' ' + path)
+        })
+      })
+      const { router } = register(
+        { jiraClient: jira, fetch: makeFetch(), fetchIndex: vi.fn(async () => ({ found: false, files: [] })) },
+        overrideSecrets
+      )
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(201)
+      expect(epicPostCall(jira)[1].body.fields.project).toEqual({ key: 'TESTPROJ' })
+      expect(jira.fetchAllJqlResults.mock.calls[0][0]).toContain('project = TESTPROJ')
+      expect(res._json.jira).toMatchObject({ key: 'TESTPROJ-7', project: 'TESTPROJ' })
+    })
+
+    it('uses the configured project for the demo-mode key', async () => {
+      const { router } = register({ isDemoMode: true }, overrideSecrets)
+      const res = await callHandler(router, { userEmail: 'jane@redhat.com', body: validBody() })
+      expect(res._status).toBe(200)
+      expect(res._json.jira).toEqual({ key: 'TESTPROJ-DEMO', url: null, project: 'TESTPROJ' })
     })
   })
 
@@ -965,9 +1064,10 @@ describe('package-requests', () => {
       expect(buildEpicName('vllm')).toBe('vllm package update request')
     })
 
-    it('buildDuplicateJql targets recent AIPCC package Epics', () => {
+    it('buildDuplicateJql targets recent package Epics in the configured project', () => {
       const jql = buildDuplicateJql('vllm')
       expect(jql).toContain('project = AIPCC')
+      expect(buildDuplicateJql('vllm', 'TESTPROJ')).toContain('project = TESTPROJ')
       expect(jql).toContain('issuetype = Epic')
       expect(jql).toContain('"package", "dashboard-filed"')
       expect(jql).toContain('summary ~ "*vllm*"')
@@ -984,10 +1084,32 @@ describe('package-requests', () => {
       })
     })
 
-    it('getGitlabToken prefers GITLAB_TOKEN over the nightly fallback', () => {
-      expect(getGitlabToken({ GITLAB_TOKEN: 'a', NIGHTLY_PIPELINE_GITLAB_TOKEN: 'b' })).toBe('a')
-      expect(getGitlabToken({ NIGHTLY_PIPELINE_GITLAB_TOKEN: 'b' })).toBe('b')
+    it('getGitlabToken only honours the dedicated onboarding token', () => {
+      expect(getGitlabToken({ PACKAGE_ONBOARDING_GITLAB_TOKEN: 'a', GITLAB_TOKEN: 'b' })).toBe('a')
+      expect(getGitlabToken({ GITLAB_TOKEN: 'b', NIGHTLY_PIPELINE_GITLAB_TOKEN: 'c' })).toBeNull()
       expect(getGitlabToken({})).toBeNull()
+      expect(getGitlabToken(undefined)).toBeNull()
+    })
+
+    it('normalizeRequestSummary keys on package name plus sorted extras', () => {
+      expect(normalizeRequestSummary('torch package update request')).toBe('torch[]')
+      expect(normalizeRequestSummary('Torch[ROCm, cuda] package update request')).toBe('torch[cuda,rocm]')
+      expect(normalizeRequestSummary('torch[cuda] package update request'))
+        .not.toBe(normalizeRequestSummary('torch[rocm] package update request'))
+      expect(normalizeRequestSummary('torchvision package update request')).toBe('torchvision[]')
+      expect(normalizeRequestSummary('something else entirely')).toBeNull()
+      expect(normalizeRequestSummary(null)).toBeNull()
+    })
+
+    it('resolveJiraProject defaults to AIPCC and validates overrides', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      expect(resolveJiraProject({})).toBe('AIPCC')
+      expect(resolveJiraProject(undefined)).toBe('AIPCC')
+      expect(resolveJiraProject({ PACKAGE_REQUEST_JIRA_PROJECT: '' })).toBe('AIPCC')
+      expect(resolveJiraProject({ PACKAGE_REQUEST_JIRA_PROJECT: ' testproj ' })).toBe('TESTPROJ')
+      expect(resolveJiraProject({ PACKAGE_REQUEST_JIRA_PROJECT: 'bad key!' })).toBe('AIPCC')
+      expect(warn).toHaveBeenCalledTimes(1)
+      warn.mockRestore()
     })
 
     it('checkPypiPackage reports found/missing and throws on API errors', async () => {

--- a/modules/product-builds/client/index.js
+++ b/modules/product-builds/client/index.js
@@ -14,4 +14,5 @@ export const routes = {
   'drop-detail': defineAsyncComponent(() => import('./views/DropDetailView.vue')),
   'artifact-detail': defineAsyncComponent(() => import('./views/ArtifactDetailView.vue')),
   'package-analysis': defineAsyncComponent(() => import('./views/PackageAnalysisView.vue')),
+  'package-request': defineAsyncComponent(() => import('./views/RequestPackageView.vue')),
 }

--- a/modules/product-builds/client/views/RequestPackageView.vue
+++ b/modules/product-builds/client/views/RequestPackageView.vue
@@ -1,0 +1,705 @@
+<script setup>
+import { ref, reactive, computed } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+import { useAuth } from '@shared/client/composables/useAuth'
+
+const { user } = useAuth()
+
+const JIRA_BASE = 'https://redhat.atlassian.net/browse'
+const PACKAGE_NAME_RE = /^[a-zA-Z][a-zA-Z0-9._-]*$/
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+const JIRA_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/
+const VERSION_RE = /^[a-zA-Z0-9._-]+$/
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const MIN_LEAD_TIME_DAYS = 8
+const SOURCES = [
+  { id: 'pypi', label: 'PyPI', hint: 'Published on pypi.org' },
+  { id: 'git', label: 'Git repository', hint: 'HTTP(S) URL of the git repository' },
+  { id: 'other', label: 'Other', hint: 'Manual source (internal index, archive, ...)' }
+]
+
+function isoDaysFromNow(days) {
+  const d = new Date()
+  d.setUTCHours(0, 0, 0, 0)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+const minDeliveryDate = computed(() => isoDaysFromNow(MIN_LEAD_TIME_DAYS))
+
+function daysUntil(dateStr) {
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+  const target = new Date(dateStr + 'T00:00:00Z')
+  if (isNaN(target.getTime())) return NaN
+  return Math.round((target - today) / 86400000)
+}
+
+function defaults() {
+  return {
+    team: '',
+    package_name: '',
+    extras: '',
+    package_source: 'pypi',
+    source_url: '',
+    version: '',
+    backport_versions: '',
+    other_hardware: '',
+    hardware_ack: false,
+    jira_id: '',
+    justification: '',
+    delivery_timeline: '',
+    release_target: '',
+    release_commitment: '',
+    testing_requirements: '',
+    testing_ack: false
+  }
+}
+
+const form = reactive(defaults())
+const fieldErrors = ref({})
+const submitting = ref(false)
+const banner = ref(null) // { type, text } form-level message
+const warning = ref(null) // 200 production-presence warning payload
+const duplicates = ref(null) // 409 existing_tickets array
+const success = ref(null) // 201 (or demo 200) payload
+
+const needsSourceUrl = computed(() => form.package_source === 'git' || form.package_source === 'other')
+const identityLabel = computed(() => (user.value ? (user.value.displayName || user.value.email) : null))
+
+function parseList(raw) {
+  return String(raw || '').split(',').map(s => s.trim()).filter(Boolean)
+}
+
+function validate() {
+  const errors = {}
+  if (!form.team.trim()) errors.team = 'Team is required'
+
+  if (!PACKAGE_NAME_RE.test(form.package_name.trim())) {
+    errors.package_name = 'Package name must start with a letter and contain only letters, digits, dots, underscores or dashes'
+  }
+
+  const extras = parseList(form.extras)
+  const seen = new Set()
+  for (const extra of extras) {
+    if (!SAFE_IDENTIFIER_RE.test(extra)) {
+      errors.extras = 'Each extra must be a safe identifier (letters, digits, dot, underscore, dash; no spaces)'
+      break
+    }
+    const key = extra.toLowerCase()
+    if (seen.has(key)) {
+      errors.extras = `Extras must not contain duplicates (${extra})`
+      break
+    }
+    seen.add(key)
+  }
+
+  if (!SOURCES.some(s => s.id === form.package_source)) {
+    errors.package_source = 'Package source is required'
+  }
+  if (needsSourceUrl.value) {
+    const url = form.source_url.trim()
+    if (!url) {
+      errors.source_url = 'Source URL is required for git and other package sources'
+    } else if (!/^https?:\/\//i.test(url)) {
+      errors.source_url = 'Source URL must be an HTTP or HTTPS URL'
+    }
+  }
+
+  const version = form.version.trim()
+  if (version && !VERSION_RE.test(version)) {
+    errors.version = 'Version must contain only letters, digits, dots, underscores or dashes'
+  }
+
+  if (!form.other_hardware.trim() && !form.hardware_ack) {
+    errors.other_hardware = 'Provide hardware details or acknowledge the all-supported-accelerators default'
+  }
+
+  if (!JIRA_KEY_RE.test(form.jira_id.trim())) {
+    errors.jira_id = 'Jira key must match the PROJECT-123 format (e.g. AIPCC-1234)'
+  }
+
+  if (!form.justification.trim()) errors.justification = 'Business justification is required'
+
+  const date = form.delivery_timeline.trim()
+  if (!DATE_RE.test(date)) {
+    errors.delivery_timeline = 'Delivery date is required (YYYY-MM-DD)'
+  } else if (daysUntil(date) < MIN_LEAD_TIME_DAYS) {
+    errors.delivery_timeline = `Delivery date must be at least ${MIN_LEAD_TIME_DAYS} calendar days from today`
+  }
+
+  if (!form.testing_requirements.trim() && !form.testing_ack) {
+    errors.testing_requirements = 'Provide testing requirements or acknowledge the default probe/import tests'
+  }
+
+  return errors
+}
+
+function buildPayload(skipProductionCheck) {
+  const payload = {
+    team: form.team.trim(),
+    package_name: form.package_name.trim(),
+    extras: parseList(form.extras),
+    package_source: form.package_source,
+    source_url: needsSourceUrl.value ? form.source_url.trim() : null,
+    version: form.version.trim() || null,
+    other_hardware: form.other_hardware.trim(),
+    hardware_defaults_acknowledged: form.hardware_ack,
+    jira_id: form.jira_id.trim(),
+    justification: form.justification.trim(),
+    delivery_timeline: form.delivery_timeline.trim(),
+    release_target: parseList(form.release_target),
+    release_commitment: form.release_commitment.trim(),
+    testing_requirements: form.testing_requirements.trim(),
+    testing_defaults_acknowledged: form.testing_ack,
+    backport_versions: parseList(form.backport_versions)
+  }
+  if (skipProductionCheck) payload.skip_production_check = true
+  return payload
+}
+
+async function submit(skipProductionCheck = false) {
+  const errors = validate()
+  fieldErrors.value = errors
+  warning.value = null
+  duplicates.value = null
+  success.value = null
+  banner.value = null
+  if (Object.keys(errors).length > 0) {
+    banner.value = { type: 'error', text: 'Please fix the highlighted fields before submitting.' }
+    return
+  }
+
+  submitting.value = true
+  try {
+    const data = await apiRequest('/modules/product-builds/package-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildPayload(skipProductionCheck))
+    })
+    if (data && data.status === 'warning') {
+      warning.value = data
+      return
+    }
+    success.value = data
+  } catch (err) {
+    const data = (err && err.data) || {}
+    if (err && err.status === 422 && data.fields) {
+      fieldErrors.value = { ...fieldErrors.value, ...data.fields }
+      banner.value = { type: 'error', text: data.error || 'Validation failed. Check the highlighted fields.' }
+    } else if (err && err.status === 409 && Array.isArray(data.existing_tickets)) {
+      duplicates.value = data.existing_tickets
+      banner.value = { type: 'error', text: data.error || 'A recent package update request already exists for this package.' }
+    } else if (err && err.status === 429) {
+      const wait = data.retry_after_seconds
+        ? ` Please try again in about ${data.retry_after_seconds} seconds.`
+        : ''
+      banner.value = { type: 'error', text: (err.message || 'Rate limited') + wait }
+    } else if (err && (err.status === 502 || err.status === 503)) {
+      banner.value = {
+        type: 'error',
+        text: (data.error || err.message || 'Upstream error') +
+          ' Please check the Product Builds configuration or try again later.'
+      }
+    } else {
+      const text = (err && err.message) ? err.message : 'Request failed'
+      banner.value = {
+        type: 'error',
+        text: err && err.status
+          ? text
+          : `Could not reach the server (${text}). Check your connection and try again.`
+      }
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+
+function cancelWarning() {
+  warning.value = null
+}
+
+function resetForm() {
+  Object.assign(form, defaults())
+  fieldErrors.value = {}
+  banner.value = null
+  warning.value = null
+  duplicates.value = null
+  success.value = null
+}
+
+function jiraHref(ticket) {
+  return ticket && (ticket.url || (JIRA_BASE + '/' + ticket.key))
+}
+</script>
+
+<template>
+  <div class="max-w-[900px]">
+    <!-- Header -->
+    <div class="mb-6 flex items-start justify-between gap-4 flex-wrap">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Request Package</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Submit a package update request. A Jira Epic is filed and the onboarding pipeline is triggered on success.
+        </p>
+      </div>
+      <div
+        v-if="identityLabel"
+        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-gray-100 dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300"
+      >
+        <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <span>Submitting as <strong class="font-semibold">{{ identityLabel }}</strong></span>
+      </div>
+    </div>
+
+    <!-- Success panel -->
+    <div v-if="success" class="bg-white dark:bg-gray-800 border border-green-200 dark:border-green-800/40 rounded-lg p-6">
+      <div class="flex items-center gap-3 mb-4">
+        <div class="w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center flex-shrink-0">
+          <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <div>
+          <h2 class="text-lg font-bold text-green-800 dark:text-green-300">Package request submitted</h2>
+          <p class="text-sm text-green-600 dark:text-green-400/80">
+            {{ success.summary || 'Request accepted' }}
+            <span v-if="success.demo"> (demo mode)</span>
+          </p>
+        </div>
+      </div>
+
+      <dl class="space-y-3 text-sm">
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 dark:text-gray-400 w-40 flex-shrink-0">Jira Epic</dt>
+          <dd>
+            <a
+              v-if="success.jira && success.jira.url"
+              :href="success.jira.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="font-semibold text-blue-600 hover:underline"
+            >{{ success.jira.key }}</a>
+            <span v-else class="font-semibold text-gray-900 dark:text-gray-200">{{ success.jira ? success.jira.key : 'N/A' }}</span>
+          </dd>
+        </div>
+        <div v-if="success.requester" class="flex items-center gap-2">
+          <dt class="text-gray-500 dark:text-gray-400 w-40 flex-shrink-0">Requester</dt>
+          <dd class="text-gray-900 dark:text-gray-200">{{ success.requester }}</dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 dark:text-gray-400 w-40 flex-shrink-0">Onboarding pipeline</dt>
+          <dd v-if="success.pipeline && success.pipeline.triggered && success.pipeline.web_url">
+            <a
+              :href="success.pipeline.web_url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="font-semibold text-blue-600 hover:underline"
+            >View pipeline</a>
+          </dd>
+          <dd v-else-if="success.pipeline" class="text-gray-500 dark:text-gray-400">
+            Not triggered<span v-if="success.pipeline.reason">: {{ success.pipeline.reason }}</span>
+            <span v-else-if="success.pipeline.error">: {{ success.pipeline.error }}</span>
+          </dd>
+        </div>
+      </dl>
+
+      <button
+        @click="resetForm"
+        class="mt-5 px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors"
+      >
+        Submit another request
+      </button>
+    </div>
+
+    <!-- Form -->
+    <form v-else novalidate @submit.prevent="submit(false)">
+      <!-- Form-level banner -->
+      <div
+        v-if="banner"
+        role="alert"
+        class="mb-4 p-3 rounded-lg text-sm border"
+        :class="banner.type === 'error'
+          ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-700 dark:text-red-400'
+          : 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400'"
+      >
+        {{ banner.text }}
+      </div>
+
+      <!-- Duplicate tickets (409) -->
+      <div
+        v-if="duplicates"
+        role="alert"
+        class="mb-4 p-4 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20"
+      >
+        <p class="text-sm font-semibold text-red-700 dark:text-red-400 mb-2">
+          Recent duplicate requests found. Review them before filing a new one.
+        </p>
+        <ul class="space-y-1.5">
+          <li v-for="ticket in duplicates" :key="ticket.key" class="text-sm text-red-700 dark:text-red-400 flex items-center gap-2 flex-wrap">
+            <a :href="jiraHref(ticket)" target="_blank" rel="noopener noreferrer" class="font-semibold hover:underline">{{ ticket.key }}</a>
+            <span v-if="ticket.summary" class="text-red-600/80 dark:text-red-400/70 truncate max-w-[320px]">{{ ticket.summary }}</span>
+            <span v-if="ticket.status" class="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-red-100 dark:bg-red-900/40">{{ ticket.status }}</span>
+            <span v-if="ticket.created" class="text-xs text-red-500/70 dark:text-red-400/50">created {{ ticket.created.slice(0, 10) }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Production warning (200) -->
+      <div
+        v-if="warning"
+        role="alert"
+        class="mb-4 p-4 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+      >
+        <div class="flex items-start gap-3">
+          <svg class="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
+              {{ warning.package_name }} is already present in production index(es)
+            </p>
+            <p class="text-sm text-amber-700 dark:text-amber-400/80 mt-1">{{ warning.message }}</p>
+            <ul v-if="warning.found_in && warning.found_in.length" class="mt-2 space-y-1">
+              <li v-for="entry in warning.found_in" :key="entry.product_version + entry.variant" class="text-xs text-amber-800 dark:text-amber-300/80">
+                <span class="font-mono">{{ entry.product_version }} / {{ entry.variant }}</span>
+                <a :href="entry.index_url" target="_blank" rel="noopener noreferrer" class="underline ml-1">{{ entry.index_url }}</a>
+                <span v-if="entry.files && entry.files.length" class="block mt-0.5 text-amber-700/70 dark:text-amber-400/60">
+                  {{ entry.files.slice(0, 3).join(', ') }}{{ entry.files.length > 3 ? ' …' : '' }}
+                </span>
+              </li>
+            </ul>
+            <div class="flex items-center gap-3 mt-3">
+              <button
+                type="button"
+                @click="submit(true)"
+                :disabled="submitting"
+                class="px-4 py-1.5 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 rounded-lg transition-colors"
+              >
+                {{ submitting ? 'Submitting...' : 'Submit anyway' }}
+              </button>
+              <button
+                type="button"
+                @click="cancelWarning"
+                class="px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 space-y-6">
+        <!-- Requester -->
+        <p class="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+          The request is filed under your signed-in identity. The server treats the authenticated identity as authoritative.
+        </p>
+
+        <!-- Team + package -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label for="req-team" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Team <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="req-team"
+              v-model="form.team"
+              type="text"
+              required
+              autocomplete="off"
+              placeholder="e.g. Platform"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.team"
+              :aria-describedby="fieldErrors.team ? 'req-team-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.team ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.team" id="req-team-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.team }}</p>
+          </div>
+
+          <div>
+            <label for="req-package-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Package name <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="req-package-name"
+              v-model="form.package_name"
+              type="text"
+              required
+              autocomplete="off"
+              placeholder="e.g. vllm"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.package_name"
+              :aria-describedby="fieldErrors.package_name ? 'req-package-name-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.package_name ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.package_name" id="req-package-name-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.package_name }}</p>
+          </div>
+
+          <div class="md:col-span-2">
+            <label for="req-extras" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Extras (optional)</label>
+            <input
+              id="req-extras"
+              v-model="form.extras"
+              type="text"
+              autocomplete="off"
+              placeholder="Comma-separated, e.g. cu12,dev"
+              :aria-invalid="!!fieldErrors.extras"
+              :aria-describedby="fieldErrors.extras ? 'req-extras-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.extras ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.extras" id="req-extras-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.extras }}</p>
+          </div>
+
+          <div class="md:col-span-2">
+            <fieldset>
+              <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Package source <span class="text-red-500" aria-hidden="true">*</span>
+              </legend>
+              <div class="flex flex-wrap gap-4" role="radiogroup" aria-required="true">
+                <label
+                  v-for="source in SOURCES"
+                  :key="source.id"
+                  class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer"
+                >
+                  <input
+                    v-model="form.package_source"
+                    type="radio"
+                    :value="source.id"
+                    name="req-package-source"
+                    class="text-primary-600 border-gray-300 dark:border-gray-600"
+                  />
+                  <span>{{ source.label }}<span class="text-gray-400 dark:text-gray-500 text-xs">({{ source.hint }})</span></span>
+                </label>
+              </div>
+            </fieldset>
+          </div>
+
+          <div v-if="needsSourceUrl" class="md:col-span-2">
+            <label for="req-source-url" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Source URL <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="req-source-url"
+              v-model="form.source_url"
+              type="url"
+              required
+              autocomplete="off"
+              placeholder="https://github.com/org/repo"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.source_url"
+              :aria-describedby="fieldErrors.source_url ? 'req-source-url-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.source_url ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.source_url" id="req-source-url-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.source_url }}</p>
+          </div>
+
+          <div>
+            <label for="req-version" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Version (optional)</label>
+            <input
+              id="req-version"
+              v-model="form.version"
+              type="text"
+              autocomplete="off"
+              placeholder="e.g. 2.5.1"
+              :aria-invalid="!!fieldErrors.version"
+              :aria-describedby="fieldErrors.version ? 'req-version-error' : 'req-version-hint'"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.version ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.version" id="req-version-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.version }}</p>
+            <div id="req-version-hint" class="mt-2 p-2.5 rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">
+              <p class="text-xs text-amber-800 dark:text-amber-300">
+                <strong>Prefer leaving this empty.</strong> Pinning a version restricts the onboarding pipeline to that
+                exact release. Only set it when you specifically need that version.
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <label for="req-backport-versions" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Backport versions (optional)</label>
+            <input
+              id="req-backport-versions"
+              v-model="form.backport_versions"
+              type="text"
+              autocomplete="off"
+              placeholder="Comma-separated, e.g. 2.4.0,2.3.5"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+        </div>
+
+        <!-- Hardware -->
+        <fieldset class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <legend class="px-2 text-sm font-medium text-gray-700 dark:text-gray-300">Hardware support <span class="text-red-500" aria-hidden="true">*</span> <span class="text-xs font-normal text-gray-400">(details or acknowledgement)</span></legend>
+          <label for="req-other-hardware" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Other hardware details (optional)
+          </label>
+          <textarea
+            id="req-other-hardware"
+            v-model="form.other_hardware"
+            rows="2"
+            placeholder="e.g. 2x H100 nodes, AMD MI300X"
+            :disabled="form.hardware_ack"
+            :aria-invalid="!!fieldErrors.other_hardware && !form.hardware_ack"
+            :aria-describedby="fieldErrors.other_hardware ? 'req-other-hardware-error' : null"
+            class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            :class="fieldErrors.other_hardware ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+          ></textarea>
+          <label class="mt-2 inline-flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              id="req-hardware-ack"
+              v-model="form.hardware_ack"
+              type="checkbox"
+              class="mt-0.5 text-primary-600 border-gray-300 dark:border-gray-600 rounded"
+            />
+            <span>I confirm the package must support all supported accelerators (default)</span>
+          </label>
+          <p v-if="fieldErrors.other_hardware" id="req-other-hardware-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.other_hardware }}</p>
+        </fieldset>
+
+        <!-- Jira + justification -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label for="req-jira-id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Related Jira key <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="req-jira-id"
+              v-model="form.jira_id"
+              type="text"
+              required
+              autocomplete="off"
+              placeholder="e.g. AIPCC-1234"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.jira_id"
+              :aria-describedby="fieldErrors.jira_id ? 'req-jira-id-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.jira_id ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p v-if="fieldErrors.jira_id" id="req-jira-id-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.jira_id }}</p>
+          </div>
+
+          <div>
+            <label for="req-delivery-timeline" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Delivery date <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="req-delivery-timeline"
+              v-model="form.delivery_timeline"
+              type="date"
+              required
+              :min="minDeliveryDate"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.delivery_timeline"
+              :aria-describedby="fieldErrors.delivery_timeline ? 'req-delivery-timeline-error' : 'req-delivery-timeline-hint'"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.delivery_timeline ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            />
+            <p id="req-delivery-timeline-hint" class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              At least {{ MIN_LEAD_TIME_DAYS }} calendar days from today.
+            </p>
+            <p v-if="fieldErrors.delivery_timeline" id="req-delivery-timeline-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.delivery_timeline }}</p>
+          </div>
+
+          <div class="md:col-span-2">
+            <label for="req-justification" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Business justification <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <textarea
+              id="req-justification"
+              v-model="form.justification"
+              rows="3"
+              required
+              placeholder="Why does your team need this package?"
+              aria-required="true"
+              :aria-invalid="!!fieldErrors.justification"
+              :aria-describedby="fieldErrors.justification ? 'req-justification-error' : null"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :class="fieldErrors.justification ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+            ></textarea>
+            <p v-if="fieldErrors.justification" id="req-justification-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.justification }}</p>
+          </div>
+
+          <div>
+            <label for="req-release-target" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Release targets (optional)</label>
+            <input
+              id="req-release-target"
+              v-model="form.release_target"
+              type="text"
+              autocomplete="off"
+              placeholder="Comma-separated product versions, e.g. 3.4,3.5"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm font-mono focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+
+          <div>
+            <label for="req-release-commitment" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Release commitment (optional)</label>
+            <input
+              id="req-release-commitment"
+              v-model="form.release_commitment"
+              type="text"
+              autocomplete="off"
+              placeholder="e.g. 3.4 GA"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+        </div>
+
+        <!-- Testing -->
+        <fieldset class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <legend class="px-2 text-sm font-medium text-gray-700 dark:text-gray-300">Testing requirements <span class="text-red-500" aria-hidden="true">*</span> <span class="text-xs font-normal text-gray-400">(details or acknowledgement)</span></legend>
+          <label for="req-testing-requirements" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Testing beyond the defaults (optional)
+          </label>
+          <textarea
+            id="req-testing-requirements"
+            v-model="form.testing_requirements"
+            rows="2"
+            placeholder="e.g. Run the full wheel test suite on GPU CI"
+            :disabled="form.testing_ack"
+            :aria-invalid="!!fieldErrors.testing_requirements"
+            :aria-describedby="fieldErrors.testing_requirements ? 'req-testing-requirements-error' : null"
+            class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            :class="fieldErrors.testing_requirements ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
+          ></textarea>
+          <label class="mt-2 inline-flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              id="req-testing-ack"
+              v-model="form.testing_ack"
+              type="checkbox"
+              class="mt-0.5 text-primary-600 border-gray-300 dark:border-gray-600 rounded"
+            />
+            <span>I accept the default probe/import tests (no additional testing requirements)</span>
+          </label>
+          <p v-if="fieldErrors.testing_requirements" id="req-testing-requirements-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.testing_requirements }}</p>
+        </fieldset>
+
+        <!-- Actions -->
+        <div class="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            :disabled="submitting || !!warning"
+            class="px-5 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {{ submitting ? 'Submitting...' : 'Submit request' }}
+          </button>
+          <button
+            type="button"
+            @click="resetForm"
+            :disabled="submitting"
+            class="px-5 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+</template>

--- a/modules/product-builds/client/views/RequestPackageView.vue
+++ b/modules/product-builds/client/views/RequestPackageView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, watch } from 'vue'
 import { apiRequest } from '@shared/client/services/api'
 import { useAuth } from '@shared/client/composables/useAuth'
 
@@ -57,6 +57,31 @@ function defaults() {
 }
 
 const form = reactive(defaults())
+const teamProject = ref('RHAISTRAT')
+const teams = ref([])
+const loadingTeams = ref(false)
+const teamLoadError = ref('')
+let teamLoadId = 0
+
+async function loadTeams() {
+  const loadId = ++teamLoadId
+  form.team = ''
+  teams.value = []
+  teamLoadError.value = ''
+  loadingTeams.value = true
+  try {
+    const data = await apiRequest(`/modules/product-builds/package-requests/teams?project=${teamProject.value}`)
+    if (loadId !== teamLoadId) return
+    teams.value = data
+  } catch {
+    if (loadId !== teamLoadId) return
+    teamLoadError.value = 'Could not load teams. Please try again.'
+  } finally {
+    if (loadId === teamLoadId) loadingTeams.value = false
+  }
+}
+
+watch(teamProject, loadTeams, { immediate: true })
 const fieldErrors = ref({})
 const submitting = ref(false)
 const banner = ref(null) // { type, text } form-level message
@@ -73,7 +98,8 @@ function parseList(raw) {
 
 function validate() {
   const errors = {}
-  if (!form.team.trim()) errors.team = 'Team is required'
+  if (!form.team) errors.team = 'Team is required'
+  else if (!teams.value.some(team => team.value === form.team)) errors.team = 'Select a team from the list'
 
   if (!PACKAGE_NAME_RE.test(form.package_name.trim())) {
     errors.package_name = 'Package name must start with a letter and contain only letters, digits, dots, underscores or dashes'
@@ -220,6 +246,7 @@ function cancelWarning() {
 }
 
 function resetForm() {
+  teamProject.value = 'RHAISTRAT'
   Object.assign(form, defaults())
   fieldErrors.value = {}
   banner.value = null
@@ -398,25 +425,52 @@ function jiraHref(ticket) {
           The request is filed under your signed-in identity. The server treats the authenticated identity as authoritative.
         </p>
 
+        <div>
+          <label for="req-team-project" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Team's Jira project</label>
+          <select
+            id="req-team-project"
+            v-model="teamProject"
+            :disabled="submitting"
+            aria-describedby="req-team-project-hint"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="RHAISTRAT">RHAISTRAT</option>
+            <option value="AIPCC">AIPCC</option>
+            <option value="RHAI">RHAI</option>
+          </select>
+          <p id="req-team-project-hint" class="mt-1 text-xs text-gray-500 dark:text-gray-400">Choose the project your team belongs to. Package requests are filed in AIPCC.</p>
+        </div>
+
         <!-- Team + package -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label for="req-team" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Team <span class="text-red-500" aria-hidden="true">*</span>
             </label>
-            <input
+            <select
               id="req-team"
               v-model="form.team"
-              type="text"
               required
-              autocomplete="off"
-              placeholder="e.g. Platform"
+              :disabled="loadingTeams || !!teamLoadError || !teams.length || submitting"
               aria-required="true"
               :aria-invalid="!!fieldErrors.team"
-              :aria-describedby="fieldErrors.team ? 'req-team-error' : null"
-              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              :aria-describedby="fieldErrors.team ? 'req-team-error' : 'req-team-status'"
+              class="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
               :class="fieldErrors.team ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'"
-            />
+            >
+              <option value="" disabled>{{ loadingTeams ? 'Loading teams...' : 'Select a team' }}</option>
+              <option v-for="team in teams" :key="team.value" :value="team.value">{{ team.label }}</option>
+            </select>
+            <div id="req-team-status" class="mt-1 text-xs" aria-live="polite">
+              <p v-if="teamLoadError" class="text-red-600 dark:text-red-400">{{ teamLoadError }}</p>
+              <p v-else-if="!loadingTeams && !teams.length" class="text-gray-500 dark:text-gray-400">No teams are available for this project.</p>
+              <button
+                v-if="teamLoadError || (!loadingTeams && !teams.length)"
+                type="button"
+                class="mt-1 text-primary-600 dark:text-primary-400 underline"
+                @click="loadTeams"
+              >Retry loading teams</button>
+            </div>
             <p v-if="fieldErrors.team" id="req-team-error" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ fieldErrors.team }}</p>
           </div>
 
@@ -685,7 +739,7 @@ function jiraHref(ticket) {
         <div class="flex items-center gap-3 pt-2">
           <button
             type="submit"
-            :disabled="submitting || !!warning"
+            :disabled="submitting || !!warning || loadingTeams || !!teamLoadError || !teams.length"
             class="px-5 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {{ submitting ? 'Submitting...' : 'Submit request' }}

--- a/modules/product-builds/client/views/RequestPackageView.vue
+++ b/modules/product-builds/client/views/RequestPackageView.vue
@@ -438,7 +438,7 @@ function jiraHref(ticket) {
             <option value="AIPCC">AIPCC</option>
             <option value="RHAI">RHAI</option>
           </select>
-          <p id="req-team-project-hint" class="mt-1 text-xs text-gray-500 dark:text-gray-400">Choose the project your team belongs to. Package requests are filed in AIPCC.</p>
+          <p id="req-team-project-hint" class="mt-1 text-xs text-gray-500 dark:text-gray-400">Choose the project your team belongs to. This only selects the team list; it does not change where the request is filed.</p>
         </div>
 
         <!-- Team + package -->

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -15,6 +15,7 @@
       { "id": "base-images", "label": "Base Images", "icon": "PackageOpen" },
       { "id": "builder-images", "label": "Builder Images", "icon": "PackageOpen" },
       { "id": "wheel-collections", "label": "Wheel Collections", "icon": "PackageOpen" },
+      { "id": "package-request", "label": "Request Package", "icon": "FileUp" },
       { "id": "package-analysis", "label": "Package Analysis", "icon": "BarChart3", "separatorBefore": true }
     ],
     "hiddenRoutes": {

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -78,6 +78,16 @@
         "key": "TRACKER_SIZE_FIELD",
         "description": "JIRA custom field ID for size (defaults to customfield_10795)",
         "required": false
+      },
+      {
+        "key": "PACKAGE_REQUEST_JIRA_PROJECT",
+        "description": "Jira project key that receives package request Epics (defaults to AIPCC)",
+        "required": false
+      },
+      {
+        "key": "PACKAGE_ONBOARDING_GITLAB_TOKEN",
+        "description": "GitLab PAT with api scope and Developer access to redhat/rhel-ai/core/package-onboarding, used to trigger the onboarding pipeline. Without it the Epic is still filed and the pipeline is reported as not triggered.",
+        "required": false
       }
     ]
   },

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -1022,6 +1022,9 @@ module.exports = function registerRoutes(router, context) {
   // --- Package Tracker ---
   require('./package-tracker')(router, context);
 
+  // --- Package Requests ---
+  require('./package-requests')(router, context);
+
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
       const index = await readFromStorage(PKG_INDEX_PATH);

--- a/modules/product-builds/server/package-requests.js
+++ b/modules/product-builds/server/package-requests.js
@@ -1,0 +1,896 @@
+/**
+ * Package update requests.
+ *
+ * Authenticated POST endpoint that validates a package update request,
+ * verifies the related Jira issue, checks for recent duplicates, validates
+ * PyPI sources, warns when the package is already in a production index,
+ * files an AIPCC Epic, and triggers the package onboarding GitLab pipeline.
+ *
+ * All external operations (Jira, PyPI, package indexes, GitLab) go through
+ * small module-level functions. The register function accepts an optional
+ * `deps` argument ({ jiraClient, fetch, fetchIndex, isDemoMode, now }) so
+ * tests can mock them without live credentials.
+ */
+
+const { createJiraClient } = require('../../../shared/server/jira');
+const {
+  PACKAGE_NAME_RE,
+  VERSION_RE,
+  fetchIndex,
+  getBaseUrl,
+  getVariants,
+  getProductVersions,
+  pMap,
+  MAX_CONCURRENT_FETCHES
+} = require('./package-index');
+
+const AIPCC_PROJECT = 'AIPCC';
+const EPIC_LABELS = ['package', 'dashboard-filed'];
+const SECURITY_NAME = 'Red Hat Employee';
+const COMPONENT_NAME = 'Accelerator Enablement';
+const EPIC_NAME_FIELD = 'customfield_10011';
+const DEFAULT_TARGET_VERSION_FIELD = 'customfield_10855';
+const PACKAGE_ONBOARDING_PROJECT = 'redhat%2Frhel-ai%2Fcore%2Fpackage-onboarding';
+const PACKAGE_ONBOARDING_BASE_URL = 'https://gitlab.com';
+
+const JIRA_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const PACKAGE_SOURCES = ['pypi', 'git', 'other'];
+const MIN_LEAD_TIME_DAYS = 8;
+const DUPLICATE_LOOKBACK_DAYS = 30;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const EXTERNAL_TIMEOUT_MS = 30_000;
+const PYPI_JSON_BASE = 'https://pypi.org/pypi';
+
+// --- Validation ---
+
+function isAtLeastDaysFromToday(dateStr, minDays, now = new Date()) {
+  const today = new Date(now);
+  today.setUTCHours(0, 0, 0, 0);
+  const target = new Date(dateStr + 'T00:00:00Z');
+  if (isNaN(target.getTime())) return false;
+  return Math.round((target - today) / 86_400_000) >= minDays;
+}
+
+/**
+ * Validate a package request body.
+ * @param {object} body - Parsed JSON request body
+ * @param {{ now?: Date }} [opts]
+ * @returns {{ valid: boolean, errors: object, request: object }}
+ */
+function validateRequest(body, opts = {}) {
+  const now = opts.now || new Date();
+  const errors = {};
+
+  const team = typeof body.team === 'string' ? body.team.trim() : '';
+  if (!team) {
+    errors.team = 'Team is required';
+  }
+
+  const packageName = typeof body.package_name === 'string' ? body.package_name.trim() : '';
+  if (!PACKAGE_NAME_RE.test(packageName)) {
+    errors.package_name = 'Package name must match ' + PACKAGE_NAME_RE.source;
+  }
+
+  let extras = null;
+  if (body.extras !== null && body.extras !== undefined) {
+    if (!Array.isArray(body.extras)) {
+      errors.extras = 'Extras must be an array of identifiers or null';
+    } else {
+      const seen = new Set();
+      extras = [];
+      for (const item of body.extras) {
+        const value = typeof item === 'string' ? item.trim() : '';
+        if (!SAFE_IDENTIFIER_RE.test(value)) {
+          errors.extras = 'Each extra must be a safe identifier (letters, digits, dot, underscore, dash; no spaces)';
+          break;
+        }
+        const key = value.toLowerCase();
+        if (seen.has(key)) {
+          errors.extras = `Extras must not contain duplicates (${value})`;
+          break;
+        }
+        seen.add(key);
+        extras.push(value);
+      }
+    }
+  }
+
+  const source = body.package_source;
+  if (!PACKAGE_SOURCES.includes(source)) {
+    errors.package_source = 'Package source must be one of: ' + PACKAGE_SOURCES.join(', ');
+  }
+
+  let sourceUrl = '';
+  if (body.source_url !== null && body.source_url !== undefined) {
+    sourceUrl = typeof body.source_url === 'string' ? body.source_url.trim() : '';
+  }
+  if (source === 'git' || source === 'other') {
+    if (!sourceUrl) {
+      errors.source_url = 'Source URL is required for git and other package sources';
+    } else if (!/^https?:\/\//i.test(sourceUrl)) {
+      errors.source_url = 'Source URL must be an HTTP or HTTPS URL';
+    }
+  }
+
+  let version = '';
+  if (body.version !== null && body.version !== undefined) {
+    version = typeof body.version === 'string' ? body.version.trim() : '';
+  }
+  if (version && !VERSION_RE.test(version)) {
+    errors.version = 'Version must match ' + VERSION_RE.source;
+  }
+
+  const otherHardware = typeof body.other_hardware === 'string' ? body.other_hardware.trim() : '';
+  const hardwareAck = body.hardware_defaults_acknowledged === true;
+  if (!otherHardware && !hardwareAck) {
+    errors.other_hardware = 'Provide other hardware details or acknowledge the hardware defaults';
+  }
+
+  const jiraId = typeof body.jira_id === 'string' ? body.jira_id.trim() : '';
+  if (!JIRA_KEY_RE.test(jiraId)) {
+    errors.jira_id = 'Jira key must match ' + JIRA_KEY_RE.source;
+  }
+
+  const justification = typeof body.justification === 'string' ? body.justification.trim() : '';
+  if (!justification) {
+    errors.justification = 'Justification is required';
+  }
+
+  const deliveryTimeline = typeof body.delivery_timeline === 'string' ? body.delivery_timeline.trim() : '';
+  if (!DATE_RE.test(deliveryTimeline)) {
+    errors.delivery_timeline = 'Delivery timeline must be a date in YYYY-MM-DD format';
+  } else if (!isAtLeastDaysFromToday(deliveryTimeline, MIN_LEAD_TIME_DAYS, now)) {
+    errors.delivery_timeline = `Delivery timeline must be at least ${MIN_LEAD_TIME_DAYS} calendar days from today`;
+  }
+
+  let releaseTarget = null;
+  if (body.release_target !== null && body.release_target !== undefined) {
+    if (!Array.isArray(body.release_target) ||
+        body.release_target.some(v => typeof v !== 'string' || !v.trim())) {
+      errors.release_target = 'Release target must be an array of version strings or null';
+    } else {
+      releaseTarget = body.release_target.map(v => v.trim());
+    }
+  }
+
+  const releaseCommitment = typeof body.release_commitment === 'string' ? body.release_commitment.trim() : '';
+
+  const testingRequirements = typeof body.testing_requirements === 'string' ? body.testing_requirements.trim() : '';
+  const testingAck = body.testing_defaults_acknowledged === true;
+  if (!testingRequirements && !testingAck) {
+    errors.testing_requirements = 'Provide testing requirements or acknowledge the testing defaults';
+  }
+
+  let backportVersions = null;
+  if (body.backport_versions !== null && body.backport_versions !== undefined) {
+    if (!Array.isArray(body.backport_versions) ||
+        body.backport_versions.some(v => typeof v !== 'string' || !v.trim())) {
+      errors.backport_versions = 'Backport versions must be an array of version strings or null';
+    } else {
+      backportVersions = body.backport_versions.map(v => v.trim());
+    }
+  }
+
+  const skipProductionCheck = body.skip_production_check === true;
+
+  return {
+    valid: Object.keys(errors).length === 0,
+    errors,
+    request: {
+      team,
+      packageName,
+      extras,
+      source,
+      sourceUrl,
+      version,
+      otherHardware,
+      hardwareAck,
+      jiraId,
+      justification,
+      deliveryTimeline,
+      releaseTarget,
+      releaseCommitment,
+      testingRequirements,
+      testingAck,
+      backportVersions,
+      skipProductionCheck
+    }
+  };
+}
+
+// --- Jira payload building ---
+
+function buildEpicSummary(packageName, extras) {
+  const suffix = extras && extras.length > 0 ? '[' + extras.join(',') + ']' : '';
+  return packageName + suffix + ' package update request';
+}
+
+function buildEpicName(packageName) {
+  return packageName + ' package update request';
+}
+
+function sanitizeTeamLabel(team) {
+  const slug = String(team || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return 'team-' + (slug || 'unknown');
+}
+
+function adfText(t) {
+  return { type: 'text', text: String(t) };
+}
+
+function adfLink(text, href) {
+  return { type: 'text', text: String(text), marks: [{ type: 'link', attrs: { href: String(href) } }] };
+}
+
+function adfLabel(t) {
+  return { type: 'text', text: String(t), marks: [{ type: 'strong' }] };
+}
+
+function adfParagraph(content) {
+  return { type: 'paragraph', content };
+}
+
+/**
+ * Build the ADF description for the Jira Epic. Label casing matches the
+ * package-tracker description parser (Team, Requester, Target Date,
+ * Release Commitment, Related Jira Ticket).
+ */
+function buildAdfDescription(request, requesterEmail, jiraHost) {
+  const lines = [];
+
+  lines.push([
+    adfLabel('Team: '),
+    adfText(request.team + ' ')
+  ]);
+
+  const extrasSuffix = request.extras && request.extras.length > 0
+    ? '[' + request.extras.join(',') + ']'
+    : '';
+  lines.push([
+    adfLabel('Package: '),
+    adfText(request.packageName + extrasSuffix + (request.version ? ' ' + request.version : '') + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Requester: '),
+    adfText(requesterEmail + ' ')
+  ]);
+
+  const sourceLine = [
+    adfLabel('Package source: '),
+    adfText(request.source)
+  ];
+  if (request.sourceUrl) {
+    sourceLine.push(adfLink(request.sourceUrl, request.sourceUrl));
+  }
+  sourceLine.push(adfText(' '));
+  lines.push(sourceLine);
+
+  if (request.otherHardware) {
+    lines.push([
+      adfLabel('Other hardware: '),
+      adfText(request.otherHardware + ' ')
+    ]);
+  }
+
+  lines.push([
+    adfLabel('Hardware defaults acknowledged: '),
+    adfText((request.hardwareAck ? 'yes' : 'no') + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Justification: '),
+    adfText(request.justification + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Target Date: '),
+    adfText(request.deliveryTimeline + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Related Jira Ticket: '),
+    adfLink(request.jiraId, jiraHost + '/browse/' + request.jiraId),
+    adfText(' ')
+  ]);
+
+  lines.push([
+    adfLabel('Release Commitment: '),
+    adfText((request.releaseCommitment || 'N/A') + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Testing requirements: '),
+    adfText((request.testingRequirements || 'N/A') + ' ')
+  ]);
+
+  lines.push([
+    adfLabel('Testing defaults acknowledged: '),
+    adfText((request.testingAck ? 'yes' : 'no') + ' ')
+  ]);
+
+  if (request.releaseTarget && request.releaseTarget.length > 0) {
+    lines.push([
+      adfLabel('Release target: '),
+      adfText(request.releaseTarget.join(', ') + ' ')
+    ]);
+  }
+
+  if (request.backportVersions && request.backportVersions.length > 0) {
+    lines.push([
+      adfLabel('Backport versions: '),
+      adfText(request.backportVersions.join(', ') + ' ')
+    ]);
+  }
+
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      { type: 'heading', attrs: { level: 2 }, content: [adfText('Package Update Request')] },
+      ...lines.map(adfParagraph)
+    ]
+  };
+}
+
+/**
+ * Build the fields payload for creating the AIPCC Epic.
+ */
+function buildEpicFields(request, requesterEmail, { jiraHost, reporterAccountId, epicNameField } = {}) {
+  const fields = {
+    project: { key: AIPCC_PROJECT },
+    issuetype: { name: 'Epic' },
+    summary: buildEpicSummary(request.packageName, request.extras),
+    description: buildAdfDescription(request, requesterEmail, jiraHost),
+    labels: [...EPIC_LABELS, sanitizeTeamLabel(request.team)],
+    duedate: request.deliveryTimeline,
+    security: { name: SECURITY_NAME },
+    components: [{ name: COMPONENT_NAME }],
+    [epicNameField || EPIC_NAME_FIELD]: buildEpicName(request.packageName)
+  };
+  if (reporterAccountId) {
+    fields.reporter = { accountId: reporterAccountId };
+  }
+  return fields;
+}
+
+function buildDuplicateJql(packageName) {
+  return `project = ${AIPCC_PROJECT} AND issuetype = Epic ` +
+    `AND labels in ("package", "dashboard-filed") ` +
+    `AND summary ~ "*${packageName}*" ` +
+    `AND created >= -${DUPLICATE_LOOKBACK_DAYS}d AND statusCategory != Done`;
+}
+
+// --- External operations (injectable for tests) ---
+
+/**
+ * Resolve the requester's Jira accountId via user search.
+ * Non-fatal: returns null when the user cannot be resolved.
+ */
+async function findReporterAccountId(jira, email) {
+  try {
+    const params = new URLSearchParams({ query: email, maxResults: '10' });
+    const data = await jira.jiraRequest(`/rest/api/3/user/search?${params}`);
+    const users = (data && data.users) || [];
+    const match = users.find(u => u && u.email && u.email.toLowerCase() === email.toLowerCase());
+    return match ? match.accountId : null;
+  } catch (err) {
+    console.warn('[package-requests] Jira user search failed:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Verify the related Jira issue exists.
+ * @returns {Promise<{key: string, summary: string}|null>}
+ */
+async function validateRelatedIssue(jira, jiraId) {
+  const data = await jira.jiraRequest(
+    `/rest/api/3/issue/${encodeURIComponent(jiraId)}?fields=summary,status`
+  );
+  if (!data || !data.key) return null;
+  return { key: data.key, summary: (data.fields && data.fields.summary) || '' };
+}
+
+/**
+ * Search for recent duplicate package update request Epics.
+ */
+async function findDuplicateRequests(jira, packageName, jiraHost) {
+  const issues = await jira.fetchAllJqlResults(
+    buildDuplicateJql(packageName),
+    'key,summary,status,created,updated',
+    { maxResults: 50 }
+  );
+  return issues.map(issue => ({
+    key: issue.key,
+    summary: (issue.fields && issue.fields.summary) || '',
+    status: (issue.fields && issue.fields.status && issue.fields.status.name) || '',
+    created: (issue.fields && issue.fields.created) || null,
+    url: jiraHost + '/browse/' + issue.key
+  }));
+}
+
+/**
+ * Validate that the package exists on PyPI via its JSON API.
+ * @returns {Promise<{found: boolean}>}
+ */
+async function checkPypiPackage(packageName, fetchFn) {
+  const url = PYPI_JSON_BASE + '/' + encodeURIComponent(packageName) + '/json';
+  const response = await fetchFn(url, {
+    headers: { 'Accept': 'application/json' },
+    signal: AbortSignal.timeout(EXTERNAL_TIMEOUT_MS)
+  });
+  if (response.ok) return { found: true };
+  if (response.status === 404) return { found: false };
+  throw new Error(`PyPI API returned HTTP ${response.status}`);
+}
+
+/**
+ * Check production package indexes for the package.
+ * @returns {Promise<Array<{product_version: string, variant: string, index_url: string, files: string[]}>>}
+ */
+async function checkProductionIndexes(packageName, opts = {}) {
+  const indexFetch = opts.fetchIndexFn || fetchIndex;
+  const base = (opts.baseUrl || getBaseUrl()).replace(/\/+$/, '');
+  const variants = opts.variants || getVariants();
+  const productVersions = opts.productVersions || getProductVersions();
+
+  const tasks = [];
+  for (const pv of productVersions) {
+    for (const variant of variants) {
+      // Production index suffix is '' (see ALL_REPO_TYPES in package-index.js)
+      const indexUrl = `${base}/${pv}/${variant}/simple/`;
+      tasks.push({ pv, variant, indexUrl });
+    }
+  }
+
+  const results = await pMap(tasks, async (task) => {
+    try {
+      const raw = await indexFetch(task.indexUrl, packageName);
+      if (raw && raw.found && Array.isArray(raw.files) && raw.files.length > 0) {
+        return {
+          product_version: task.pv,
+          variant: task.variant,
+          index_url: task.indexUrl,
+          files: raw.files.map(f => f.filename).slice(0, 10)
+        };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, MAX_CONCURRENT_FETCHES);
+
+  return results.filter(Boolean);
+}
+
+function getGitLabConfig() {
+  return {
+    gitlabBaseUrl: PACKAGE_ONBOARDING_BASE_URL,
+    gitlabProject: PACKAGE_ONBOARDING_PROJECT
+  };
+}
+
+function getGitlabToken(secrets) {
+  return (secrets && (secrets.GITLAB_TOKEN || secrets.NIGHTLY_PIPELINE_GITLAB_TOKEN)) || null;
+}
+
+function buildPipelineVariables(request, epicKey) {
+  const packageName = request.extras && request.extras.length > 0
+    ? request.packageName + '[' + request.extras.join(',') + ']'
+    : request.packageName;
+  const variables = {
+    PACKAGE_NAME: packageName,
+    JIRA_TICKET_ID: epicKey
+  };
+  if (request.version) variables.PACKAGE_VERSION = request.version;
+  return variables;
+}
+
+/**
+ * Trigger the package onboarding GitLab pipeline.
+ * @returns {Promise<{triggered: boolean, pipeline_id: number|null, web_url: string|null}>}
+ */
+async function triggerOnboardingPipeline({ gitlabBaseUrl, gitlabProject, token, variables, fetchFn }) {
+  const fetchImpl = fetchFn || fetch;
+  const url = `${gitlabBaseUrl}/api/v4/projects/${gitlabProject}/pipelines`;
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'PRIVATE-TOKEN': token,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ ref: 'main', variables }),
+    signal: AbortSignal.timeout(EXTERNAL_TIMEOUT_MS)
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`GitLab pipeline trigger failed (${response.status}): ${text.slice(0, 200)}`);
+  }
+  const data = await response.json();
+  return { triggered: true, pipeline_id: data.id || null, web_url: data.web_url || null };
+}
+
+// --- In-memory rate limiting: one submission per user per 60 seconds ---
+
+const _lastSubmission = new Map();
+
+function checkRateLimit(email, now = Date.now()) {
+  const key = String(email).toLowerCase();
+  const last = _lastSubmission.get(key);
+  if (last !== undefined && now - last < RATE_LIMIT_WINDOW_MS) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.ceil((RATE_LIMIT_WINDOW_MS - (now - last)) / 1000)
+    };
+  }
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+function recordSubmission(email, now = Date.now()) {
+  _lastSubmission.set(String(email).toLowerCase(), now);
+  if (_lastSubmission.size > 1000) {
+    for (const [key, ts] of _lastSubmission) {
+      if (now - ts >= RATE_LIMIT_WINDOW_MS) _lastSubmission.delete(key);
+    }
+  }
+}
+
+function isDemoMode(deps) {
+  if (deps && typeof deps.isDemoMode === 'function') return deps.isDemoMode() === true;
+  if (deps && typeof deps.isDemoMode === 'boolean') return deps.isDemoMode;
+  return process.env.DEMO_MODE === 'true';
+}
+
+// --- Route registration ---
+
+/**
+ * @param {import('express').Router} router
+ * @param {{ secrets?: Record<string, string>, resolveSecret?: Function, requireAuth?: Function }} context
+ * @param {{ jiraClient?: object, fetch?: Function, fetchIndex?: Function, isDemoMode?: Function|boolean, now?: Function }} [deps]
+ */
+module.exports = function registerPackageRequestRoutes(router, context, deps = {}) {
+  const secrets = (context && context.secrets) || {};
+  const fetchImpl = deps.fetch || fetch;
+  const noopAuth = function (_req, _res, next) { next(); };
+  const requireAuth = (context && context.requireAuth) || noopAuth;
+
+  let _jira;
+  function getJira() {
+    if (deps.jiraClient) return deps.jiraClient;
+    if (!_jira) {
+      _jira = createJiraClient({
+        email: secrets.JIRA_EMAIL || '',
+        token: secrets.JIRA_TOKEN || ''
+      });
+    }
+    return _jira;
+  }
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/package-requests:
+   *   post:
+   *     tags: [Package Requests]
+   *     summary: Submit a package update request
+   *     description: >-
+   *       Authenticated endpoint that validates a package update request,
+   *       verifies the related Jira issue, checks for recent duplicate
+   *       requests, validates PyPI sources, and warns when the package is
+   *       already present in a production index. On success it files an AIPCC
+   *       Epic with its required Epic Name field, due date, team label, Red Hat
+   *       Employee security, and Accelerator Enablement component, sets the
+   *       release target field when provided, and triggers the
+   *       redhat/rhel-ai/core/package-onboarding GitLab pipeline. Pipeline
+   *       failure is non-fatal.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [team, package_name, package_source, jira_id, justification, delivery_timeline]
+   *             properties:
+   *               team:
+   *                 type: string
+   *                 description: Requesting team name
+   *               package_name:
+   *                 type: string
+   *                 description: Python package name
+   *               extras:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                 nullable: true
+   *                 description: Optional extras (e.g. cu12)
+   *               package_source:
+   *                 type: string
+   *                 enum: [pypi, git, other]
+   *               source_url:
+   *                 type: string
+   *                 nullable: true
+   *                 description: Required HTTP(S) URL for git/other sources
+   *               version:
+   *                 type: string
+   *                 nullable: true
+   *               other_hardware:
+   *                 type: string
+   *                 description: Hardware beyond the defaults, or empty when acknowledging defaults
+   *               hardware_defaults_acknowledged:
+   *                 type: boolean
+   *               jira_id:
+   *                 type: string
+   *                 description: Related Jira issue key (must exist)
+   *               justification:
+   *                 type: string
+   *               delivery_timeline:
+   *                 type: string
+   *                 format: date
+   *                 description: Desired delivery date (YYYY-MM-DD), at least 8 calendar days out
+   *               release_target:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                 nullable: true
+   *                 description: Target product versions
+   *               release_commitment:
+   *                 type: string
+   *               testing_requirements:
+   *                 type: string
+   *                 description: Testing beyond the defaults, or empty when acknowledging defaults
+   *               testing_defaults_acknowledged:
+   *                 type: boolean
+   *               backport_versions:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                 nullable: true
+   *               skip_production_check:
+   *                 type: boolean
+   *                 description: Skip the production index presence check
+   *     responses:
+   *       200:
+   *         description: Warning when the package is already in a production index (no Epic created), or deterministic demo-mode success
+   *       201:
+   *         description: Epic created; onboarding pipeline triggered (or failure reported non-fatally)
+   *       400:
+   *         description: Request body is not a JSON object
+   *       401:
+   *         description: Unauthenticated (no user email available)
+   *       409:
+   *         description: A recent duplicate request exists (existing_tickets returned)
+   *       422:
+   *         description: Validation failed (per-field errors)
+   *       429:
+   *         description: >-
+   *           Rate limited (one submission per user per 60 seconds). The limit
+   *           slot is only consumed when a submission actually proceeds to Epic
+   *           creation, so a 200 production-presence warning does not block an
+   *           immediate retry with skip_production_check:true.
+   *       502:
+   *         description: Jira Epic creation or PyPI validation failed
+   *       503:
+   *         description: Jira is not configured
+   */
+  router.post('/package-requests', requireAuth, async function(req, res) {
+    try {
+      const email = String(req.userEmail || (req.user && req.user.email) || '').toLowerCase().trim();
+      if (!email) {
+        return res.status(401).json({ error: 'Authentication required. No user email available.' });
+      }
+
+      if (req.body !== undefined && req.body !== null &&
+          (typeof req.body !== 'object' || Array.isArray(req.body))) {
+        return res.status(400).json({ error: 'Request body must be a JSON object' });
+      }
+      const body = (req.body && typeof req.body === 'object' && !Array.isArray(req.body)) ? req.body : {};
+
+      const now = deps.now ? deps.now() : new Date();
+      const validation = validateRequest(body, { now });
+      if (!validation.valid) {
+        return res.status(422).json({ error: 'Validation failed', fields: validation.errors });
+      }
+      const request = validation.request;
+
+      // Rate limit gate only. The slot is consumed when the request actually
+      // proceeds to Epic creation (or completes in demo mode), so aborting
+      // responses (422/409/502/503) and the 200 production-presence warning
+      // do not block an immediate retry.
+      const limit = checkRateLimit(email, Date.now());
+      if (!limit.allowed) {
+        return res.status(429).json({
+          error: 'Rate limited: one package request per user per 60 seconds',
+          retry_after_seconds: limit.retryAfterSeconds
+        });
+      }
+
+      if (isDemoMode(deps)) {
+        recordSubmission(email);
+        return res.status(200).json({
+          status: 'created',
+          demo: true,
+          requester: email,
+          summary: buildEpicSummary(request.packageName, request.extras),
+          jira: { key: 'AIPCC-DEMO', url: null },
+          pipeline: { triggered: false, reason: 'demo mode' }
+        });
+      }
+
+      if (!deps.jiraClient && (!secrets.JIRA_EMAIL || !secrets.JIRA_TOKEN)) {
+        return res.status(503).json({ error: 'Jira is not configured (JIRA_EMAIL/JIRA_TOKEN missing)' });
+      }
+      const jira = getJira();
+      const jiraHost = jira.JIRA_HOST;
+
+      // Verify the related Jira issue before doing anything else.
+      let related = null;
+      try {
+        related = await validateRelatedIssue(jira, request.jiraId);
+      } catch (err) {
+        console.warn('[package-requests] Related issue lookup failed:', err.message);
+      }
+      if (!related) {
+        return res.status(422).json({
+          error: 'Validation failed',
+          fields: { jira_id: `Related Jira issue ${request.jiraId} was not found or could not be verified` }
+        });
+      }
+
+      // Check recent duplicates (fail open on search errors).
+      let duplicates = [];
+      try {
+        duplicates = await findDuplicateRequests(jira, request.packageName, jiraHost);
+      } catch (err) {
+        console.warn('[package-requests] Duplicate search failed:', err.message);
+      }
+      if (duplicates.length > 0) {
+        return res.status(409).json({
+          error: 'A recent package update request already exists for this package',
+          existing_tickets: duplicates
+        });
+      }
+
+      // Validate PyPI sources via the PyPI JSON API.
+      if (request.source === 'pypi') {
+        let pypi;
+        try {
+          pypi = await checkPypiPackage(request.packageName, fetchImpl);
+        } catch (err) {
+          return res.status(502).json({ error: 'PyPI validation failed: ' + err.message });
+        }
+        if (!pypi.found) {
+          return res.status(422).json({
+            error: 'Validation failed',
+            fields: { package_source: `Package "${request.packageName}" was not found on PyPI` }
+          });
+        }
+      }
+
+      // Check production indexes; warn instead of creating a duplicate Epic.
+      if (!request.skipProductionCheck) {
+        const foundIn = await checkProductionIndexes(request.packageName, {
+          fetchIndexFn: deps.fetchIndex,
+          baseUrl: deps.indexBaseUrl,
+          variants: deps.indexVariants,
+          productVersions: deps.indexProductVersions
+        });
+        if (foundIn.length > 0) {
+          return res.status(200).json({
+            status: 'warning',
+            warning: 'package_already_in_production',
+            package_name: request.packageName,
+            found_in: foundIn,
+            message: 'This package is already present in at least one production index. Review before filing a duplicate request.',
+            skipped: true
+          });
+        }
+      }
+
+      // All gates passed; this submission proceeds to Epic creation.
+      recordSubmission(email);
+
+      // Resolve the reporter from the authenticated email (non-fatal).
+      const reporterAccountId = await findReporterAccountId(jira, email);
+
+      // Create the AIPCC Epic.
+      const fields = buildEpicFields(request, email, { jiraHost, reporterAccountId });
+      let created;
+      try {
+        created = await jira.jiraRequest('/rest/api/3/issue', { method: 'POST', body: { fields } });
+      } catch (err) {
+        console.error('[package-requests] Jira Epic creation failed:', err.message);
+        return res.status(502).json({ error: 'Failed to create Jira Epic: ' + err.message });
+      }
+      const epicKey = created.key;
+
+      // Set the release target custom field when present (non-fatal).
+      let releaseTargetSet = false;
+      if (request.releaseTarget && request.releaseTarget.length > 0) {
+        const targetField = (context && context.resolveSecret)
+          ? (context.resolveSecret('TRACKER_TARGET_VERSION_FIELD') || DEFAULT_TARGET_VERSION_FIELD)
+          : DEFAULT_TARGET_VERSION_FIELD;
+        try {
+          await jira.jiraRequest(`/rest/api/3/issue/${encodeURIComponent(epicKey)}`, {
+            method: 'PUT',
+            body: { fields: { [targetField]: request.releaseTarget.map(v => ({ name: v })) } }
+          });
+          releaseTargetSet = true;
+        } catch (err) {
+          console.warn('[package-requests] Failed to set release target (non-fatal):', err.message);
+        }
+      }
+
+      // Trigger the package onboarding GitLab pipeline (non-fatal).
+      let pipeline;
+      const gitlabToken = getGitlabToken(secrets);
+      if (!gitlabToken) {
+        pipeline = { triggered: false, reason: 'gitlab_token_not_configured' };
+      } else {
+        const gitlab = getGitLabConfig();
+        try {
+          pipeline = await triggerOnboardingPipeline({
+            gitlabBaseUrl: gitlab.gitlabBaseUrl,
+            gitlabProject: gitlab.gitlabProject,
+            token: gitlabToken,
+            variables: buildPipelineVariables(request, epicKey),
+            fetchFn: deps.fetch
+          });
+        } catch (err) {
+          console.warn('[package-requests] Pipeline trigger failed (non-fatal):', err.message);
+          pipeline = { triggered: false, error: err.message };
+        }
+      }
+
+      res.status(201).json({
+        status: 'created',
+        requester: email,
+        summary: fields.summary,
+        jira: {
+          key: epicKey,
+          id: created.id || null,
+          url: jiraHost + '/browse/' + epicKey,
+          summary: fields.summary
+        },
+        related_issue: related,
+        release_target_set: releaseTargetSet,
+        pipeline
+      });
+    } catch (err) {
+      console.error('[package-requests] Unexpected error:', err.message);
+      res.status(500).json({ error: 'Failed to process package request' });
+    }
+  });
+};
+
+module.exports._testExports = {
+  validateRequest,
+  isAtLeastDaysFromToday,
+  buildEpicSummary,
+  buildEpicName,
+  sanitizeTeamLabel,
+  buildAdfDescription,
+  buildEpicFields,
+  buildDuplicateJql,
+  buildPipelineVariables,
+  checkPypiPackage,
+  checkProductionIndexes,
+  findDuplicateRequests,
+  validateRelatedIssue,
+  findReporterAccountId,
+  triggerOnboardingPipeline,
+  getGitLabConfig,
+  getGitlabToken,
+  checkRateLimit,
+  recordSubmission,
+  isDemoMode,
+  _lastSubmission,
+  AIPCC_PROJECT,
+  SECURITY_NAME,
+  COMPONENT_NAME,
+  EPIC_NAME_FIELD,
+  JIRA_KEY_RE,
+  RATE_LIMIT_WINDOW_MS
+};

--- a/modules/product-builds/server/package-requests.js
+++ b/modules/product-builds/server/package-requests.js
@@ -40,8 +40,22 @@ const PACKAGE_SOURCES = ['pypi', 'git', 'other'];
 const MIN_LEAD_TIME_DAYS = 8;
 const DUPLICATE_LOOKBACK_DAYS = 30;
 const RATE_LIMIT_WINDOW_MS = 60_000;
+const TEAM_OPTIONS_CACHE_TTL_MS = 5 * 60_000;
 const EXTERNAL_TIMEOUT_MS = 30_000;
 const PYPI_JSON_BASE = 'https://pypi.org/pypi';
+const TEAM_PROJECTS = ['RHAISTRAT', 'AIPCC', 'RHAI'];
+const AIPCC_TEAM_OPTIONS = [
+  'Accelerator Enablement',
+  'AIPCC Ecosystems',
+  'AIPCC Productization',
+  'Development Platform',
+  'Model Validation'
+].map(name => ({ value: name, label: name }));
+const DEMO_TEAM_OPTIONS = {
+  RHAISTRAT: [{ value: 'AI Core Platform', label: 'AI Core Platform' }],
+  AIPCC: AIPCC_TEAM_OPTIONS,
+  RHAI: AIPCC_TEAM_OPTIONS
+};
 
 // --- Validation ---
 
@@ -373,8 +387,9 @@ async function findReporterAccountId(jira, email) {
   try {
     const params = new URLSearchParams({ query: email, maxResults: '10' });
     const data = await jira.jiraRequest(`/rest/api/3/user/search?${params}`);
-    const users = (data && data.users) || [];
-    const match = users.find(u => u && u.email && u.email.toLowerCase() === email.toLowerCase());
+    const users = Array.isArray(data) ? data : [];
+    const match = users.find(u => u && u.emailAddress &&
+      u.emailAddress.toLowerCase() === email.toLowerCase());
     return match ? match.accountId : null;
   } catch (err) {
     console.warn('[package-requests] Jira user search failed:', err.message);
@@ -489,13 +504,36 @@ function buildPipelineVariables(request, epicKey) {
   return variables;
 }
 
+const _teamOptionsCache = new Map();
+
+async function getTeamOptions(jira, project, now = Date.now()) {
+  const cached = _teamOptionsCache.get(project);
+  if (cached && now - cached.fetchedAt < TEAM_OPTIONS_CACHE_TTL_MS) {
+    return cached.options;
+  }
+
+  const data = await jira.jiraRequest(
+    `/rest/api/3/project/${encodeURIComponent(project)}/components`
+  );
+  const names = new Set();
+  for (const component of Array.isArray(data) ? data : []) {
+    const name = String((component && component.name) || '').trim();
+    if (name) names.add(name);
+  }
+  const options = Array.from(names)
+    .sort((a, b) => a.localeCompare(b))
+    .map(name => ({ value: name, label: name }));
+  _teamOptionsCache.set(project, { fetchedAt: now, options });
+  return options;
+}
+
 /**
  * Trigger the package onboarding GitLab pipeline.
  * @returns {Promise<{triggered: boolean, pipeline_id: number|null, web_url: string|null}>}
  */
 async function triggerOnboardingPipeline({ gitlabBaseUrl, gitlabProject, token, variables, fetchFn }) {
   const fetchImpl = fetchFn || fetch;
-  const url = `${gitlabBaseUrl}/api/v4/projects/${gitlabProject}/pipelines`;
+  const url = `${gitlabBaseUrl}/api/v4/projects/${gitlabProject}/pipeline`;
   const response = await fetchImpl(url, {
     method: 'POST',
     headers: {
@@ -503,7 +541,10 @@ async function triggerOnboardingPipeline({ gitlabBaseUrl, gitlabProject, token, 
       'Content-Type': 'application/json',
       'Accept': 'application/json'
     },
-    body: JSON.stringify({ ref: 'main', variables }),
+    body: JSON.stringify({
+      ref: 'main',
+      variables: Object.entries(variables).map(([key, value]) => ({ key, value }))
+    }),
     signal: AbortSignal.timeout(EXTERNAL_TIMEOUT_MS)
   });
   if (!response.ok) {
@@ -517,6 +558,7 @@ async function triggerOnboardingPipeline({ gitlabBaseUrl, gitlabProject, token, 
 // --- In-memory rate limiting: one submission per user per 60 seconds ---
 
 const _lastSubmission = new Map();
+const _pendingSubmissions = new Set();
 
 function checkRateLimit(email, now = Date.now()) {
   const key = String(email).toLowerCase();
@@ -537,6 +579,17 @@ function recordSubmission(email, now = Date.now()) {
       if (now - ts >= RATE_LIMIT_WINDOW_MS) _lastSubmission.delete(key);
     }
   }
+}
+
+function beginSubmission(email) {
+  const key = String(email).toLowerCase();
+  if (_pendingSubmissions.has(key)) return false;
+  _pendingSubmissions.add(key);
+  return true;
+}
+
+function endSubmission(email) {
+  _pendingSubmissions.delete(String(email).toLowerCase());
 }
 
 function isDemoMode(deps) {
@@ -572,6 +625,74 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
 
   /**
    * @openapi
+   * /api/modules/product-builds/package-requests/teams:
+   *   get:
+   *     tags: [Package Requests]
+   *     summary: List Jira component options for package-request teams
+   *     description: >-
+   *       Returns a cached, alphabetically sorted list of Jira project
+   *       components shaped as value/label options. The project defaults to
+   *       RHAISTRAT and is restricted to RHAISTRAT, AIPCC, or RHAI.
+   *     parameters:
+   *       - in: query
+   *         name: project
+   *         schema:
+   *           type: string
+   *           enum: [RHAISTRAT, AIPCC, RHAI]
+   *           default: RHAISTRAT
+   *     responses:
+   *       200:
+   *         description: Sorted Jira component options
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *                 required: [value, label]
+   *                 properties:
+   *                   value:
+   *                     type: string
+   *                   label:
+   *                     type: string
+   *       400:
+   *         description: Unsupported Jira project
+   *       401:
+   *         description: Unauthenticated
+   *       502:
+   *         description: Jira component lookup failed
+   *       503:
+   *         description: Jira is not configured
+   */
+  router.get('/package-requests/teams', requireAuth, async function(req, res) {
+    const requestedProject = req.query && req.query.project;
+    const project = requestedProject === undefined ? 'RHAISTRAT' : String(requestedProject).trim();
+    if (!TEAM_PROJECTS.includes(project)) {
+      return res.status(400).json({
+        error: 'Invalid project',
+        message: 'Project must be one of: ' + TEAM_PROJECTS.join(', ')
+      });
+    }
+
+    if (isDemoMode(deps)) {
+      return res.json(DEMO_TEAM_OPTIONS[project]);
+    }
+
+    if (!deps.jiraClient && (!secrets.JIRA_EMAIL || !secrets.JIRA_TOKEN)) {
+      return res.status(503).json({ error: 'Jira is not configured (JIRA_EMAIL/JIRA_TOKEN missing)' });
+    }
+
+    try {
+      const options = await getTeamOptions(getJira(), project);
+      return res.json(options);
+    } catch (err) {
+      console.error('[package-requests] Jira component lookup failed:', err.message);
+      return res.status(502).json({ error: 'Failed to fetch teams from Jira' });
+    }
+  });
+
+  /**
+   * @openapi
    * /api/modules/product-builds/package-requests:
    *   post:
    *     tags: [Package Requests]
@@ -585,7 +706,9 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
    *       Employee security, and Accelerator Enablement component, sets the
    *       release target field when provided, and triggers the
    *       redhat/rhel-ai/core/package-onboarding GitLab pipeline. Pipeline
-   *       failure is non-fatal.
+   *       failure is non-fatal. The per-user cooldown starts only after Jira
+   *       confirms Epic creation; an in-flight guard prevents concurrent
+   *       requests from the same user from creating duplicate Epics.
    *     requestBody:
    *       required: true
    *       content:
@@ -666,16 +789,17 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
    *         description: Validation failed (per-field errors)
    *       429:
    *         description: >-
-   *           Rate limited (one submission per user per 60 seconds). The limit
-   *           slot is only consumed when a submission actually proceeds to Epic
-   *           creation, so a 200 production-presence warning does not block an
-   *           immediate retry with skip_production_check:true.
+   *           A request from this user is already in flight, or the user is
+   *           within the 60-second cooldown after successful Epic creation. A
+   *           failed Jira creation and a 200 production-presence warning do not
+   *           consume the cooldown slot.
    *       502:
    *         description: Jira Epic creation or PyPI validation failed
    *       503:
    *         description: Jira is not configured
    */
   router.post('/package-requests', requireAuth, async function(req, res) {
+    let pendingEmail = null;
     try {
       const email = String(req.userEmail || (req.user && req.user.email) || '').toLowerCase().trim();
       if (!email) {
@@ -695,8 +819,8 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
       }
       const request = validation.request;
 
-      // Rate limit gate only. The slot is consumed when the request actually
-      // proceeds to Epic creation (or completes in demo mode), so aborting
+      // Rate limit gate only. The slot is consumed when Jira confirms Epic
+      // creation (or the request completes in demo mode), so aborting
       // responses (422/409/502/503) and the 200 production-presence warning
       // do not block an immediate retry.
       const limit = checkRateLimit(email, Date.now());
@@ -706,6 +830,14 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
           retry_after_seconds: limit.retryAfterSeconds
         });
       }
+
+      if (!beginSubmission(email)) {
+        return res.status(429).json({
+          error: 'A package request for this user is already being processed',
+          retry_after_seconds: 1
+        });
+      }
+      pendingEmail = email;
 
       if (isDemoMode(deps)) {
         recordSubmission(email);
@@ -789,9 +921,6 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
         }
       }
 
-      // All gates passed; this submission proceeds to Epic creation.
-      recordSubmission(email);
-
       // Resolve the reporter from the authenticated email (non-fatal).
       const reporterAccountId = await findReporterAccountId(jira, email);
 
@@ -805,6 +934,10 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
         return res.status(502).json({ error: 'Failed to create Jira Epic: ' + err.message });
       }
       const epicKey = created.key;
+
+      // Jira confirmed creation. Start the cooldown before optional follow-up
+      // work so non-fatal release-target or pipeline failures retain it.
+      recordSubmission(email);
 
       // Set the release target custom field when present (non-fatal).
       let releaseTargetSet = false;
@@ -844,7 +977,7 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
         }
       }
 
-      res.status(201).json({
+      return res.status(201).json({
         status: 'created',
         requester: email,
         summary: fields.summary,
@@ -861,6 +994,8 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
     } catch (err) {
       console.error('[package-requests] Unexpected error:', err.message);
       res.status(500).json({ error: 'Failed to process package request' });
+    } finally {
+      if (pendingEmail) endSubmission(pendingEmail);
     }
   });
 };
@@ -875,6 +1010,7 @@ module.exports._testExports = {
   buildEpicFields,
   buildDuplicateJql,
   buildPipelineVariables,
+  getTeamOptions,
   checkPypiPackage,
   checkProductionIndexes,
   findDuplicateRequests,
@@ -885,12 +1021,18 @@ module.exports._testExports = {
   getGitlabToken,
   checkRateLimit,
   recordSubmission,
+  beginSubmission,
+  endSubmission,
   isDemoMode,
   _lastSubmission,
+  _pendingSubmissions,
+  _teamOptionsCache,
   AIPCC_PROJECT,
   SECURITY_NAME,
   COMPONENT_NAME,
   EPIC_NAME_FIELD,
   JIRA_KEY_RE,
-  RATE_LIMIT_WINDOW_MS
+  RATE_LIMIT_WINDOW_MS,
+  TEAM_OPTIONS_CACHE_TTL_MS,
+  TEAM_PROJECTS
 };

--- a/modules/product-builds/server/package-requests.js
+++ b/modules/product-builds/server/package-requests.js
@@ -4,7 +4,8 @@
  * Authenticated POST endpoint that validates a package update request,
  * verifies the related Jira issue, checks for recent duplicates, validates
  * PyPI sources, warns when the package is already in a production index,
- * files an AIPCC Epic, and triggers the package onboarding GitLab pipeline.
+ * files an Epic in the configured Jira project (PACKAGE_REQUEST_JIRA_PROJECT,
+ * default AIPCC), and triggers the package onboarding GitLab pipeline.
  *
  * All external operations (Jira, PyPI, package indexes, GitLab) go through
  * small module-level functions. The register function accepts an optional
@@ -24,7 +25,8 @@ const {
   MAX_CONCURRENT_FETCHES
 } = require('./package-index');
 
-const AIPCC_PROJECT = 'AIPCC';
+const DEFAULT_JIRA_PROJECT = 'AIPCC';
+const JIRA_PROJECT_KEY_RE = /^[A-Z][A-Z0-9]+$/;
 const EPIC_LABELS = ['package', 'dashboard-filed'];
 const SECURITY_NAME = 'Red Hat Employee';
 const COMPONENT_NAME = 'Accelerator Enablement';
@@ -352,9 +354,9 @@ function buildAdfDescription(request, requesterEmail, jiraHost) {
 /**
  * Build the fields payload for creating the AIPCC Epic.
  */
-function buildEpicFields(request, requesterEmail, { jiraHost, reporterAccountId, epicNameField } = {}) {
+function buildEpicFields(request, requesterEmail, { jiraHost, reporterAccountId, epicNameField, jiraProject } = {}) {
   const fields = {
-    project: { key: AIPCC_PROJECT },
+    project: { key: jiraProject || DEFAULT_JIRA_PROJECT },
     issuetype: { name: 'Epic' },
     summary: buildEpicSummary(request.packageName, request.extras),
     description: buildAdfDescription(request, requesterEmail, jiraHost),
@@ -370,8 +372,8 @@ function buildEpicFields(request, requesterEmail, { jiraHost, reporterAccountId,
   return fields;
 }
 
-function buildDuplicateJql(packageName) {
-  return `project = ${AIPCC_PROJECT} AND issuetype = Epic ` +
+function buildDuplicateJql(packageName, jiraProject = DEFAULT_JIRA_PROJECT) {
+  return `project = ${jiraProject} AND issuetype = Epic ` +
     `AND labels in ("package", "dashboard-filed") ` +
     `AND summary ~ "*${packageName}*" ` +
     `AND created >= -${DUPLICATE_LOOKBACK_DAYS}d AND statusCategory != Done`;
@@ -410,15 +412,42 @@ async function validateRelatedIssue(jira, jiraId) {
 }
 
 /**
- * Search for recent duplicate package update request Epics.
+ * Reduce an Epic summary to a comparable key: lowercase package name plus
+ * sorted, lowercase extras. Returns null when the summary does not follow the
+ * package update request template, so unrelated Epics never count as
+ * duplicates.
  */
-async function findDuplicateRequests(jira, packageName, jiraHost) {
+function normalizeRequestSummary(summary) {
+  const match = String(summary || '').trim()
+    .match(/^([^[\]\s]+)(?:\[([^\]]*)\])?\s+package update request$/i);
+  if (!match) return null;
+  const extras = (match[2] || '')
+    .split(',')
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean)
+    .sort();
+  return match[1].toLowerCase() + '[' + extras.join(',') + ']';
+}
+
+/**
+ * Search for recent duplicate package update request Epics.
+ *
+ * The JQL wildcard search is broad (it matches any summary containing the
+ * package name), so results are filtered to the exact package + extras
+ * combination. torch[cuda] and torch[rocm] are therefore distinct requests,
+ * and torch does not collide with torchvision.
+ */
+async function findDuplicateRequests(jira, { packageName, extras, jiraHost, jiraProject }) {
   const issues = await jira.fetchAllJqlResults(
-    buildDuplicateJql(packageName),
+    buildDuplicateJql(packageName, jiraProject),
     'key,summary,status,created,updated',
     { maxResults: 50 }
   );
-  return issues.map(issue => ({
+  const target = normalizeRequestSummary(buildEpicSummary(packageName, extras));
+  return issues.filter(issue => {
+    const summary = issue && issue.fields && issue.fields.summary;
+    return normalizeRequestSummary(summary) === target;
+  }).map(issue => ({
     key: issue.key,
     summary: (issue.fields && issue.fields.summary) || '',
     status: (issue.fields && issue.fields.status && issue.fields.status.name) || '',
@@ -488,8 +517,31 @@ function getGitLabConfig() {
   };
 }
 
+/**
+ * Token used to create pipelines in the package-onboarding project. Creating
+ * a pipeline needs a PAT with the `api` scope and Developer access to the
+ * project, which the read-only platform GITLAB_TOKEN does not have, so only
+ * the dedicated secret is honoured. Without it the Epic is still filed and
+ * the pipeline is reported as not triggered.
+ */
 function getGitlabToken(secrets) {
-  return (secrets && (secrets.GITLAB_TOKEN || secrets.NIGHTLY_PIPELINE_GITLAB_TOKEN)) || null;
+  return (secrets && secrets.PACKAGE_ONBOARDING_GITLAB_TOKEN) || null;
+}
+
+/**
+ * Jira project that receives package request Epics. Read from the
+ * PACKAGE_REQUEST_JIRA_PROJECT secret declared in module.json; falls back to
+ * AIPCC when unset or not a valid project key.
+ */
+function resolveJiraProject(secrets) {
+  const raw = secrets && secrets.PACKAGE_REQUEST_JIRA_PROJECT;
+  const value = typeof raw === 'string' ? raw.trim().toUpperCase() : '';
+  if (!value) return DEFAULT_JIRA_PROJECT;
+  if (!JIRA_PROJECT_KEY_RE.test(value)) {
+    console.warn(`[package-requests] Ignoring invalid PACKAGE_REQUEST_JIRA_PROJECT "${raw}"; using ${DEFAULT_JIRA_PROJECT}`);
+    return DEFAULT_JIRA_PROJECT;
+  }
+  return value;
 }
 
 function buildPipelineVariables(request, epicKey) {
@@ -607,6 +659,7 @@ function isDemoMode(deps) {
  */
 module.exports = function registerPackageRequestRoutes(router, context, deps = {}) {
   const secrets = (context && context.secrets) || {};
+  const jiraProject = resolveJiraProject(secrets);
   const fetchImpl = deps.fetch || fetch;
   const noopAuth = function (_req, _res, next) { next(); };
   const requireAuth = (context && context.requireAuth) || noopAuth;
@@ -701,12 +754,16 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
    *       Authenticated endpoint that validates a package update request,
    *       verifies the related Jira issue, checks for recent duplicate
    *       requests, validates PyPI sources, and warns when the package is
-   *       already present in a production index. On success it files an AIPCC
-   *       Epic with its required Epic Name field, due date, team label, Red Hat
-   *       Employee security, and Accelerator Enablement component, sets the
+   *       already present in a production index. On success it files an Epic
+   *       in the configured Jira project (PACKAGE_REQUEST_JIRA_PROJECT, default
+   *       AIPCC) with its required Epic Name field, due date, team label, Red
+   *       Hat Employee security, and Accelerator Enablement component, sets the
    *       release target field when provided, and triggers the
-   *       redhat/rhel-ai/core/package-onboarding GitLab pipeline. Pipeline
-   *       failure is non-fatal. The per-user cooldown starts only after Jira
+   *       redhat/rhel-ai/core/package-onboarding GitLab pipeline using
+   *       PACKAGE_ONBOARDING_GITLAB_TOKEN. Pipeline failure, or a missing
+   *       pipeline token, is non-fatal. Duplicate detection compares the full
+   *       package name including extras, so torch[cuda] and torch[rocm] are
+   *       distinct requests. The per-user cooldown starts only after Jira
    *       confirms Epic creation; an in-flight guard prevents concurrent
    *       requests from the same user from creating duplicate Epics.
    *     requestBody:
@@ -846,7 +903,7 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
           demo: true,
           requester: email,
           summary: buildEpicSummary(request.packageName, request.extras),
-          jira: { key: 'AIPCC-DEMO', url: null },
+          jira: { key: jiraProject + '-DEMO', url: null, project: jiraProject },
           pipeline: { triggered: false, reason: 'demo mode' }
         });
       }
@@ -874,7 +931,12 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
       // Check recent duplicates (fail open on search errors).
       let duplicates = [];
       try {
-        duplicates = await findDuplicateRequests(jira, request.packageName, jiraHost);
+        duplicates = await findDuplicateRequests(jira, {
+          packageName: request.packageName,
+          extras: request.extras,
+          jiraHost,
+          jiraProject
+        });
       } catch (err) {
         console.warn('[package-requests] Duplicate search failed:', err.message);
       }
@@ -924,8 +986,8 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
       // Resolve the reporter from the authenticated email (non-fatal).
       const reporterAccountId = await findReporterAccountId(jira, email);
 
-      // Create the AIPCC Epic.
-      const fields = buildEpicFields(request, email, { jiraHost, reporterAccountId });
+      // Create the Epic in the configured Jira project.
+      const fields = buildEpicFields(request, email, { jiraHost, reporterAccountId, jiraProject });
       let created;
       try {
         created = await jira.jiraRequest('/rest/api/3/issue', { method: 'POST', body: { fields } });
@@ -985,7 +1047,8 @@ module.exports = function registerPackageRequestRoutes(router, context, deps = {
           key: epicKey,
           id: created.id || null,
           url: jiraHost + '/browse/' + epicKey,
-          summary: fields.summary
+          summary: fields.summary,
+          project: jiraProject
         },
         related_issue: related,
         release_target_set: releaseTargetSet,
@@ -1009,6 +1072,7 @@ module.exports._testExports = {
   buildAdfDescription,
   buildEpicFields,
   buildDuplicateJql,
+  normalizeRequestSummary,
   buildPipelineVariables,
   getTeamOptions,
   checkPypiPackage,
@@ -1019,6 +1083,7 @@ module.exports._testExports = {
   triggerOnboardingPipeline,
   getGitLabConfig,
   getGitlabToken,
+  resolveJiraProject,
   checkRateLimit,
   recordSubmission,
   beginSubmission,
@@ -1027,7 +1092,7 @@ module.exports._testExports = {
   _lastSubmission,
   _pendingSubmissions,
   _teamOptionsCache,
-  AIPCC_PROJECT,
+  DEFAULT_JIRA_PROJECT,
   SECURITY_NAME,
   COMPONENT_NAME,
   EPIC_NAME_FIELD,

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -54,6 +54,7 @@ export const viewOwners = {
   'product-builds/drop-detail':                    'Pavol Pitonak',
   'product-builds/overview':                       'Giulia Naponiello',
   'product-builds/package-analysis':               'Einat Pacifici',
+  'product-builds/package-request':                'Andre Lustosa',
   'product-builds/rhaiis':                         'Pavol Pitonak',
   'product-builds/rhel-ai':                        'Pavol Pitonak',
   'product-builds/search':                         'Rishabh Kothari',

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -139,7 +139,6 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
-  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -38,6 +38,27 @@ test.describe('Product Builds Module @product-builds', () => {
     expect(appErrors).toHaveLength(0);
   });
 
+  test('should expose the Request Package navigation item and form', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME)
+
+    const requestLink = page.locator('aside').getByText('Request Package', { exact: true })
+    await expect(requestLink).toBeVisible()
+    await page.goto('/#/product-builds/package-request')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME)
+
+    expect(page.url()).toMatch(/product-builds\/package-request/)
+    await expect(page.getByRole('heading', { name: 'Request Package' })).toBeVisible()
+    await expect(page.locator('#req-team')).toBeVisible()
+    await expect(page.locator('#req-package-name')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Submit request' })).toBeVisible()
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message))
+    expect(appErrors).toHaveLength(0)
+  })
+
   test('should navigate to RHAIIS view', async ({ page }) => {
     await page.goto('/#/product-builds/rhaiis');
     await page.waitForLoadState('networkidle');

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -43,20 +43,75 @@ test.describe('Product Builds Module @product-builds', () => {
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME)
 
+    await page.locator('aside').getByRole('button', { name: 'Product Builds', exact: true }).click()
     const requestLink = page.locator('aside').getByText('Request Package', { exact: true })
     await expect(requestLink).toBeVisible()
-    await page.goto('/#/product-builds/package-request')
+    await requestLink.click()
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME)
 
     expect(page.url()).toMatch(/product-builds\/package-request/)
     await expect(page.getByRole('heading', { name: 'Request Package' })).toBeVisible()
-    await expect(page.locator('#req-team')).toBeVisible()
+    const team = page.getByRole('combobox', { name: 'Team', exact: true })
+    await expect(team).toBeVisible()
+    await expect(team).toBeEnabled()
+    for (const project of ['AIPCC', 'RHAI']) {
+      const responsePromise = page.waitForResponse(response => response.url().includes(`/package-requests/teams?project=${project}`))
+      await page.locator('#req-team-project').selectOption(project)
+      const response = await responsePromise
+      expect(response.ok()).toBe(true)
+      const options = await response.json()
+      expect(options.length).toBeGreaterThan(0)
+      for (const option of options) {
+        expect(option).toEqual({ value: expect.any(String), label: expect.any(String) })
+      }
+      await team.selectOption(options[0].value)
+      await expect(team).toHaveValue(options[0].value)
+    }
     await expect(page.locator('#req-package-name')).toBeVisible()
     await expect(page.getByRole('button', { name: 'Submit request' })).toBeVisible()
 
     const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message))
     expect(appErrors).toHaveLength(0)
+  })
+
+  test('should retry a failed package request with the selected team', async ({ page }) => {
+    // Only the submission response is simulated; the form and team endpoint are real.
+    const submissions = []
+    await page.route('**/api/modules/product-builds/package-requests', async route => {
+      submissions.push(route.request().postDataJSON())
+      if (submissions.length === 1) {
+        await route.fulfill({ status: 502, json: { error: 'Failed to create Jira Epic' } })
+      } else {
+        await route.fulfill({ status: 201, json: {
+          status: 'created', jira: { key: 'AIPCC-999', url: 'https://redhat.atlassian.net/browse/AIPCC-999' },
+          pipeline: { triggered: true, web_url: 'https://gitlab.com/example/-/pipelines/777' }
+        } })
+      }
+    })
+    await page.goto('/#/product-builds/package-request')
+    await page.locator('#req-team-project').selectOption('RHAI')
+    const team = page.locator('#req-team')
+    await expect(team).toBeEnabled()
+    const option = await team.locator('option:not([disabled])').first().getAttribute('value')
+    await team.selectOption(option)
+    await page.locator('#req-package-name').fill('vllm')
+    await page.locator('#req-jira-id').fill('RHAI-892')
+    await page.locator('#req-justification').fill('Package required for the release')
+    const date = new Date()
+    date.setUTCDate(date.getUTCDate() + 30)
+    await page.locator('#req-delivery-timeline').fill(date.toISOString().slice(0, 10))
+    await page.locator('#req-hardware-ack').check()
+    await page.locator('#req-testing-ack').check()
+    await page.getByRole('button', { name: 'Submit request', exact: true }).click()
+    await expect(page.getByText(/Failed to create Jira Epic/)).toBeVisible()
+    await expect(team).toHaveValue(option)
+    await page.getByRole('button', { name: 'Submit request', exact: true }).click()
+    await expect(page.getByText('Package request submitted')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'View pipeline' })).toBeVisible()
+    expect(submissions).toHaveLength(2)
+    expect(submissions[0].team).toBe(option)
+    expect(submissions[1]).toEqual(submissions[0])
   })
 
   test('should navigate to RHAIIS view', async ({ page }) => {


### PR DESCRIPTION
## Summary
- restore the Product Builds package request workflow with a dedicated Vue form and navigation entry
- preserve the existing package request API contract and handle success, warnings, duplicates, validation, rate limits, upstream errors, and network failures
- set the required Jira Epic Name field correctly and trigger the actual package-onboarding pipeline contract
- add focused Vitest coverage and Product Builds Playwright coverage

## Validation
- Focused Vitest: 59 tests passed
- npm run lint
- npm run validate:modules
- npm run validate:openapi
- npm run build
- Playwright integration test attempted, but local Chromium is not installed


