### PR TITLE
AIPCC-31376: Correct Autofix funnel methodology

### DIFF
--- a/docs/AI-AUTOFIX-REPORTING.md
+++ b/docs/AI-AUTOFIX-REPORTING.md
@@ -1,0 +1,62 @@
+# Jira Autofix reporting methodology
+
+The Jira Autofix report keeps two cohorts separate.
+
+## Gross policy cohort
+
+The gross cohort query selects `type = Bug` in configured Autofix projects. It
+excludes only deterministic issue markers that are observable without mutable
+workflow state:
+
+- `summary !~ "CVE-"`
+- label `CVE`
+- `summary !~ "EMBARGOED"`
+- security level `Embargoed Security Issue`
+
+It does not exclude closed or resolved tickets, `no-autofix`, or
+`auto-created`. A ticket can have been eligible before it was closed or a
+mutable opt-out label was added. The gross denominator therefore includes
+those tickets and supports detection of work missed before pickup.
+
+The report also exposes a current non-excluded snapshot. This snapshot removes
+current `no-autofix`, `auto-created`, and `CVE` labels from the gross result.
+It is a current-state diagnostic, not a historical eligibility denominator.
+
+The query can be scoped with `autofixComponents`. When no component scope is
+configured, the report marks the project-wide result as a non-authoritative
+fallback because component-level policy ownership is unavailable.
+
+## Pipeline cohort
+
+The existing label query remains separate. It counts issues carrying a Jira
+Autofix or triage label, including `jira-autofix-stale`. The ready share is
+named `Pipeline-ready Share`; it is not an eligibility rate. Jira labels are
+mutable and do not prove that a ticket passed policy gates at a historical
+time.
+
+## Lifecycle funnel
+
+The report displays eligible, analyzed, PR proposed, and PR merged stages. It
+also displays abandonment (stale, rejected, and max-retry outcomes) separately
+from blocked workflow friction, with conversion rates between nested stages.
+
+The preferred source is the immutable Autofix lifecycle outcome contract from
+AIPCC-31384. This repository consumes canonical event fields only. It does not
+copy or own that schema. Until the producer and contract MR land, the report
+uses gross Jira cohort data, Jira pipeline labels, and Forge API responses as
+proxy evidence and marks the funnel non-authoritative.
+
+Event rows do not imply complete ingestion. The funnel is authoritative only
+when the snapshot explicitly sets `outcomeEventsComplete` and the event source
+provides canonical events for the reporting window. The API reports malformed
+and out-of-window event counts separately.
+
+Project, issue-type, and component filters are currently client-side and do not
+receive the gross cohort rows. The UI therefore hides the funnel while one of
+those filters is active instead of presenting unfiltered counts as team-level
+results.
+
+Forge proposal or merge evidence is verified only when an Autofix Jira comment
+contains a GitHub PR or GitLab MR URL and the existing Forge client fetches its
+status. A Jira link without a fetched status is an unverified lower bound. A
+Jira label alone is not Forge verification.

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -2,6 +2,21 @@
 
 This document describes the JSON structure of all files stored in the `data/` directory (production) and `fixtures/` directory (demo mode). **Demo fixtures must always match production format** — see [Fixture Rules](#fixture-rules) below.
 
+## Jira Autofix — `data/ai-impact/autofix-data.json`
+
+The Autofix snapshot keeps the existing `issues` pipeline-labeled cohort and
+adds `policyEligibleIssues`, the gross Bug cohort returned by the separate
+policy query. The gross query excludes CVE summary or label markers and
+embargoed issues. It does not exclude closed status or mutable opt-out labels.
+`currentPolicyEligibleIssues` is a separate current non-excluded snapshot that
+removes current `no-autofix`, `auto-created`, and `CVE` labels. It is a
+diagnostic snapshot, not a historical eligibility denominator.
+
+`metrics.stageFunnel` reports eligible, analyzed, PR proposed, PR merged,
+abandonment, and conversions. Its `authoritative` flag is true only when
+canonical immutable events from the AIPCC-31384 Autofix outcome contract are
+available. Jira label and Forge-link fallbacks are explicitly non-authoritative.
+
 ## Person Metrics — `data/people/{name}.json`
 
 Filename is the person's display name lowercased with non-alphanumeric chars replaced by `_`.

--- a/fixtures/ai-impact/autofix-data.json
+++ b/fixtures/ai-impact/autofix-data.json
@@ -1,5 +1,19 @@
 {
   "fetchedAt": "2026-04-22T05:17:38.418Z",
+  "policyEligibleIssues": [],
+  "currentPolicyEligibleIssues": [],
+  "outcomeEvents": [],
+  "outcomeEventsComplete": false,
+  "evidence": {
+    "pipeline": "Jira labels",
+    "policyEligible": "Demo fixture does not include live gross Bug cohort",
+    "stageContract": "AIPCC-31384 lifecycle outcome contract dependency",
+    "policyScope": "project-wide fallback; component scope not configured"
+  },
+  "queries": {
+    "pipeline": null,
+    "policyEligible": null
+  },
   "issues": [
     {
       "key": "RHOAIENG-59199",

--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -11,7 +11,16 @@ const {
   getLastWeekBounds,
   getWindowBounds,
   computeAutofixMetrics,
-  buildTrendData
+  buildTrendData,
+  buildPolicyEligibleJql,
+  getPolicyExclusionReasons,
+  isPolicyEligibleIssue,
+  isCurrentPolicyEligibleIssue,
+  computePolicyEligibleCohort,
+  computeStageFunnel,
+  normalizeOutcomeEvent,
+  extractForgeLinks,
+  buildForgeEvidence
 } = require('../../server/jira/autofix-fetcher')
 
 describe('classifyIssue', () => {
@@ -25,6 +34,10 @@ describe('classifyIssue', () => {
 
   it('returns autofix-max-retries for jira-autofix-max-retries', () => {
     expect(classifyIssue(['jira-autofix-max-retries'])).toBe('autofix-max-retries')
+  })
+
+  it('returns autofix-stale for jira-autofix-stale', () => {
+    expect(classifyIssue(['jira-autofix-stale'])).toBe('autofix-stale')
   })
 
   it('returns autofix-ci-failing for jira-autofix-ci-failing', () => {
@@ -174,9 +187,209 @@ describe('computeAutofixMetrics', () => {
     expect(m.successRate).toBe(50)
   })
 
+  it('includes stale in terminal outcomes and abandonment', () => {
+    const m = computeAutofixMetrics([
+      { created: recent, pipelineState: 'autofix-stale', components: [] },
+      { created: recent, pipelineState: 'autofix-merged', components: [] }
+    ], 'last7')
+    expect(m.autofixStates.stale).toBe(1)
+    expect(m.terminalTotal).toBe(2)
+    expect(m.stageFunnel.abandonment.stale).toBe(1)
+  })
+
   it('returns zero success rate when no terminal autofix issues in window', () => {
     const m = computeAutofixMetrics([], 'last7')
     expect(m.successRate).toBe(0)
+  })
+})
+
+describe('policy cohort methodology', () => {
+  const base = {
+    issueType: 'Bug',
+    status: 'New',
+    labels: [],
+    summary: 'A normal bug',
+    created: new Date().toISOString(),
+    pipelineState: 'unknown',
+    components: []
+  }
+
+  it('builds gross policy query with explicit immutable exclusions and no status exclusion', () => {
+    const jql = buildPolicyEligibleJql({
+      autofixProjects: ['AIPCC'],
+      autofixComponents: ['Model Server'],
+      autofixCreatedAfter: '2026-01-01'
+    })
+    expect(jql).toContain('type = Bug')
+    expect(jql).toContain('labels NOT IN ("CVE")')
+    expect(jql).toContain('summary !~ "CVE-"')
+    expect(jql).toContain('Embargoed Security Issue')
+    expect(jql).toContain('component IN ("Model Server")')
+    expect(jql).not.toContain('status NOT IN')
+    expect(jql).not.toContain('no-autofix')
+  })
+
+  it('keeps mutable opt-out labels in gross cohort but removes them from current snapshot', () => {
+    const closed = { ...base, status: 'Closed', labels: ['no-autofix'] }
+    expect(isPolicyEligibleIssue(closed)).toBe(true)
+    expect(isCurrentPolicyEligibleIssue(closed)).toBe(false)
+    expect(getPolicyExclusionReasons({ ...base, labels: ['CVE'] })).toContain('cve_label')
+    expect(isPolicyEligibleIssue({ ...base, summary: 'CVE-2026-1234' })).toBe(false)
+    expect(isPolicyEligibleIssue({ ...base, securityLevel: 'Embargoed Security Issue' })).toBe(false)
+  })
+
+  it('returns gross denominator and current non-excluded snapshot separately', () => {
+    const cohort = computePolicyEligibleCohort([
+      { ...base },
+      { ...base, key: 'AIPCC-2', labels: ['no-autofix'] },
+      { ...base, key: 'AIPCC-3', summary: 'CVE-2026-1234' }
+    ], 'last7', 'project-wide fallback')
+    expect(cohort.denominator).toBe(2)
+    expect(cohort.currentSnapshot).toBe(1)
+    expect(cohort.exclusionCounts).toBeNull()
+    expect(cohort.exclusionCountsAvailable).toBe(false)
+    expect(cohort.scope).toBe('project-wide fallback')
+  })
+
+  it('uses issue creation time for gross cohort windows, not terminal time', () => {
+    const oldCreated = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+    const recentTerminal = new Date().toISOString()
+    const cohort = computePolicyEligibleCohort([
+      { ...base, created: oldCreated, terminalAt: recentTerminal, pipelineState: 'autofix-merged' }
+    ], 'last7')
+    expect(cohort.candidateCount).toBe(0)
+  })
+})
+
+describe('lifecycle funnel evidence', () => {
+  const recent = new Date().toISOString()
+
+  it('reports stage conversions and abandonment from Jira and Forge proxy evidence', () => {
+    const policy = [
+      { key: 'AIPCC-1', issueType: 'Bug', status: 'New', labels: [], summary: 'One', created: recent },
+      { key: 'AIPCC-2', issueType: 'Bug', status: 'New', labels: [], summary: 'Two', created: recent },
+      { key: 'AIPCC-3', issueType: 'Bug', status: 'New', labels: [], summary: 'Three', created: recent }
+    ]
+    const pipeline = [
+      { key: 'AIPCC-1', created: recent, pipelineState: 'autofix-review', components: [], mrLinks: [], mrStatuses: {} },
+      { key: 'AIPCC-2', created: recent, pipelineState: 'autofix-stale', components: [], mrLinks: [], mrStatuses: {} },
+      { key: 'AIPCC-3', created: recent, pipelineState: 'autofix-blocked', components: [], mrLinks: [], mrStatuses: {} }
+    ]
+    const funnel = computeStageFunnel(pipeline, policy, [], 'last7')
+    expect(funnel.authoritative).toBe(false)
+    expect(funnel.stages).toEqual({ eligible: 3, analyzed: 3, prProposed: 2, prMerged: 0 })
+    expect(funnel.abandonment.stale).toBe(1)
+    expect(funnel.abandonment.total).toBe(1)
+    expect(funnel.blocked).toBe(1)
+    expect(funnel.conversions.eligibleToAnalyzed.rate).toBe(100)
+  })
+
+  it('accepts canonical contract events and rejects aliases or legacy timestamps', () => {
+    const event = {
+      schema_version: '1.0',
+      event_type: 'jira_autofix.lifecycle.outcome',
+      event_id: `outcome-v1-${'a'.repeat(64)}`,
+      correlation_id: 'run-1',
+      attempt: 1,
+      stage: 'proposal',
+      final_outcome: 'proposed',
+      cohort_timestamp: recent,
+      transition_timestamp: recent,
+      correlation: { jira_key: 'AIPCC-1' },
+      metrics: {},
+      metadata: {}
+    }
+    expect(normalizeOutcomeEvent(event)).not.toBeNull()
+    expect(normalizeOutcomeEvent({ ...event, stage: 'proposed' })).toBeNull()
+    expect(normalizeOutcomeEvent({ ...event, cohort_timestamp: undefined, event_timestamp: recent })).toBeNull()
+    expect(normalizeOutcomeEvent({ ...event, event_id: `outcome-v2-${'a'.repeat(64)}` })).toBeNull()
+    expect(normalizeOutcomeEvent({
+      ...event,
+      cohort_timestamp: '2026-09-04T12:00:00Z',
+      transition_timestamp: '2026-09-04T11:59:59Z'
+    })).toBeNull()
+  })
+
+  it('separates malformed events from valid events outside the reporting window', () => {
+    const event = {
+      schema_version: '1.0',
+      event_type: 'jira_autofix.lifecycle.outcome',
+      event_id: `outcome-v1-${'b'.repeat(64)}`,
+      correlation_id: 'run-2',
+      attempt: 1,
+      stage: 'policy_eligibility',
+      final_outcome: 'eligible',
+      cohort_timestamp: '2020-01-01T00:00:00Z',
+      transition_timestamp: '2020-01-01T00:00:00Z',
+      correlation: { jira_key: 'AIPCC-2' },
+      metrics: {},
+      metadata: {}
+    }
+    const funnel = computeStageFunnel([], [], [event, { invalid: true }], 'last7')
+    expect(funnel.eventStats.invalid).toBe(1)
+    expect(funnel.eventStats.outsideWindow).toBe(1)
+  })
+
+  it('uses complete canonical events, filters ineligible eligibility events, and keeps blocked separate', () => {
+    const event = {
+      schema_version: '1.0',
+      event_type: 'jira_autofix.lifecycle.outcome',
+      correlation_id: 'run-3',
+      attempt: 1,
+      cohort_timestamp: recent,
+      transition_timestamp: recent,
+      correlation: { jira_key: 'AIPCC-3' },
+      metrics: {},
+      metadata: {}
+    }
+    const events = [
+      { ...event, event_id: `outcome-v1-${'c'.repeat(64)}`, stage: 'policy_eligibility', final_outcome: 'eligible' },
+      { ...event, event_id: `outcome-v1-${'d'.repeat(64)}`, stage: 'policy_eligibility', final_outcome: 'ineligible' },
+      { ...event, event_id: `outcome-v1-${'e'.repeat(64)}`, stage: 'blocked', final_outcome: 'blocked' }
+    ]
+    const funnel = computeStageFunnel([], [], events, 'last7', { outcomeEventsComplete: true })
+    expect(funnel.authoritative).toBe(true)
+    expect(funnel.stages.eligible).toBe(1)
+    expect(funnel.abandonment.total).toBe(0)
+    expect(funnel.blocked).toBe(1)
+  })
+
+  it('keeps complete event stages nested within the eligible cohort', () => {
+    const base = {
+      schema_version: '1.0',
+      event_type: 'jira_autofix.lifecycle.outcome',
+      correlation_id: 'run-4',
+      attempt: 1,
+      cohort_timestamp: recent,
+      transition_timestamp: recent,
+      metrics: {},
+      metadata: {}
+    }
+    const events = [
+      { ...base, event_id: `outcome-v1-${'1'.repeat(64)}`, stage: 'policy_eligibility', final_outcome: 'eligible', correlation: { jira_key: 'AIPCC-1' } },
+      { ...base, event_id: `outcome-v1-${'2'.repeat(64)}`, stage: 'analysis', final_outcome: 'analyzed', correlation: { jira_key: 'AIPCC-1' } },
+      { ...base, event_id: `outcome-v1-${'3'.repeat(64)}`, stage: 'proposal', final_outcome: 'proposed', correlation: { jira_key: 'AIPCC-2' } },
+      { ...base, event_id: `outcome-v1-${'4'.repeat(64)}`, stage: 'merged', final_outcome: 'merged', correlation: { jira_key: 'AIPCC-3' } }
+    ]
+
+    const funnel = computeStageFunnel([], [], events, 'last7', { outcomeEventsComplete: true })
+
+    expect(funnel.stages).toEqual({ eligible: 1, analyzed: 1, prProposed: 0, prMerged: 0 })
+    expect(funnel.conversions.eligibleToAnalyzed.rate).toBe(100)
+  })
+
+  it('extracts Forge links only from canonical Autofix bot comments', () => {
+    const link = 'https://github.com/org/repo/pull/7'
+    expect(extractForgeLinks({ comments: [
+      { body: `Human comment ${link}` },
+      { body: `### jira-autofix bot\n\nA merge/pull request was created: ${link}` }
+    ] })).toEqual([link])
+    expect(buildForgeEvidence({ mrLinks: [link], mrStatuses: {} })).toMatchObject({
+      available: true,
+      proposalVerified: false,
+      mergeVerified: false,
+      source: 'forge-link-unverified'
+    })
   })
 })
 

--- a/modules/ai-impact/__tests__/server/config.test.js
+++ b/modules/ai-impact/__tests__/server/config.test.js
@@ -92,6 +92,14 @@ describe('saveConfig', () => {
     await saveConfig(writeToStorage, { trendThresholdPp: 0 });
     await saveConfig(writeToStorage, { trendThresholdPp: 50 });
   });
+
+  it('validates optional Autofix component scope', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await saveConfig(writeToStorage, { autofixComponents: ['Model Server'] });
+    expect(writeToStorage.mock.calls[0][1]).toEqual({ autofixComponents: ['Model Server'] });
+    await expect(saveConfig(writeToStorage, { autofixComponents: 'Model Server' })).rejects.toThrow('array or null');
+    await expect(saveConfig(writeToStorage, { autofixComponents: ['Bad"Component'] })).rejects.toThrow('unsafe characters');
+  });
 });
 
 describe('validateJqlSafeString', () => {

--- a/modules/ai-impact/client/components/AIImpactSettings.vue
+++ b/modules/ai-impact/client/components/AIImpactSettings.vue
@@ -261,6 +261,14 @@ function getAutofixProjectsDisplay() {
   }
   return config.value.autofixProjects || ''
 }
+
+function getAutofixComponentsDisplay() {
+  if (!config.value) return ''
+  if (Array.isArray(config.value.autofixComponents)) {
+    return config.value.autofixComponents.join(', ')
+  }
+  return config.value.autofixComponents || ''
+}
 </script>
 
 <template>
@@ -397,6 +405,18 @@ function getAutofixProjectsDisplay() {
             class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500"
           />
           <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">Only include issues created on or after this date (YYYY-MM-DD)</p>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Policy Components (optional)</label>
+          <input
+            :value="getAutofixComponentsDisplay()"
+            @input="config.autofixComponents = $event.target.value.split(',').map(s => s.trim()).filter(Boolean)"
+            type="text"
+            placeholder="Model Server, Notebooks"
+            class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500"
+          />
+          <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">Scopes gross policy cohort. Empty means project-wide non-authoritative fallback.</p>
         </div>
       </div>
     </div>

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -274,10 +274,11 @@ const metrics = computed(() => {
     merged: windowIssues.filter(i => i.pipelineState === 'autofix-merged').length,
     rejected: windowIssues.filter(i => i.pipelineState === 'autofix-rejected').length,
     maxRetries: windowIssues.filter(i => i.pipelineState === 'autofix-max-retries').length,
+    stale: windowIssues.filter(i => i.pipelineState === 'autofix-stale').length,
     blocked: windowIssues.filter(i => i.pipelineState === 'autofix-blocked').length
   }
 
-  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries
+  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries + autofixStates.stale
   const successRate = terminalTotal > 0 ? Math.round((autofixStates.merged / terminalTotal) * 100) : 0
 
   const priorityBreakdown = {}
@@ -307,7 +308,14 @@ const metrics = computed(() => {
     totalImpactScore += (issue.effortScore || 0)
   }
 
-  return { triageTotal, triageVerdicts, autofixStates, autofixTotal: triageVerdicts.ready, successRate, windowTotal: windowIssues.length, totalIssues: issues.length, priorityBreakdown, medianTimeToFixDays, effortBreakdown, totalImpactScore }
+  return {
+    ...props.autofixData.metrics,
+    triageTotal, triageVerdicts, autofixStates, autofixTotal: triageVerdicts.ready,
+    successRate, windowTotal: windowIssues.length, totalIssues: issues.length,
+    priorityBreakdown, medianTimeToFixDays, effortBreakdown, totalImpactScore,
+    pipelineCohort: { denominator: windowIssues.length, ready: triageVerdicts.ready, source: 'jira-pipeline-label-query', authoritative: false },
+    pipelineReadyShare: { numerator: triageVerdicts.ready, denominator: windowIssues.length, rate: windowIssues.length > 0 ? Math.round((triageVerdicts.ready / windowIssues.length) * 1000) / 10 : null }
+  }
 })
 
 const trendData = computed(() => {
@@ -342,13 +350,14 @@ const trendData = computed(() => {
     const ciFailing = weekIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length
     const blocked = weekIssues.filter(i => i.pipelineState === 'autofix-blocked').length
     const maxRetries = weekIssues.filter(i => i.pipelineState === 'autofix-max-retries').length
+    const autofixStale = weekIssues.filter(i => i.pipelineState === 'autofix-stale').length
     const missingInfo = weekIssues.filter(i => i.pipelineState === 'triage-missing-info').length
     const stale = weekIssues.filter(i => i.pipelineState === 'triage-stale').length
     const external = weekIssues.filter(i => i.pipelineState === 'triage-external').length
     const securityReview = weekIssues.filter(i => i.pipelineState === 'triage-security-review').length
     points.push({
       date: weekEnd.toISOString().slice(0, 10), triaged, autofixed, merged, total: weekIssues.length,
-      review, ciFailing, blocked, maxRetries, missingInfo, stale, external, securityReview
+      review, ciFailing, blocked, maxRetries, autofixStale, missingInfo, stale, external, securityReview
     })
   }
   return points
@@ -369,7 +378,8 @@ const STATE_OPTIONS = [
   { value: 'autofix-merged', label: 'AI Fix Merged' },
   { value: 'autofix-rejected', label: 'AI Fix Rejected' },
   { value: 'autofix-max-retries', label: 'AI Max Retries' },
-  { value: 'autofix-blocked', label: 'AI Blocked' }
+  { value: 'autofix-blocked', label: 'AI Blocked' },
+  { value: 'autofix-stale', label: 'AI Stale' }
 ]
 
 const stateFilterOptions = STATE_OPTIONS.filter(o => o.value !== 'all')
@@ -425,11 +435,32 @@ const hasTrendActivity = computed(() => {
   return trendData.value.some(p => p.triaged > 0)
 })
 
+// The API computes the gross cohort before client-side filters are applied.
+// Hiding it under local filters avoids presenting global counts as team-level data.
+const stageFunnel = computed(() => hasActiveFilter.value ? null : metrics.value?.stageFunnel || null)
+
+const stageFunnelRows = computed(() => {
+  const stages = stageFunnel.value?.stages || {}
+  const eligibleLabel = stageFunnel.value?.authoritative
+    ? 'Gross policy-eligible Bugs'
+    : 'Eligible (Jira proxy)'
+  return [
+    { key: 'eligible', label: eligibleLabel, color: 'bg-indigo-500' },
+    { key: 'analyzed', label: 'Analyzed', color: 'bg-blue-500' },
+    { key: 'prProposed', label: 'PR proposed', color: 'bg-purple-500' },
+    { key: 'prMerged', label: 'PR merged', color: 'bg-green-500' }
+  ].map(stage => ({ ...stage, count: stages[stage.key] ?? null }))
+})
+
+function formatConversion(conversion) {
+  return conversion?.rate === null || conversion?.rate === undefined ? 'N/A' : `${conversion.rate}%`
+}
+
 const funnelChartData = computed(() => ({
   labels: trendData.value.map(p => p.date),
   datasets: [
     {
-      label: 'Eligible for Autofix',
+      label: 'Pipeline analyzed',
       data: trendData.value.map(p => p.autofixed),
       borderColor: '#10b981',
       backgroundColor: 'rgba(16, 185, 129, 0.1)',
@@ -480,7 +511,8 @@ const waitingChartData = computed(() => ({
     { label: 'Under Review', data: trendData.value.map(p => p.review || 0), backgroundColor: 'rgba(59, 130, 246, 0.6)' },
     { label: 'CI Failing', data: trendData.value.map(p => p.ciFailing || 0), backgroundColor: 'rgba(249, 115, 22, 0.6)' },
     { label: 'Blocked', data: trendData.value.map(p => p.blocked || 0), backgroundColor: 'rgba(234, 179, 8, 0.6)' },
-    { label: 'Max Retries', data: trendData.value.map(p => p.maxRetries || 0), backgroundColor: 'rgba(239, 68, 68, 0.6)' }
+    { label: 'Max Retries', data: trendData.value.map(p => p.maxRetries || 0), backgroundColor: 'rgba(239, 68, 68, 0.6)' },
+    { label: 'Autofix Stale', data: trendData.value.map(p => p.autofixStale || 0), backgroundColor: 'rgba(156, 163, 175, 0.6)' }
   ]
 }))
 
@@ -530,6 +562,7 @@ function stateColorClass(state) {
   if (state === 'autofix-pending' || state === 'autofix-ready') return 'bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400'
   if (state === 'autofix-rejected') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
   if (state === 'autofix-max-retries') return 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400'
+  if (state === 'autofix-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
   if (state === 'autofix-blocked' || state === 'triage-missing-info') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
   if (state === 'triage-not-fixable') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
   if (state === 'triage-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
@@ -554,7 +587,7 @@ const triageSegments = computed(() => {
   if (!metrics.value) return []
   const v = metrics.value.triageVerdicts
   return [
-    { label: 'Ready for AI', count: v.ready || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix', 'jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-ci-failing', 'jira-autofix-merged', 'jira-autofix-rejected', 'jira-autofix-max-retries', 'jira-autofix-blocked'] },
+    { label: 'Ready for AI', count: v.ready || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix', 'jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-ci-failing', 'jira-autofix-merged', 'jira-autofix-rejected', 'jira-autofix-max-retries', 'jira-autofix-blocked', 'jira-autofix-stale'] },
     { label: 'Missing Info', count: v.missingInfo || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-triage-missing-info'] },
     { label: 'Not AI-Fixable', count: v.notFixable || 0, color: 'bg-red-500', textClass: 'text-red-600 dark:text-red-400', jiraLabels: ['jira-triage-not-fixable'] },
     { label: 'External Reporter', count: v.external || 0, color: 'bg-purple-500', textClass: 'text-purple-600 dark:text-purple-400', jiraLabels: ['jira-triage-external'] },
@@ -577,6 +610,7 @@ const autofixSegments = computed(() => {
     { label: 'Queued for AI', count: a.ready || 0, color: 'bg-gray-400', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-autofix'], excludeLabels: ['jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-ci-failing', 'jira-autofix-merged', 'jira-autofix-rejected', 'jira-autofix-max-retries', 'jira-autofix-blocked'] },
     { label: 'AI Fix Rejected', count: a.rejected || 0, color: 'bg-red-500', textClass: 'text-red-600 dark:text-red-400', jiraLabels: ['jira-autofix-rejected'] },
     { label: 'AI Max Retries', count: a.maxRetries || 0, color: 'bg-orange-500', textClass: 'text-orange-600 dark:text-orange-400', jiraLabels: ['jira-autofix-max-retries'] },
+    { label: 'AI Stale', count: a.stale || 0, color: 'bg-gray-400', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-autofix-stale'] },
     { label: 'AI Blocked', count: a.blocked || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-autofix-blocked'] }
   ].filter(s => s.count > 0)
 })
@@ -628,7 +662,7 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   if (useTerminalDate) {
     const isTerminalLabel = jiraLabels.some(l =>
       l === 'jira-autofix-merged' || l === 'jira-autofix-rejected' ||
-      l === 'jira-autofix-max-retries'
+      l === 'jira-autofix-max-retries' || l === 'jira-autofix-stale'
     )
     if (isTerminalLabel) {
       const matchingStates = new Set()
@@ -825,14 +859,14 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div class="absolute right-0 top-6 z-20 hidden group-hover:block w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300 text-left">
-                Percentage of triaged issues that qualified for autofix. Calculated as: <span class="font-medium">eligible ÷ total triaged × 100</span>. The AI triage bot evaluates each issue and labels it as fixable or not.
+                Share of the current Jira pipeline-labeled cohort carrying an Autofix-ready state. This is not the gross policy denominator.
               </div>
             </div>
             <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
-              {{ metrics.triageTotal > 0 ? Math.round((metrics.triageVerdicts.ready || 0) / metrics.triageTotal * 100) : 0 }}%
+              {{ metrics.pipelineReadyShare?.rate ?? (metrics.triageTotal > 0 ? Math.round((metrics.triageVerdicts.ready || 0) / metrics.triageTotal * 100) : 0) }}%
             </div>
-            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Eligibility Rate</div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.triageVerdicts.ready || 0 }} of {{ metrics.triageTotal }} triaged</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Pipeline-ready Share</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.pipelineReadyShare?.numerator ?? metrics.triageVerdicts.ready ?? 0 }} of {{ metrics.pipelineReadyShare?.denominator ?? metrics.triageTotal ?? 0 }} labeled</div>
           </div>
           <div class="relative bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
             <div class="absolute top-2 right-2 group">
@@ -840,14 +874,14 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div class="absolute right-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300 text-left">
-                Percentage of successfully merged autofixes out of all terminal outcomes. Calculated as: <span class="font-medium">merged ÷ (merged + rejected + max-retries) × 100</span>. In-progress issues are excluded since they haven't reached a final outcome.
+                Percentage of successfully merged autofixes out of all terminal outcomes. Calculated as: <span class="font-medium">merged ÷ (merged + rejected + max-retries + stale) × 100</span>. In-progress issues are excluded since they haven't reached a final outcome.
               </div>
             </div>
             <div class="text-2xl font-bold" :class="metrics.successRate >= 50 ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'">
               {{ metrics.successRate }}%
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Success Rate</div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.autofixStates.merged || 0 }} of {{ (metrics.autofixStates.merged || 0) + (metrics.autofixStates.rejected || 0) + (metrics.autofixStates.maxRetries || 0) }} resolved</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.autofixStates.merged || 0 }} of {{ (metrics.autofixStates.merged || 0) + (metrics.autofixStates.rejected || 0) + (metrics.autofixStates.maxRetries || 0) + (metrics.autofixStates.stale || 0) }} resolved</div>
           </div>
           <div class="relative bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
             <div class="absolute top-2 right-2 group">
@@ -904,6 +938,54 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
           </div>
         </div>
 
+        <!-- Lifecycle funnel -->
+        <div class="px-6 pb-6">
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <div class="flex items-start justify-between gap-4 mb-4">
+              <div>
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Autofix lifecycle funnel</h3>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Eligible to analyzed to PR proposed to PR merged. Counts use one issue per stage.
+                </p>
+              </div>
+              <span
+                v-if="stageFunnel"
+                class="text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded"
+                :class="stageFunnel.authoritative ? 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400' : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-500/20 dark:text-yellow-400'"
+              >{{ stageFunnel.authoritative ? 'Immutable events' : 'Proxy evidence' }}</span>
+            </div>
+            <div v-if="stageFunnel" class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              <div v-for="stage in stageFunnelRows" :key="stage.key" class="rounded border border-gray-100 dark:border-gray-700 p-3">
+                <div class="flex items-center gap-2">
+                  <span class="w-2.5 h-2.5 rounded-sm" :class="stage.color" />
+                  <span class="text-xs text-gray-500 dark:text-gray-400">{{ stage.label }}</span>
+                </div>
+                <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 mt-2">{{ stage.count ?? 'N/A' }}</div>
+              </div>
+            </div>
+            <p v-else-if="hasActiveFilter" class="text-xs text-yellow-700 dark:text-yellow-400">
+              Clear project, issue-type, and component filters to view the gross cohort funnel. The current API does not return a filterable gross cohort to the browser.
+            </p>
+            <div v-if="stageFunnel" class="mt-4 grid grid-cols-2 lg:grid-cols-6 gap-3 text-xs">
+              <div><span class="text-gray-400">Eligible to analyzed</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ formatConversion(stageFunnel.conversions.eligibleToAnalyzed) }}</div></div>
+              <div><span class="text-gray-400">Analyzed to proposed</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ formatConversion(stageFunnel.conversions.analyzedToPrProposed) }}</div></div>
+              <div><span class="text-gray-400">Proposed to merged</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ formatConversion(stageFunnel.conversions.prProposedToPrMerged) }}</div></div>
+              <div><span class="text-gray-400">Eligible to merged</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ formatConversion(stageFunnel.conversions.eligibleToPrMerged) }}</div></div>
+              <div><span class="text-gray-400">Abandoned</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ stageFunnel.abandonment.total }}</div></div>
+              <div><span class="text-gray-400">Blocked</span><div class="font-semibold text-gray-700 dark:text-gray-200">{{ stageFunnel.blocked }}</div></div>
+            </div>
+            <p v-if="stageFunnel?.limitations?.length" class="text-[10px] text-yellow-700 dark:text-yellow-400 mt-4">
+              {{ stageFunnel.limitations[0] }}
+            </p>
+            <p v-if="stageFunnel?.eventStats?.valid || stageFunnel?.eventStats?.outsideWindow || stageFunnel?.eventStats?.invalid" class="text-[10px] text-gray-400 dark:text-gray-500 mt-2">
+              Lifecycle event coverage: {{ stageFunnel.eventStats.valid }} in window, {{ stageFunnel.eventStats.outsideWindow }} outside window, {{ stageFunnel.eventStats.invalid }} malformed.
+            </p>
+            <p v-if="metrics.policyEligibleCohort?.available" class="text-[10px] text-gray-400 dark:text-gray-500 mt-2">
+              Gross Bug denominator: {{ metrics.policyEligibleCohort.denominator }}. Current non-excluded snapshot: {{ metrics.policyEligibleCohort.currentSnapshot }}. Scope: {{ metrics.policyEligibleCohort.scope }}.
+            </p>
+          </div>
+        </div>
+
         <!-- Status Snapshot -->
         <div class="px-6 pb-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
           <!-- Triage Outcomes -->
@@ -917,7 +999,7 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                   </svg>
                   <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
                     <div class="space-y-1">
-                      <div class="flex justify-between"><span class="font-medium">Ready for AI</span><span class="text-gray-400">Qualified for autofix</span></div>
+                      <div class="flex justify-between"><span class="font-medium">Pipeline Ready</span><span class="text-gray-400">Carries an Autofix-ready label</span></div>
                       <div class="flex justify-between"><span class="font-medium">Missing Info</span><span class="text-gray-400">Waiting on reporter</span></div>
                       <div class="flex justify-between"><span class="font-medium">Not AI-Fixable</span><span class="text-gray-400">Not suitable for AI</span></div>
                       <div class="flex justify-between"><span class="font-medium">External Reporter</span><span class="text-gray-400">Needs RH approval</span></div>
@@ -1193,7 +1275,7 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
-                    Green line: issues that qualified for autofix. Blue line: AI created an MR waiting for human code review. Bars: fixes that humans approved and merged. The gap between lines shows conversion at each stage.
+                    Green line: issues carrying an Autofix pipeline state. Blue line: Jira issues with a PR review state. Bars: fixes marked merged. These are proxy trends until immutable lifecycle events are available.
                   </div>
                 </div>
               </div>

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -9,6 +9,8 @@ const DEFAULT_CONFIG = {
   lookbackMonths: 0,
   trendThresholdPp: 2,
   autofixProjects: ['AIPCC', 'RHOAIENG', 'RHAIENG', 'RHAIFIRST', 'INFERENG', 'JN'],
+  // Null means project-wide policy cohort. Set to component names to scope it.
+  autofixComponents: null,
   autofixCreatedAfter: null,
   docProject: 'RHAISTRAT',
   docRequiredStatuses: ['Review', 'Release Pending'],
@@ -126,6 +128,18 @@ async function saveConfig(writeToStorage, config) {
       validateJqlSafeString(p, 'autofixProjects entry');
     }
     merged.autofixProjects = config.autofixProjects;
+  }
+
+  if (config.autofixComponents !== undefined) {
+    if (config.autofixComponents !== null && !Array.isArray(config.autofixComponents)) {
+      throw new Error('autofixComponents must be an array or null');
+    }
+    if (Array.isArray(config.autofixComponents)) {
+      for (const component of config.autofixComponents) {
+        validateJqlSafeString(component, 'autofixComponents entry');
+      }
+    }
+    merged.autofixComponents = config.autofixComponents;
   }
 
   // Only persist fields that differ from defaults so that future default

--- a/modules/ai-impact/server/export.js
+++ b/modules/ai-impact/server/export.js
@@ -81,6 +81,21 @@ async function exportAutofixData(addFile, readFromStorage, mapping) {
   if (Array.isArray(anonymized.issues)) {
     anonymized.issues = anonymized.issues.map(issue => anonymizeIssue(issue, mapping));
   }
+  if (Array.isArray(anonymized.policyEligibleIssues)) {
+    anonymized.policyEligibleIssues = anonymized.policyEligibleIssues.map(issue => anonymizeIssue(issue, mapping));
+  }
+  if (Array.isArray(anonymized.currentPolicyEligibleIssues)) {
+    anonymized.currentPolicyEligibleIssues = anonymized.currentPolicyEligibleIssues.map(issue => anonymizeIssue(issue, mapping));
+  }
+  if (Array.isArray(anonymized.outcomeEvents)) {
+    anonymized.outcomeEvents = anonymized.outcomeEvents.map(event => ({
+      ...event,
+      correlation: event.correlation
+        ? { ...event.correlation, jira_key: event.correlation.jira_key
+          ? mapping.anonymizeJiraKey(event.correlation.jira_key) : event.correlation.jira_key }
+        : event.correlation
+    }));
+  }
   addFile(`${PREFIX}/autofix-data.json`, anonymized);
 }
 

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -23,7 +23,12 @@ module.exports = function registerRoutes(router, context) {
   const { resolveLinkedFeatures } = require('./jira/link-resolver');
   const { getConfig, saveConfig } = require('./config');
   const { computeAllMetrics } = require('./metrics');
-  const { fetchAutofixData, computeAutofixMetrics, buildTrendData: buildAutofixTrend } = require('./jira/autofix-fetcher');
+  const {
+    fetchAutofixData,
+    computeAutofixMetrics,
+    buildTrendData: buildAutofixTrend,
+    buildForgeEvidence
+  } = require('./jira/autofix-fetcher');
   const { fetchDocData, fetchDocActivityEvents, fetchDocCumulativeStats, fetchDocCompletedData, computeDocMetrics, buildDocTrendData, resolveMRLinksFromKpiData } = require('./jira/doc-fetcher');
   const mrStatus = require('./mr-status');
   const { enrichMRStatuses } = mrStatus;
@@ -142,8 +147,30 @@ module.exports = function registerRoutes(router, context) {
         ...i,
         created: shift(i.created),
         updated: shift(i.updated),
+        terminalAt: shift(i.terminalAt),
+        mrLinks: i.mrLinks || [],
+        mrStatuses: i.mrStatuses || {}
+      })),
+      policyEligibleIssues: (data.policyEligibleIssues || []).map(i => ({
+        ...i,
+        created: shift(i.created),
+        updated: shift(i.updated),
         terminalAt: shift(i.terminalAt)
-      }))
+      })),
+      currentPolicyEligibleIssues: (data.currentPolicyEligibleIssues || []).map(i => ({
+        ...i,
+        created: shift(i.created),
+        updated: shift(i.updated),
+        terminalAt: shift(i.terminalAt)
+      })),
+      outcomeEvents: (data.outcomeEvents || []).map(event => ({
+        ...event,
+        cohort_timestamp: shift(event.cohort_timestamp),
+        transition_timestamp: shift(event.transition_timestamp)
+      })),
+      outcomeEventsComplete: data.outcomeEventsComplete === true,
+      evidence: data.evidence,
+      queries: data.queries
     };
   }
 
@@ -173,7 +200,8 @@ module.exports = function registerRoutes(router, context) {
       assignee: issue.assignee,
       pipelineState: issue.pipelineState,
       effortScore: issue.effortScore ?? null,
-      effortTier: issue.effortTier ?? null
+      effortTier: issue.effortTier ?? null,
+      forgeEvidence: buildForgeEvidence(issue)
     };
   }
 
@@ -181,7 +209,7 @@ module.exports = function registerRoutes(router, context) {
    * @openapi
    * /modules/ai-impact/autofix-data:
    *   get:
-   *     summary: Autofix pipeline data with computed metrics and trend
+   *     summary: Jira Autofix cohorts, lifecycle funnel, and trend data
    *     tags: [ai-impact]
    *     parameters:
    *       - in: query
@@ -198,7 +226,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Comma-separated Jira component names to filter issues by
    *     responses:
    *       200:
-   *         description: Autofix dataset with metrics, trend data, and issues
+   *         description: Autofix dataset with separate policy and pipeline cohorts. Lifecycle stage conversions are authoritative only when immutable Autofix outcome events are present.
    */
   router.get('/autofix-data', requireScope('ai-impact:read'), async function(req, res) {
     const timeWindow = VALID_AUTOFIX_TIME_WINDOWS.includes(req.query.timeWindow)
@@ -210,13 +238,31 @@ module.exports = function registerRoutes(router, context) {
       return res.json({
         fetchedAt: null,
         jiraHost: JIRA_HOST,
-        metrics: { triageTotal: 0, triageVerdicts: {}, autofixStates: {}, autofixTotal: 0, successRate: 0, windowTotal: 0, totalIssues: 0, priorityBreakdown: {}, medianTimeToFixDays: null, effortBreakdown: { quickWin: 0, standardFix: 0, complexFix: 0 }, totalImpactScore: 0 },
+        metrics: {
+          triageTotal: 0,
+          triageVerdicts: {},
+          autofixStates: {},
+          autofixTotal: 0,
+          successRate: 0,
+          windowTotal: 0,
+          totalIssues: 0,
+          priorityBreakdown: {},
+          medianTimeToFixDays: null,
+          effortBreakdown: { quickWin: 0, standardFix: 0, complexFix: 0 },
+          totalImpactScore: 0,
+          pipelineCohort: { denominator: 0, ready: 0, source: 'jira-pipeline-label-query', authoritative: false },
+          pipelineReadyShare: { numerator: 0, denominator: 0, rate: null },
+          policyEligibleCohort: { available: false, denominator: null },
+          stageFunnel: null
+        },
         trendData: [],
         issues: []
       });
     }
 
     let issues = data.issues;
+    let policyEligibleIssues = data.policyEligibleIssues;
+    let currentPolicyEligibleIssues = data.currentPolicyEligibleIssues;
     if (req.query.components) {
       const componentSet = new Set(
         req.query.components.split(',').map(function(c) { return c.trim(); }).filter(Boolean)
@@ -225,10 +271,26 @@ module.exports = function registerRoutes(router, context) {
         issues = issues.filter(function(issue) {
           return (issue.components || []).some(function(c) { return componentSet.has(c); });
         });
+        if (Array.isArray(policyEligibleIssues)) {
+          policyEligibleIssues = policyEligibleIssues.filter(function(issue) {
+            return (issue.components || []).some(function(c) { return componentSet.has(c); });
+          });
+        }
+        if (Array.isArray(currentPolicyEligibleIssues)) {
+          currentPolicyEligibleIssues = currentPolicyEligibleIssues.filter(function(issue) {
+            return (issue.components || []).some(function(c) { return componentSet.has(c); });
+          });
+        }
       }
     }
 
-    const metrics = computeAutofixMetrics(issues, timeWindow);
+    const metrics = computeAutofixMetrics(issues, timeWindow, {
+      policyEligibleIssues,
+      currentPolicyEligibleIssues,
+      outcomeEvents: data.outcomeEvents || [],
+      outcomeEventsComplete: data.outcomeEventsComplete === true,
+      policyScope: data.evidence?.policyScope
+    });
     const trendData = buildAutofixTrend(issues, timeWindow);
 
     res.json({
@@ -236,7 +298,12 @@ module.exports = function registerRoutes(router, context) {
       jiraHost: JIRA_HOST,
       metrics,
       trendData,
-      issues: issues.map(stripIssueFields)
+      issues: issues.map(stripIssueFields),
+      evidence: data.evidence || {
+        pipeline: 'Jira labels',
+        policyEligible: 'Jira JQL policy query unavailable in this snapshot',
+        stageContract: 'AIPCC-31384 lifecycle outcome contract dependency'
+      }
     });
   });
 
@@ -359,13 +426,28 @@ module.exports = function registerRoutes(router, context) {
 
     let autofixCount = 0;
     try {
-      const autofixIssues = await fetchAutofixData(jiraRequest, config);
+      const autofixReport = await fetchAutofixData(jiraRequest, config);
+      const allAutofixIssues = [
+        ...(autofixReport.issues || []),
+        ...(autofixReport.policyEligibleIssues || [])
+      ];
+      const uniqueAutofixMap = new Map();
+      for (const issue of allAutofixIssues) {
+        if (!uniqueAutofixMap.has(issue.key)) uniqueAutofixMap.set(issue.key, issue);
+      }
+      const uniqueAutofixIssues = [...uniqueAutofixMap.values()];
+      await enrichMRStatuses(uniqueAutofixIssues);
+      const pipelineByKey = new Map((autofixReport.issues || []).map(issue => [issue.key, issue]));
+      for (const issue of autofixReport.policyEligibleIssues || []) {
+        const pipelineIssue = pipelineByKey.get(issue.key);
+        if (pipelineIssue) issue.mrStatuses = pipelineIssue.mrStatuses || {};
+      }
       await writeToStorage('ai-impact/autofix-data.json', {
         fetchedAt: new Date().toISOString(),
-        issues: autofixIssues
+        ...autofixReport
       });
       invalidateAutofixCache();
-      autofixCount = autofixIssues.length;
+      autofixCount = (autofixReport.issues || []).length;
     } catch (autofixErr) {
       console.error('[ai-impact] Autofix data refresh failed:', autofixErr.message);
     }

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -4,12 +4,34 @@ const { validateJqlSafeString } = require('../config');
 const TERMINAL_LABELS = [
   'jira-autofix-merged',
   'jira-autofix-rejected',
-  'jira-autofix-max-retries'
+  'jira-autofix-max-retries',
+  'jira-autofix-stale'
 ];
 
 const TERMINAL_STATES = new Set([
-  'autofix-merged', 'autofix-rejected', 'autofix-max-retries'
+  'autofix-merged', 'autofix-rejected', 'autofix-max-retries', 'autofix-stale'
 ]);
+
+// Gross cohort excludes only immutable issue content markers. Mutable labels
+// and status changes remain in the cohort so closed-before-pickup is visible.
+const GROSS_POLICY_EXCLUSION_LABELS = ['CVE'];
+const CURRENT_POLICY_EXCLUSION_LABELS = ['no-autofix', 'auto-created', 'CVE'];
+const POLICY_PROPOSAL_STATES = new Set([
+  'autofix-review',
+  'autofix-ci-failing',
+  'autofix-merged',
+  'autofix-rejected',
+  'autofix-max-retries',
+  'autofix-stale'
+]);
+const POLICY_ABANDONMENT_STATES = new Set([
+  'autofix-rejected',
+  'autofix-max-retries',
+  'autofix-stale'
+]);
+const POLICY_BLOCKED_STATES = new Set(['autofix-blocked']);
+const OUTCOME_EVENT_TYPE = 'jira_autofix.lifecycle.outcome';
+const AUTOFIX_BOT_SENTINEL = 'jira-autofix bot';
 
 // All labels from the jira-autofix triage + autofix pipelines
 const TRIAGE_LABELS = [
@@ -29,7 +51,8 @@ const AUTOFIX_LABELS = [
   'jira-autofix-merged',
   'jira-autofix-rejected',
   'jira-autofix-max-retries',
-  'jira-autofix-blocked'
+  'jira-autofix-blocked',
+  'jira-autofix-stale'
 ];
 
 const ALL_PIPELINE_LABELS = [...TRIAGE_LABELS, ...AUTOFIX_LABELS];
@@ -41,6 +64,7 @@ function classifyIssue(labels) {
   if (labelSet.has('jira-autofix-merged')) return 'autofix-merged';
   if (labelSet.has('jira-autofix-rejected')) return 'autofix-rejected';
   if (labelSet.has('jira-autofix-max-retries')) return 'autofix-max-retries';
+  if (labelSet.has('jira-autofix-stale')) return 'autofix-stale';
   // Active autofix states (blocked before pending — blocked is added when
   // the bot gets stuck after starting, but pending may not be removed)
   if (labelSet.has('jira-autofix-blocked')) return 'autofix-blocked';
@@ -76,8 +100,38 @@ function processIssue(issue) {
     labels,
     components,
     assignee: issue.fields.assignee?.displayName || null,
-    pipelineState: classifyIssue(labels)
+    securityLevel: issue.fields.security?.name || null,
+    pipelineState: classifyIssue(labels),
+    mrLinks: extractForgeLinks(issue.fields.comment)
   };
+}
+
+function extractForgeLinks(commentField) {
+  const comments = commentField?.comments || (Array.isArray(commentField) ? commentField : []);
+  const text = comments
+    .map(comment => collectJiraText(comment.body || comment))
+    .filter(commentText => new RegExp(`(^|\\n)\\s*(?:#{1,6}\\s*)?${AUTOFIX_BOT_SENTINEL}`, 'i').test(commentText))
+    .join(' ');
+  const matches = text.match(/https?:\/\/[^\s"'<>]+/g) || [];
+  const links = new Set();
+  for (const match of matches) {
+    const link = match.replace(/[),.;]+$/, '');
+    if (/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(link) ||
+        /\/merge_requests\/\d+/.test(link)) {
+      links.add(link);
+    }
+  }
+  return [...links];
+}
+
+function collectJiraText(value) {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(collectJiraText).join(' ');
+  if (!value || typeof value !== 'object') return '';
+  return Object.entries(value).map(([key, item]) => {
+    if (key === 'attrs' && item && typeof item === 'object' && item.href) return item.href;
+    return collectJiraText(item);
+  }).join(' ');
 }
 
 function extractPipelineHistory(changelog, pipelineState) {
@@ -236,7 +290,313 @@ function issueInWindow(issue, windowStart, windowEnd, useTerminalDate) {
   return c >= windowStart && c < windowEnd;
 }
 
-function computeAutofixMetrics(issues, timeWindow) {
+function issueCreatedInWindow(issue, windowStart, windowEnd) {
+  const created = new Date(issue.created).getTime();
+  return created >= windowStart && created < windowEnd;
+}
+
+function getPolicyExclusionReasons(issue) {
+  const labels = new Set(issue.labels || []);
+  const reasons = [];
+
+  if (issue.issueType && issue.issueType !== 'Bug') reasons.push('not_bug');
+  if (labels.has('CVE')) reasons.push('cve_label');
+  if (/CVE-/i.test(issue.summary || '')) reasons.push('cve_summary');
+  if (/EMBARGOED/i.test(issue.summary || '') ||
+      issue.securityLevel === 'Embargoed Security Issue') {
+    reasons.push('embargoed');
+  }
+
+  return reasons;
+}
+
+function isPolicyEligibleIssue(issue) {
+  return getPolicyExclusionReasons(issue).length === 0;
+}
+
+function isCurrentPolicyEligibleIssue(issue) {
+  if (!isPolicyEligibleIssue(issue)) return false;
+  const labels = new Set(issue.labels || []);
+  return !CURRENT_POLICY_EXCLUSION_LABELS.some(label => labels.has(label));
+}
+
+function buildProjectClause(projects) {
+  return projects.map(project => `"${project}"`).join(', ');
+}
+
+function buildCreatedAfterClause(createdAfter) {
+  return createdAfter ? ` AND created >= "${createdAfter}"` : '';
+}
+
+function buildPipelineJql(config) {
+  const projectClause = buildProjectClause(config.autofixProjects);
+  const labelClause = ALL_PIPELINE_LABELS.map(label => `"${label}"`).join(', ');
+  return `project IN (${projectClause}) AND labels IN (${labelClause})` +
+    buildCreatedAfterClause(config.autofixCreatedAfter) + ' ORDER BY created DESC';
+}
+
+function buildPolicyEligibleJql(config) {
+  const projectClause = buildProjectClause(config.autofixProjects);
+  const excludedLabels = GROSS_POLICY_EXCLUSION_LABELS.map(label => `"${label}"`).join(', ');
+  const clauses = [
+    `project IN (${projectClause})`,
+    'type = Bug',
+    `(labels IS EMPTY OR labels NOT IN (${excludedLabels}))`,
+    'summary !~ "EMBARGOED"',
+    '(level IS EMPTY OR level != "Embargoed Security Issue")',
+    'summary !~ "CVE-"'
+  ];
+  if (Array.isArray(config.autofixComponents) && config.autofixComponents.length > 0) {
+    const components = config.autofixComponents.map(component => `"${component}"`).join(', ');
+    clauses.push(`component IN (${components})`);
+  }
+  return clauses.join(' AND ') + buildCreatedAfterClause(config.autofixCreatedAfter) + ' ORDER BY created DESC';
+}
+
+function buildForgeEvidence(issue) {
+  const links = issue.mrLinks || [];
+  const statuses = links.length > 0 ? Object.values(issue.mrStatuses || {}) : [];
+  const proposalVerified = statuses.some(status => ['opened', 'merged', 'closed'].includes(status));
+  const mergeVerified = statuses.includes('merged');
+  return {
+    available: links.length > 0,
+    proposalVerified,
+    mergeVerified,
+    statusCount: statuses.length,
+    source: statuses.length > 0 ? 'forge-api' : links.length > 0 ? 'forge-link-unverified' : 'none'
+  };
+}
+
+const VALID_OUTCOME_STAGES = new Set([
+  'policy_eligibility',
+  'analysis',
+  'proposal',
+  'iteration',
+  'blocked',
+  'rejected',
+  'abandoned',
+  'stale',
+  'merged',
+  'reconciliation',
+  'failed'
+]);
+
+function normalizeOutcomeEvent(event) {
+  if (!event || typeof event !== 'object') return null;
+  if (event.event_type !== OUTCOME_EVENT_TYPE ||
+      typeof event.event_id !== 'string' ||
+      !/^outcome-v1-[0-9a-f]{64}$/.test(event.event_id)) return null;
+  if (typeof event.schema_version !== 'string' || !/^1\.[0-9]+$/.test(event.schema_version)) return null;
+  if (typeof event.correlation_id !== 'string' || !event.correlation_id ||
+      typeof event.final_outcome !== 'string' ||
+      !Number.isInteger(event.attempt) || event.attempt < 1 ||
+      !event.metrics || typeof event.metrics !== 'object' ||
+      !event.metadata || typeof event.metadata !== 'object') return null;
+  if (event.metadata?.synthetic === true || event.metadata?.excluded === true) return null;
+
+  const key = event.correlation?.jira_key;
+  const stage = event.stage;
+  if (!key || typeof key !== 'string' || !VALID_OUTCOME_STAGES.has(stage)) return null;
+  const cohortTimestamp = event.cohort_timestamp;
+  const transitionTimestamp = event.transition_timestamp;
+  if (!cohortTimestamp || Number.isNaN(new Date(cohortTimestamp).getTime()) ||
+      !transitionTimestamp || Number.isNaN(new Date(transitionTimestamp).getTime())) return null;
+  if (new Date(transitionTimestamp).getTime() < new Date(cohortTimestamp).getTime()) return null;
+  return { ...event, stage, jiraKey: key, cohortTimestamp };
+}
+
+function conversion(numerator, denominator) {
+  return {
+    numerator,
+    denominator,
+    rate: denominator > 0 ? Math.round((numerator / denominator) * 1000) / 10 : null
+  };
+}
+
+function computePolicyEligibleCohort(
+  policyEligibleIssues,
+  timeWindow,
+  scope = null,
+  currentPolicyEligibleIssues = null
+) {
+  if (!Array.isArray(policyEligibleIssues)) {
+    return {
+      available: false,
+      denominator: null,
+      candidateCount: null,
+      currentSnapshot: null,
+      exclusions: GROSS_POLICY_EXCLUSION_LABELS.concat(['cve_summary', 'embargoed'])
+    };
+  }
+
+  const { start: windowStart, end: windowEnd } = getWindowBounds(timeWindow);
+  const candidates = policyEligibleIssues.filter(issue =>
+    issueCreatedInWindow(issue, windowStart, windowEnd)
+  );
+  const eligible = candidates.filter(isPolicyEligibleIssue);
+  const currentEligible = Array.isArray(currentPolicyEligibleIssues)
+    ? currentPolicyEligibleIssues.filter(issue => issueCreatedInWindow(issue, windowStart, windowEnd))
+    : candidates.filter(isCurrentPolicyEligibleIssue);
+  const observedMutableExclusionCounts = {};
+  for (const issue of candidates) {
+    const labels = new Set(issue.labels || []);
+    if (labels.has('no-autofix')) {
+      observedMutableExclusionCounts.no_autofix = (observedMutableExclusionCounts.no_autofix || 0) + 1;
+    }
+    if (labels.has('auto-created')) {
+      observedMutableExclusionCounts.auto_created = (observedMutableExclusionCounts.auto_created || 0) + 1;
+    }
+  }
+
+  return {
+    available: true,
+    denominator: eligible.length,
+    currentSnapshot: currentEligible.length,
+    candidateCount: candidates.length,
+    total: policyEligibleIssues.length,
+    exclusionCounts: null,
+    exclusionCountsAvailable: false,
+    exclusionCountsNote: 'CVE and embargo exclusions are applied in Jira JQL and are not counted by this snapshot.',
+    observedMutableExclusionCounts,
+    exclusions: GROSS_POLICY_EXCLUSION_LABELS.concat(['cve_summary', 'embargoed']),
+    currentSnapshotExclusions: CURRENT_POLICY_EXCLUSION_LABELS,
+    source: 'jira-policy-query',
+    scope: scope || 'project-wide fallback; component scope not configured',
+    authoritative: false
+  };
+}
+
+function computeStageFunnel(issues, policyEligibleIssues, outcomeEvents, timeWindow, options = {}) {
+  const { start: windowStart, end: windowEnd } = getWindowBounds(timeWindow);
+  const rawEvents = Array.isArray(outcomeEvents) ? outcomeEvents : [];
+  const parsedEvents = rawEvents.map(normalizeOutcomeEvent).filter(Boolean);
+  const validEvents = parsedEvents.filter(event =>
+    new Date(event.cohortTimestamp).getTime() >= windowStart &&
+    new Date(event.cohortTimestamp).getTime() < windowEnd
+  );
+  const deduplicatedEvents = [...new Map(validEvents.map(event => [event.event_id, event])).values()];
+
+  function eventKeys(stage, predicate = () => true) {
+    return new Set(deduplicatedEvents
+      .filter(event => event.stage === stage && predicate(event))
+      .map(event => event.jiraKey));
+  }
+
+  function intersect(left, right) {
+    return new Set([...left].filter(key => right.has(key)));
+  }
+
+  if (deduplicatedEvents.length > 0 && options.outcomeEventsComplete === true) {
+    const eligible = eventKeys('policy_eligibility', event => event.final_outcome === 'eligible');
+    const analyzed = intersect(eligible, eventKeys('analysis'));
+    const proposed = intersect(analyzed, eventKeys('proposal'));
+    const merged = intersect(proposed, eventKeys('merged'));
+    const abandonment = new Set(
+      deduplicatedEvents
+        .filter(event => ['abandoned', 'stale', 'rejected'].includes(event.stage))
+        .map(event => event.jiraKey)
+        .filter(key => eligible.has(key))
+    );
+    const blocked = intersect(eligible, eventKeys('blocked'));
+    return {
+      source: 'autofix-outcome-events',
+      authoritative: true,
+      contract: 'AIPCC-31384 lifecycle outcome contract',
+      stages: {
+        eligible: eligible.size,
+        analyzed: analyzed.size,
+        prProposed: proposed.size,
+        prMerged: merged.size
+      },
+      abandonment: {
+        total: abandonment.size,
+        stale: eventKeys('stale').size,
+        rejected: eventKeys('rejected').size,
+        abandoned: eventKeys('abandoned').size
+      },
+      blocked: blocked.size,
+      conversions: {
+        eligibleToAnalyzed: conversion(analyzed.size, eligible.size),
+        analyzedToPrProposed: conversion(proposed.size, analyzed.size),
+        prProposedToPrMerged: conversion(merged.size, proposed.size),
+        eligibleToPrMerged: conversion(merged.size, eligible.size)
+      },
+      eventStats: {
+        valid: deduplicatedEvents.length,
+        duplicate: validEvents.length - deduplicatedEvents.length,
+        invalid: rawEvents.length - parsedEvents.length,
+        outsideWindow: parsedEvents.length - validEvents.length
+      },
+      limitations: []
+    };
+  }
+
+  const policyWindow = Array.isArray(policyEligibleIssues)
+    ? policyEligibleIssues
+      .filter(issue => issueCreatedInWindow(issue, windowStart, windowEnd))
+      .map((issue, index) => ({ ...issue, key: issue.key || `__policy-${index}` }))
+    : [];
+  const policyKeys = new Set(policyWindow.filter(isPolicyEligibleIssue).map(issue => issue.key));
+  const pipelineWindow = issues
+    .filter(issue => issueCreatedInWindow(issue, windowStart, windowEnd))
+    .map((issue, index) => ({ ...issue, key: issue.key || `__pipeline-${index}` }));
+  const cohortKeys = policyKeys.size > 0 ? policyKeys : new Set(pipelineWindow.map(issue => issue.key));
+  const pipelineByKey = new Map(pipelineWindow.map(issue => [issue.key, issue]));
+  const analyzedKeys = new Set(pipelineWindow.filter(issue => cohortKeys.has(issue.key)).map(issue => issue.key));
+  const proposedKeys = new Set();
+  const mergedKeys = new Set();
+  const abandonmentKeys = new Set();
+  const blockedKeys = new Set();
+  const abandonment = { stale: 0, rejected: 0, maxRetries: 0 };
+
+  for (const key of cohortKeys) {
+    const issue = pipelineByKey.get(key);
+    if (!issue) continue;
+    const forge = buildForgeEvidence(issue);
+    if (POLICY_PROPOSAL_STATES.has(issue.pipelineState) || forge.proposalVerified) proposedKeys.add(key);
+    if (issue.pipelineState === 'autofix-merged' || forge.mergeVerified) mergedKeys.add(key);
+    if (POLICY_ABANDONMENT_STATES.has(issue.pipelineState)) {
+      abandonmentKeys.add(key);
+      if (issue.pipelineState === 'autofix-stale') abandonment.stale++;
+      if (issue.pipelineState === 'autofix-rejected') abandonment.rejected++;
+      if (issue.pipelineState === 'autofix-max-retries') abandonment.maxRetries++;
+    }
+    if (POLICY_BLOCKED_STATES.has(issue.pipelineState)) blockedKeys.add(key);
+  }
+
+  return {
+    source: 'jira-labels-and-forge-status-proxy',
+    authoritative: false,
+    contract: 'AIPCC-31384 lifecycle outcome contract (pending producer dependency)',
+    stages: {
+      eligible: cohortKeys.size,
+      analyzed: analyzedKeys.size,
+      prProposed: proposedKeys.size,
+      prMerged: mergedKeys.size
+    },
+    abandonment: { total: abandonmentKeys.size, ...abandonment },
+    blocked: blockedKeys.size,
+    conversions: {
+      eligibleToAnalyzed: conversion(analyzedKeys.size, cohortKeys.size),
+      analyzedToPrProposed: conversion(proposedKeys.size, analyzedKeys.size),
+      prProposedToPrMerged: conversion(mergedKeys.size, proposedKeys.size),
+      eligibleToPrMerged: conversion(mergedKeys.size, cohortKeys.size)
+    },
+    eventStats: {
+      valid: validEvents.length,
+      duplicate: validEvents.length - deduplicatedEvents.length,
+      invalid: rawEvents.length - parsedEvents.length,
+      outsideWindow: parsedEvents.length - validEvents.length
+    },
+    limitations: [
+      'Jira labels are mutable and do not prove historical stage transitions.',
+      'Forge verification requires a URL in a Jira Autofix bot comment and API credentials.',
+      'Use immutable Autofix lifecycle events for authoritative cohort conversion reporting.'
+    ]
+  };
+}
+
+function computeAutofixMetrics(issues, timeWindow, options = {}) {
   const { start: windowStart, end: windowEnd, useTerminalDate } = getWindowBounds(timeWindow);
 
   const counts = {};
@@ -258,6 +618,7 @@ function computeAutofixMetrics(issues, timeWindow) {
     merged: get('autofix-merged'),
     rejected: get('autofix-rejected'),
     maxRetries: get('autofix-max-retries'),
+    stale: get('autofix-stale'),
     blocked: get('autofix-blocked')
   };
 
@@ -277,7 +638,8 @@ function computeAutofixMetrics(issues, timeWindow) {
     triageVerdicts.notFixable + triageVerdicts.stale + triageVerdicts.pending +
     triageVerdicts.external + triageVerdicts.securityReview;
 
-  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries;
+  const terminalTotal = autofixStates.merged + autofixStates.rejected +
+    autofixStates.maxRetries + autofixStates.stale;
   const successRate = terminalTotal > 0
     ? Math.round((autofixStates.merged / terminalTotal) * 100)
     : 0;
@@ -302,6 +664,20 @@ function computeAutofixMetrics(issues, timeWindow) {
     totalImpactScore += (mergedWindowIssues[j].effortScore || 0);
   }
 
+  const policyEligibleCohort = computePolicyEligibleCohort(
+    options.policyEligibleIssues,
+    timeWindow,
+    options.policyScope,
+    options.currentPolicyEligibleIssues
+  );
+  const stageFunnel = computeStageFunnel(
+    issues,
+    options.policyEligibleIssues,
+    options.outcomeEvents,
+    timeWindow,
+    { outcomeEventsComplete: options.outcomeEventsComplete === true }
+  );
+
   return {
     triageTotal,
     triageVerdicts,
@@ -314,7 +690,16 @@ function computeAutofixMetrics(issues, timeWindow) {
     priorityBreakdown,
     medianTimeToFixDays,
     effortBreakdown,
-    totalImpactScore
+    totalImpactScore,
+    pipelineCohort: {
+      denominator: windowTotal,
+      ready: triageVerdicts.ready,
+      source: 'jira-pipeline-label-query',
+      authoritative: false
+    },
+    pipelineReadyShare: conversion(triageVerdicts.ready, windowTotal),
+    policyEligibleCohort,
+    stageFunnel
   };
 }
 
@@ -356,7 +741,7 @@ function buildTrendData(issues, timeWindow) {
       weekStart: weekEnd.getTime() - MS_PER_WEEK,
       weekEnd: weekEnd.getTime(),
       triaged: 0, autofixed: 0, merged: 0, total: 0,
-      review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
+      review: 0, ciFailing: 0, blocked: 0, maxRetries: 0, autofixStale: 0,
       missingInfo: 0, stale: 0, external: 0, securityReview: 0
     });
   }
@@ -390,6 +775,7 @@ function buildTrendData(issues, timeWindow) {
     else if (state === 'autofix-ci-failing') bucket.ciFailing++;
     else if (state === 'autofix-blocked') bucket.blocked++;
     else if (state === 'autofix-max-retries') bucket.maxRetries++;
+    else if (state === 'autofix-stale') bucket.autofixStale++;
     else if (state === 'triage-missing-info') bucket.missingInfo++;
     else if (state === 'triage-stale') bucket.stale++;
     else if (state === 'triage-external') bucket.external++;
@@ -401,6 +787,7 @@ function buildTrendData(issues, timeWindow) {
       date: b.date, triaged: b.triaged, autofixed: b.autofixed,
       merged: b.merged, total: b.total, review: b.review,
       ciFailing: b.ciFailing, blocked: b.blocked, maxRetries: b.maxRetries,
+      autofixStale: b.autofixStale,
       missingInfo: b.missingInfo, stale: b.stale,
       external: b.external, securityReview: b.securityReview
     };
@@ -408,28 +795,30 @@ function buildTrendData(issues, timeWindow) {
 }
 
 async function fetchAutofixData(jiraRequest, config) {
-  const { autofixProjects, autofixCreatedAfter } = config;
+  const { autofixProjects, autofixComponents, autofixCreatedAfter } = config;
 
   for (const p of autofixProjects) {
     validateJqlSafeString(p, 'autofixProjects entry');
+  }
+  if (Array.isArray(autofixComponents)) {
+    for (const component of autofixComponents) {
+      validateJqlSafeString(component, 'autofixComponents entry');
+    }
   }
   if (autofixCreatedAfter) {
     validateJqlSafeString(autofixCreatedAfter, 'autofixCreatedAfter');
   }
 
-  const projectClause = autofixProjects.map(p => `"${p}"`).join(', ');
-  const labelClause = ALL_PIPELINE_LABELS.map(l => `"${l}"`).join(', ');
-
-  let jql = `project IN (${projectClause}) AND labels IN (${labelClause})`;
-  if (autofixCreatedAfter) {
-    jql += ` AND created >= "${autofixCreatedAfter}"`;
-  }
-  jql += ' ORDER BY created DESC';
-
-  const fields = 'summary,status,issuetype,priority,created,updated,labels,components,assignee';
-  const rawIssues = await fetchAllJqlResults(jiraRequest, jql, fields);
+  const pipelineJql = buildPipelineJql({ autofixProjects, autofixCreatedAfter });
+  const policyEligibleJql = buildPolicyEligibleJql({ autofixProjects, autofixComponents, autofixCreatedAfter });
+  const fields = 'summary,status,issuetype,priority,created,updated,labels,components,assignee,security,comment';
+  const [rawIssues, rawPolicyEligibleIssues] = await Promise.all([
+    fetchAllJqlResults(jiraRequest, pipelineJql, fields),
+    fetchAllJqlResults(jiraRequest, policyEligibleJql, fields)
+  ]);
 
   const processed = rawIssues.map(processIssue);
+  const policyEligibleIssues = rawPolicyEligibleIssues.map(processIssue);
 
   const terminalIssues = processed.filter(i => TERMINAL_STATES.has(i.pipelineState));
   const BATCH = 10;
@@ -459,11 +848,48 @@ async function fetchAutofixData(jiraRequest, config) {
     processed[i].effortTier = scoring.effortTier;
   }
 
-  return processed;
+  const processedByKey = new Map(processed.map(issue => [issue.key, issue]));
+  for (const issue of policyEligibleIssues) {
+    const pipelineIssue = processedByKey.get(issue.key);
+    if (!pipelineIssue) continue;
+    issue.pipelineState = pipelineIssue.pipelineState;
+    issue.terminalAt = pipelineIssue.terminalAt;
+    issue.ciFailureCount = pipelineIssue.ciFailureCount;
+    issue.reviewRoundCount = pipelineIssue.reviewRoundCount;
+    issue.wasBlocked = pipelineIssue.wasBlocked;
+    issue.mrLinks = pipelineIssue.mrLinks;
+  }
+
+  return {
+    issues: processed,
+    policyEligibleIssues,
+    currentPolicyEligibleIssues: policyEligibleIssues.filter(isCurrentPolicyEligibleIssue),
+    outcomeEvents: [],
+    outcomeEventsComplete: false,
+    evidence: {
+      pipeline: 'Jira labels',
+      policyEligible: 'Jira JQL policy query',
+      stageContract: 'AIPCC-31384 lifecycle outcome contract dependency',
+      policyScope: Array.isArray(autofixComponents) && autofixComponents.length > 0
+        ? `configured components: ${autofixComponents.join(', ')}`
+        : 'project-wide fallback; component scope not configured'
+    },
+    queries: { pipeline: pipelineJql, policyEligible: policyEligibleJql }
+  };
 }
 
 module.exports = {
   fetchAutofixData,
+  buildPipelineJql,
+  buildPolicyEligibleJql,
+  getPolicyExclusionReasons,
+  isPolicyEligibleIssue,
+  isCurrentPolicyEligibleIssue,
+  computePolicyEligibleCohort,
+  computeStageFunnel,
+  normalizeOutcomeEvent,
+  buildForgeEvidence,
+  extractForgeLinks,
   processIssue,
   classifyIssue,
   extractTerminalAt,
@@ -479,5 +905,8 @@ module.exports = {
   TRIAGE_LABELS,
   AUTOFIX_LABELS,
   TERMINAL_LABELS,
-  TERMINAL_STATES
+  TERMINAL_STATES,
+  GROSS_POLICY_EXCLUSION_LABELS,
+  CURRENT_POLICY_EXCLUSION_LABELS,
+  POLICY_PROPOSAL_STATES
 };

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -243,9 +243,20 @@ test.describe('AI Impact Views @ai-impact', () => {
   });
 
   test('Jira AutoFix view renders impact metrics sections', async ({ page }) => {
+    const autofixResponsePromise = page.waitForResponse(response =>
+      response.url().includes('/api/modules/ai-impact/autofix-data') && response.status() === 200
+    );
     await page.goto('/#/ai-impact/autofix');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const autofixResponse = await autofixResponsePromise;
+    const autofixPayload = await autofixResponse.json();
+    expect(autofixPayload.metrics).toHaveProperty('pipelineCohort');
+    expect(autofixPayload.metrics).toHaveProperty('stageFunnel');
+    expect(autofixPayload.metrics.stageFunnel).toHaveProperty('conversions');
+    expect(autofixPayload.metrics.stageFunnel.authoritative).toBe(false);
+    expect(autofixPayload.evidence.stageContract).toContain('AIPCC-31384');
 
     const priorityHeading = page.locator('text=Priority Distribution');
     await expect(priorityHeading).toBeVisible();
@@ -258,6 +269,11 @@ test.describe('AI Impact Views @ai-impact', () => {
 
     const effortColumn = page.locator('th:has-text("Effort")');
     await expect(effortColumn).toBeVisible();
+
+    await expect(page.getByText('Autofix lifecycle funnel')).toBeVisible();
+    await expect(page.getByText('Proxy evidence')).toBeVisible();
+    await expect(page.getByText('Pipeline-ready Share')).toBeVisible();
+    await expect(page.getByText('Eligibility Rate')).toHaveCount(0);
 
     expect(page.errors).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

- separate the gross Bug cohort from the mutable pipeline-labeled cohort
- retain closed and currently opted-out Bugs in the gross denominator
- expose the current non-excluded snapshot separately
- include stale outcomes and distinguish abandonment from blocked workflow friction
- verify canonical Autofix forge links where credentials allow
- consume canonical immutable lifecycle events only when completeness is explicit
- rename the old eligibility measure to Pipeline-ready Share

## Validation

- 5,606 unit tests passed; 11 skipped
- 103 focused Autofix/config tests passed after final review fixes
- lint, production build, module validation, platform validation, and OpenAPI validation passed
- required Playwright assertions are included; local execution is blocked by the missing Chromium binary

## Dependencies and limitations

The immutable event producer depends on AIPCC-31384 and AIPCC-31377. Until that producer lands, the UI labels Jira and forge-derived funnel values as proxy evidence. Client-side project and component filters hide the global funnel instead of presenting mismatched denominators.

Jira: https://redhat.atlassian.net/browse/AIPCC-31376
