### PR TITLE
RHOAIENG-82505: Flag released releases with open tasks

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1786,6 +1786,7 @@ are not selected on open. If no release qualifies, no version is selected.
 - Task objects carry the Jira `status`/`status_category` and `resolution` (same semantics as `resolution` in [Person Metrics](#person-metrics--datapeoplenamejson): the raw Jira resolution name, or `null`/absent while unresolved).
 - The UI renders a task's label as `<Status> - <Resolution>` (e.g. `"Done - Won't Do"`) whenever `resolution` is set, falling back to just `<Status>` otherwise; `resolution` is optional — older payloads without it still render using `status` alone.
 - No-work resolutions (`"Won't Do"`, `"Can't Do"`, `"Obsolete"`, `"Duplicate"`, `"Cannot Reproduce"`) are rendered in a muted/gray style instead of green, even when `status_category` is `"Done"`, since the work itself wasn't completed.
+- When `release_schedule.status` is `"Released"` or `"GA"`, the dashboard displays `Released with Open Tasks` in red if any test-execution task is unfinished. A task is unfinished when its status category is not `"Done"` or it has a no-work resolution. Otherwise, a released release keeps the normal green `Released` presentation.
 
 ## System Health — Disconnected Readiness Reports (`data/system-health/disconnected/reports.json`)
 

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1740,6 +1740,11 @@ this file — the payload itself is produced outside this repo by the external
 `fetch_release_metrics.py` script and pushed via its `POST /upload` endpoint.
 Rendered by `modules/releases/client/reports/ReleaseReadinessDirector.vue`.
 
+The dashboard defaults to the available release with the latest valid
+`release_schedule.ga_date` on or before the current UTC date. Future releases
+and version views without a schedule are available for manual selection but
+are not selected on open. If no release qualifies, no version is selected.
+
 ```json
 {
   "version": "rhoai-3.5.EA2",

--- a/modules/releases/__tests__/client/release-readiness-status.test.js
+++ b/modules/releases/__tests__/client/release-readiness-status.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getRequiredOpenTasks,
+  releaseDisplayStatus
+} from '../../client/reports/release-readiness-status'
+
+function releaseData(status, tasks) {
+  return {
+    release_schedule: { status },
+    breakdowns: {
+      initiative: {
+        test_execution: {
+          phases: [{ epic_key: 'phase-1', tasks }]
+        }
+      }
+    }
+  }
+}
+
+describe('release readiness display status', () => {
+  it('flags released releases with unfinished tasks', () => {
+    const data = releaseData('Released', [
+      { key: 'RHOAIENG-1', status_category: 'Done', resolution: 'Done' },
+      { key: 'RHOAIENG-2', status_category: 'In Progress', resolution: null }
+    ])
+
+    expect(getRequiredOpenTasks(data)).toHaveLength(1)
+    expect(releaseDisplayStatus(data)).toBe('Released with Open Tasks')
+  })
+
+  it('treats no-work resolutions as unfinished work', () => {
+    const data = releaseData('GA', [
+      { key: 'RHOAIENG-1', status_category: 'Done', resolution: "Won't Do" }
+    ])
+
+    expect(releaseDisplayStatus(data)).toBe('Released with Open Tasks')
+  })
+
+  it('keeps normal released status when all tasks are complete', () => {
+    const data = releaseData('Released', [
+      { key: 'RHOAIENG-1', status_category: 'Done', resolution: 'Done' }
+    ])
+
+    expect(releaseDisplayStatus(data)).toBe('Released')
+  })
+
+  it('does not flag unfinished tasks before release', () => {
+    const data = releaseData('Planning', [
+      { key: 'RHOAIENG-1', status_category: 'In Progress', resolution: null }
+    ])
+
+    expect(releaseDisplayStatus(data)).toBe('Planning')
+  })
+
+  it('deduplicates tasks repeated across breakdowns', () => {
+    const data = releaseData('Released', [
+      { key: 'RHOAIENG-1', status_category: 'Open', resolution: null }
+    ])
+    data.breakdowns.other = data.breakdowns.initiative
+
+    expect(getRequiredOpenTasks(data)).toHaveLength(1)
+  })
+})

--- a/modules/releases/__tests__/server/release-readiness/routes.test.js
+++ b/modules/releases/__tests__/server/release-readiness/routes.test.js
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const registerRoutes = require('../../../server/release-readiness/routes')
+
+describe('release readiness default release', () => {
+  let handler
+  let storage
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-07T12:00:00Z'))
+    storage = { listStorageFiles: vi.fn(), readFromStorage: vi.fn() }
+    const router = {
+      get: (path, ...handlers) => { if (path === '/versions') handler = handlers.at(-1) },
+      post: vi.fn()
+    }
+    registerRoutes(router, { storage, requireAuth: vi.fn(), requireScope: () => vi.fn() })
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  async function getVersions(entries) {
+    storage.listStorageFiles.mockResolvedValue(Object.keys(entries).map(v => `${v}.json`))
+    storage.readFromStorage.mockImplementation(async path => {
+      const entry = entries[path.split('/').at(-1).replace('.json', '')]
+      if (entry instanceof Error) throw entry
+      return entry
+    })
+    const res = { json: vi.fn() }
+    await handler({}, res)
+    return res.json.mock.calls[0][0]
+  }
+
+  const scheduled = ga_date => ({ release_schedule: { ga_date } })
+
+  it('selects the latest arrived GA, regardless of file order', async () => {
+    const result = await getVersions({
+      future: scheduled('2026-11-15'),
+      version: {},
+      current: scheduled('2026-08-19'),
+      old: scheduled('2026-05-01')
+    })
+    expect(result.default_version).toBe('current')
+    expect(result.versions).toEqual(['future', 'version', 'current', 'old'])
+  })
+
+  it('includes a release arriving today', async () => {
+    expect((await getVersions({ old: scheduled('2026-08-19'), today: scheduled('2026-09-07') })).default_version).toBe('today')
+  })
+
+  it('does not fall back to future, undated, invalid, or unreadable versions', async () => {
+    expect((await getVersions({
+      future: scheduled('2026-11-15'),
+      version: {},
+      invalid: scheduled('2026-02-30'),
+      malformed: scheduled('not-a-date'),
+      unreadable: new Error('Unreadable metrics')
+    })).default_version).toBeNull()
+  })
+
+  it('returns no default when storage is empty', async () => {
+    expect(await getVersions({})).toEqual({ versions: [], default_version: null })
+  })
+})

--- a/modules/releases/client/reports/ReleaseReadinessDirector.vue
+++ b/modules/releases/client/reports/ReleaseReadinessDirector.vue
@@ -795,8 +795,6 @@ function ragBarClass(rag) {
   return 'bg-gray-400'
 }
 
-// Resolutions that mean the item was closed without completing the work
-// (mirrors the no-work resolutions excluded from person-metrics, see docs/DATA-FORMATS.md)
 function statusResolutionLabel(status, resolution) {
   return resolution ? `${status} - ${resolution}` : status
 }

--- a/modules/releases/client/reports/ReleaseReadinessDirector.vue
+++ b/modules/releases/client/reports/ReleaseReadinessDirector.vue
@@ -31,9 +31,11 @@
             <span class="text-sm font-bold">{{ formatScheduleDate(releaseSchedule.ga_date) }}</span>
           </div>
           <div class="flex flex-col items-center rounded-xl px-5 py-2.5 min-w-[90px]"
-            :class="releaseSchedule.status === 'Released' ? 'bg-emerald-500/30' : 'bg-amber-500/30'">
+            :class="releaseDisplayStatus(data) === 'Released with Open Tasks'
+              ? 'bg-red-500/30'
+              : isReleasedStatus(releaseSchedule.status) ? 'bg-emerald-500/30' : 'bg-amber-500/30'">
             <span class="text-[10px] font-semibold uppercase tracking-wider text-blue-200 mb-0.5">Status</span>
-            <span class="text-sm font-bold">{{ releaseSchedule.status }}</span>
+            <span class="text-sm font-bold">{{ releaseDisplayStatus(data) }}</span>
           </div>
         </div>
       </div>
@@ -451,6 +453,7 @@
 import { ref, reactive, computed, inject, onMounted } from 'vue'
 import { ArrowLeft, Shield } from 'lucide-vue-next'
 import { useReleaseReadiness } from './composables/useReleaseReadiness'
+import { isNoWorkResolution, isReleasedStatus, releaseDisplayStatus } from './release-readiness-status'
 
 const moduleNav = inject('moduleNav')
 const {
@@ -794,12 +797,6 @@ function ragBarClass(rag) {
 
 // Resolutions that mean the item was closed without completing the work
 // (mirrors the no-work resolutions excluded from person-metrics, see docs/DATA-FORMATS.md)
-const NO_WORK_RESOLUTIONS = ["Won't Do", "Can't Do", 'Obsolete', 'Duplicate', 'Cannot Reproduce']
-
-function isNoWorkResolution(resolution) {
-  return !!resolution && NO_WORK_RESOLUTIONS.includes(resolution)
-}
-
 function statusResolutionLabel(status, resolution) {
   return resolution ? `${status} - ${resolution}` : status
 }

--- a/modules/releases/client/reports/ReleaseReadinessDirector.vue
+++ b/modules/releases/client/reports/ReleaseReadinessDirector.vue
@@ -468,9 +468,11 @@ const JIRA_HOST = 'https://redhat.atlassian.net'
 const expandedPhases = reactive({})
 
 onMounted(async () => {
+  data.value = null
+  error.value = null
   await loadVersions()
-  if (versions.value.length > 0) {
-    const initial = defaultVersion.value || versions.value[0]
+  if (defaultVersion.value && versions.value.includes(defaultVersion.value)) {
+    const initial = defaultVersion.value
     selectedVersion.value = initial
     await loadMetrics(initial)
     if (data.value && data.value.component_readiness) {

--- a/modules/releases/client/reports/release-readiness-status.js
+++ b/modules/releases/client/reports/release-readiness-status.js
@@ -1,0 +1,48 @@
+const NO_WORK_RESOLUTIONS = new Set([
+  "Won't Do",
+  "Can't Do",
+  'Obsolete',
+  'Duplicate',
+  'Cannot Reproduce'
+])
+
+export function isNoWorkResolution(resolution) {
+  return !!resolution && NO_WORK_RESOLUTIONS.has(resolution)
+}
+
+export function isTaskComplete(task) {
+  if (!task) return true
+  if (isNoWorkResolution(task.resolution)) return false
+
+  return (task.status_category || task.status) === 'Done'
+}
+
+export function getRequiredOpenTasks(data) {
+  const openTasks = []
+  const seenKeys = new Set()
+
+  for (const breakdown of Object.values(data?.breakdowns || {})) {
+    for (const phase of breakdown?.test_execution?.phases || []) {
+      for (const task of phase.tasks || []) {
+        // A task can appear in more than one breakdown when initiatives overlap.
+        if (task.key && seenKeys.has(task.key)) continue
+        if (task.key) seenKeys.add(task.key)
+        if (!isTaskComplete(task)) openTasks.push(task)
+      }
+    }
+  }
+
+  return openTasks
+}
+
+export function isReleasedStatus(status) {
+  return ['released', 'ga'].includes(String(status || '').trim().toLowerCase())
+}
+
+export function releaseDisplayStatus(data) {
+  const status = data?.release_schedule?.status
+  if (isReleasedStatus(status) && getRequiredOpenTasks(data).length > 0) {
+    return 'Released with Open Tasks'
+  }
+  return status || ''
+}

--- a/modules/releases/server/release-readiness/routes.js
+++ b/modules/releases/server/release-readiness/routes.js
@@ -37,7 +37,7 @@ const STORAGE_PREFIX = 'releases/release-readiness';
  *     summary: List available release readiness versions
  *     responses:
  *       200:
- *         description: Object with versions array and default_version
+ *         description: Object with versions array and default_version (latest GA date on or before today, or null)
  */
 
 /**
@@ -89,7 +89,7 @@ function registerReleaseReadinessRoutes(router, { storage, requireAuth, requireS
       .filter(f => f.endsWith('.json'))
       .map(f => f.replace('.json', '').replace(/_/g, ' '));
 
-    const defaultVersion = findUpcomingVersion(versions, storage);
+    const defaultVersion = await findCurrentVersion(versions, storage);
 
     res.json({ versions, default_version: defaultVersion });
   });
@@ -137,11 +137,11 @@ function sanitizeFilename(version) {
 }
 
 /**
- * Scan stored metrics to find the version with the nearest upcoming GA date.
- * Returns null if no upcoming version is found (falls back to first version
- * on the client side).
+ * Select the latest release whose GA date has arrived (using the UTC day).
+ * Undated version views and future releases remain available for manual selection.
+ * Returns null when no current release can be determined.
  */
-function findUpcomingVersion(versions, storage) {
+async function findCurrentVersion(versions, storage) {
   const today = new Date().toISOString().slice(0, 10);
   let best = null;
   let bestGa = null;
@@ -149,10 +149,13 @@ function findUpcomingVersion(versions, storage) {
   for (const v of versions) {
     try {
       const filename = sanitizeFilename(v);
-      const data = storage.readFromStorage(`${STORAGE_PREFIX}/${filename}.json`);
+      const data = await storage.readFromStorage(`${STORAGE_PREFIX}/${filename}.json`);
       const gaDate = data?.release_schedule?.ga_date;
-      if (gaDate && gaDate >= today) {
-        if (!bestGa || gaDate < bestGa) {
+      const validDate = typeof gaDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(gaDate)
+        && Number.isFinite(Date.parse(gaDate))
+        && new Date(gaDate).toISOString().slice(0, 10) === gaDate;
+      if (validDate && gaDate <= today) {
+        if (!bestGa || gaDate > bestGa) {
           bestGa = gaDate;
           best = v;
         }

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1066,6 +1066,46 @@ test.describe('Releases Release Readiness @releases', () => {
     await expect(page.getByRole('heading', { name: 'rhoai-3.6.EA1', exact: true })).toBeVisible();
   });
 
+  test('release readiness flags released releases with unfinished tasks in red', async ({ page }) => {
+    const openVersion = 'rhoai-3.5.EA1';
+    const cleanVersion = 'rhoai-3.5.EA2';
+    const payload = (version, tasks) => ({
+      version,
+      generated_at: '2026-09-07T10:00:00Z',
+      release_schedule: { ga_date: '2026-05-01', status: 'Released' },
+      director_summary: {
+        gate_statuses: [{ gate: 'Test Execution', done: 1, total: 1, pct: 100, rag: 'GREEN' }],
+        test_timeline: []
+      },
+      breakdowns: {
+        initiative: { test_execution: { phases: [{ epic_key: 'phase-1', tasks }] } }
+      },
+      component_readiness: { all_components: [], phases: [] },
+      product_blockers: { total_open: 0, components: [] }
+    });
+
+    await page.route('**/api/modules/releases/release-readiness/versions', route => route.fulfill({
+      json: { versions: [openVersion, cleanVersion], default_version: openVersion }
+    }));
+    await page.route('**/api/modules/releases/release-readiness?version=*', route => {
+      const version = new URL(route.request().url()).searchParams.get('version');
+      const tasks = version === openVersion
+        ? [{ key: 'RHOAIENG-82501', status: 'In Progress', status_category: 'In Progress', resolution: null }]
+        : [{ key: 'RHOAIENG-82502', status: 'Done', status_category: 'Done', resolution: 'Done' }];
+      return route.fulfill({ json: payload(version, tasks) });
+    });
+
+    await page.goto('/#/releases/reports?report=release-readiness');
+    const status = page.getByText('Released with Open Tasks', { exact: true });
+    await expect(status).toBeVisible();
+    await expect(status.locator('..')).toHaveClass(/bg-red-500\/30/);
+
+    const selector = page.locator('select').filter({ has: page.locator(`option[value="${cleanVersion}"]`) });
+    await selector.selectOption(cleanVersion);
+    await expect(page.getByText('Released', { exact: true })).toBeVisible();
+    await expect(page.getByText('Released with Open Tasks', { exact: true })).toHaveCount(0);
+  });
+
   test('release readiness metrics API returns data for fixture version', async ({ request }) => {
     const res = await request.get('/api/modules/releases/release-readiness?version=rhoai-3.5.EA2');
     if (res.status() === 404) {

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1033,6 +1033,39 @@ test.describe('Releases Release Readiness @releases', () => {
     expect(Array.isArray(body.versions)).toBe(true);
   });
 
+  test('release readiness opens on the current release and allows manual switching', async ({ page }) => {
+    const current = 'rhoai-3.5.EA1';
+    const future = 'rhoai-3.6.EA1';
+    await page.route('**/api/modules/releases/release-readiness/versions', route => route.fulfill({
+      json: { versions: [future, 'rhoai-3.5.EA2', current], default_version: current }
+    }));
+
+    await page.goto('/#/releases/reports?report=release-readiness');
+    const selector = page.locator('select').filter({ has: page.locator(`option[value="${current}"]`) });
+    await expect(selector).toHaveValue(current);
+    await expect(page.getByRole('heading', { name: current, exact: true })).toBeVisible();
+
+    await selector.selectOption(future);
+    await expect(page.getByRole('heading', { name: future, exact: true })).toBeVisible();
+
+    await page.getByTitle('Back to Reports').click();
+    await page.getByText('RHOAI Release Readiness', { exact: true }).click();
+    await expect(selector).toHaveValue(current);
+    await expect(page.getByRole('heading', { name: current, exact: true })).toBeVisible();
+  });
+
+  test('release readiness leaves selection empty when no current release is available', async ({ page }) => {
+    await page.route('**/api/modules/releases/release-readiness/versions', route => route.fulfill({
+      json: { versions: ['rhoai-3.6.EA1'], default_version: null }
+    }));
+    await page.goto('/#/releases/reports?report=release-readiness');
+    const selector = page.locator('select').filter({ has: page.locator('option[value="rhoai-3.6.EA1"]') });
+    await expect(selector).toHaveValue('');
+    await expect(page.getByText('Select a release version to view readiness status')).toBeVisible();
+    await selector.selectOption('rhoai-3.6.EA1');
+    await expect(page.getByRole('heading', { name: 'rhoai-3.6.EA1', exact: true })).toBeVisible();
+  });
+
   test('release readiness metrics API returns data for fixture version', async ({ request }) => {
     const res = await request.get('/api/modules/releases/release-readiness?version=rhoai-3.5.EA2');
     if (res.status() === 404) {


### PR DESCRIPTION
## Summary

- Display `Released with Open Tasks` in red when a released/GA release has unfinished test-execution tasks.
- Restore the normal released presentation when all tasks are complete.
- Add unit and integration coverage plus data-format documentation.

Refs RHOAIENG-82505

## Validation

- `npm run lint`
- `npm run build`
- `npm run validate:modules`
- `npm run validate:openapi`
- Focused Vitest tests: 9 passed
- Full Vitest suite: 5,563 passed; 53 unrelated localStorage environment failures
- Browser acceptance test could not run because Chromium is not installed locally.