### PR TITLE
AI Planner: reconcile to 19 Priority Outcomes matching Org Pulse

### DIFF
--- a/modules/releases/client/plan/views/AIPlanner.vue
+++ b/modules/releases/client/plan/views/AIPlanner.vue
@@ -1,15 +1,29 @@
 <script setup>
+import { ref } from 'vue'
+import { useDraftPlans } from '../composables/useDraftPlans'
+
+const { session } = useDraftPlans()
+const iframeRef = ref(null)
+
 // Pinned to specific commit — update via PR to rhai-org-pulse
-const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/fbd9241/index.html'
+const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/de5b07f/index.html'
+
+function onIframeLoad() {
+  const actor = session.value && session.value.actor
+  if (!actor || !iframeRef.value) return
+  iframeRef.value.contentWindow.postMessage({ type: 'pm-user', actor }, '*')
+}
 </script>
 
 <template>
   <div class="ai-planner-container" style="width: 100%; height: calc(100vh - 120px);">
     <iframe
+      ref="iframeRef"
       :src="PLANNER_URL"
       style="width: 100%; height: 100%; border: none;"
       title="AI-First Release Planner"
       sandbox="allow-scripts"
+      @load="onIframeLoad"
     />
   </div>
 </template>

--- a/modules/releases/client/plan/views/AIPlanner.vue
+++ b/modules/releases/client/plan/views/AIPlanner.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Pinned to specific commit — update via PR to rhai-org-pulse
-const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/57588c5/index.html'
+const PLANNER_URL = 'https://htmlpreview.github.io/?https://github.com/yuvalluria/rhai-release-planner/blob/fbd9241/index.html'
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- Updates AI Planner iframe SHA: `57588c5` → `fbd9241`
- Reconciles Priority Outcomes from 18 → 19 to exactly match the Org Pulse official Big Rocks list
- Renames, adds, and removes outcomes to align naming and coverage with RHAISTRAT strategy

**Changes in this planner version (fbd9241):**
- Add: From Tools to Swarms (MCP) — P6 (RHAISTRAT-1354/1355/932)
- Add: vLLM Omni — P15 (RHAISTRAT-1266)
- Add: llm-d Tool Calling Pass Through — P16 (RHAISTRAT-1971/1357)
- Add: Security Remediation — P19 (RHAISTRAT-2046)
- Rename: llm-d Platform → llm-d on xKS (merged with Unified RHAII on xKS)
- Rename: Bring Your Own Agent → Bring Your Own Agent / Agent Ops
- Rename: NVIDIA Rubin Day 0 → Red Hat AI Factory with NVIDIA Rubin Day 0
- Remove: Unified RHAII on xKS (duplicate), Inference Server for Agents, RBAC (now under Multitenancy)
- Update capacity banner: 18 → 19 outcomes (46% more than 3.4)

## Test plan
- [ ] Open AI Planner tab in Org Pulse — planner loads in iframe
- [ ] Verify Priority Outcomes tab shows 19 tiles (P1–P19)
- [ ] Confirm new outcomes visible: From Tools to Swarms (MCP), vLLM Omni, llm-d Tool Calling Pass Through, Security Remediation
- [ ] Confirm renamed outcomes: llm-d on xKS, Bring Your Own Agent / Agent Ops, Red Hat AI Factory with NVIDIA Rubin Day 0