### PR TITLE
fix(ai-impact): show Jira target versions for ODH onboarding components

### DIFF
--- a/modules/ai-impact/__tests__/client/version-group.test.js
+++ b/modules/ai-impact/__tests__/client/version-group.test.js
@@ -43,11 +43,11 @@ describe('extractVersionGroup', () => {
     expect(extractVersionGroup('EA1')).toBeNull()
   })
 
-  it('recognizes ODH build type values', () => {
-    expect(extractVersionGroup('CI')).toBe('CI')
-    expect(extractVersionGroup('ci')).toBe('CI')
-    expect(extractVersionGroup('Release')).toBe('Release')
-    expect(extractVersionGroup('release')).toBe('Release')
+  it('returns null for ODH YAML build_type values', () => {
+    expect(extractVersionGroup('CI')).toBeNull()
+    expect(extractVersionGroup('ci')).toBeNull()
+    expect(extractVersionGroup('Release')).toBeNull()
+    expect(extractVersionGroup('release')).toBeNull()
   })
 })
 
@@ -61,15 +61,6 @@ describe('collectVersionGroups', () => {
       'rhoai-3.6',
       'rhoai-2.21'
     ])).toEqual(['2.21', '3.5', '3.5.EA1', '3.6'])
-  })
-
-  it('places ODH build types after numeric versions', () => {
-    expect(collectVersionGroups([
-      'CI',
-      'rhoai-3.5',
-      'Release',
-      'rhoai-3.6'
-    ])).toEqual(['3.5', '3.6', 'CI', 'Release'])
   })
 })
 

--- a/modules/ai-impact/__tests__/server/component-onboarding-target-version.test.js
+++ b/modules/ai-impact/__tests__/server/component-onboarding-target-version.test.js
@@ -1,12 +1,12 @@
-const { describe, it, expect } = require('vitest');
-const {
+import { describe, it, expect } from 'vitest';
+import {
   isOdhBuildType,
   resolveTargetVersion,
   extractVersionNameFromJiraField,
   needsTargetVersionEnrichment
-} = require('../../server/component-onboarding/target-version');
-const { validateComponentOnboarding } = require('../../server/component-onboarding/validation');
-const { enrichTargetVersionsFromJira } = require('../../server/component-onboarding/jira-sync');
+} from '../../server/component-onboarding/target-version.js';
+import { validateComponentOnboarding } from '../../server/component-onboarding/validation.js';
+import { enrichTargetVersionsFromJira } from '../../server/component-onboarding/jira-sync.js';
 
 describe('isOdhBuildType', () => {
   it('detects CI and Release build types', () => {

--- a/modules/ai-impact/__tests__/server/component-onboarding-target-version.test.js
+++ b/modules/ai-impact/__tests__/server/component-onboarding-target-version.test.js
@@ -1,0 +1,120 @@
+const { describe, it, expect } = require('vitest');
+const {
+  isOdhBuildType,
+  resolveTargetVersion,
+  extractVersionNameFromJiraField,
+  needsTargetVersionEnrichment
+} = require('../../server/component-onboarding/target-version');
+const { validateComponentOnboarding } = require('../../server/component-onboarding/validation');
+const { enrichTargetVersionsFromJira } = require('../../server/component-onboarding/jira-sync');
+
+describe('isOdhBuildType', () => {
+  it('detects CI and Release build types', () => {
+    expect(isOdhBuildType('CI')).toBe(true);
+    expect(isOdhBuildType('release')).toBe(true);
+    expect(isOdhBuildType('3.6 GA RHOAI RELEASE')).toBe(false);
+  });
+});
+
+describe('resolveTargetVersion', () => {
+  it('prefers jiraTargetVersion over legacy build_type targetVersion', () => {
+    expect(resolveTargetVersion({
+      targetVersion: 'CI',
+      jiraTargetVersion: '3.6 GA RHOAI RELEASE'
+    })).toBe('3.6 GA RHOAI RELEASE');
+  });
+
+  it('drops build_type-only targetVersion values', () => {
+    expect(resolveTargetVersion({ targetVersion: 'Release' })).toBeNull();
+  });
+
+  it('keeps numeric Jira target versions', () => {
+    expect(resolveTargetVersion({ targetVersion: 'rhoai-3.5' })).toBe('rhoai-3.5');
+    expect(resolveTargetVersion({ targetVersion: '3.6 EA2 RHOAI RELEASE' })).toBe('3.6 EA2 RHOAI RELEASE');
+  });
+});
+
+describe('validateComponentOnboarding targetVersion', () => {
+  const base = {
+    key: 'RHOAIENG-1',
+    summary: 'Test onboarding',
+    status: 'In Progress',
+    completionStatus: 'in-progress',
+    productContext: 'ODH',
+    syncedAt: '2026-01-01T00:00:00.000Z'
+  };
+
+  it('stores null targetVersion when ingest sends build_type as targetVersion', () => {
+    const result = validateComponentOnboarding({ ...base, targetVersion: 'CI' });
+    expect(result.valid).toBe(true);
+    expect(result.data.targetVersion).toBeNull();
+  });
+
+  it('stores Jira target version from jiraTargetVersion alias', () => {
+    const result = validateComponentOnboarding({
+      ...base,
+      targetVersion: 'CI',
+      jiraTargetVersion: '3.6 GA RHOAI RELEASE'
+    });
+    expect(result.valid).toBe(true);
+    expect(result.data.targetVersion).toBe('3.6 GA RHOAI RELEASE');
+  });
+});
+
+describe('extractVersionNameFromJiraField', () => {
+  it('extracts version name from Jira field shapes', () => {
+    expect(extractVersionNameFromJiraField({ name: '3.6 GA RHOAI RELEASE' }))
+      .toBe('3.6 GA RHOAI RELEASE');
+    expect(extractVersionNameFromJiraField([{ name: '3.5 EA1 RHOAI RELEASE' }]))
+      .toBe('3.5 EA1 RHOAI RELEASE');
+    expect(extractVersionNameFromJiraField('rhoai-3.6')).toBe('rhoai-3.6');
+  });
+});
+
+describe('enrichTargetVersionsFromJira', () => {
+  it('back-fills targetVersion from Jira for ODH build_type placeholders', async () => {
+    const data = {
+      components: {
+        'RHOAIENG-93240': {
+          latest: {
+            key: 'RHOAIENG-93240',
+            targetVersion: 'CI',
+            productContext: 'ODH'
+          },
+          history: []
+        }
+      }
+    };
+
+    const fetchFn = async (_jiraRequest, _jql, _fields) => ([
+      {
+        key: 'RHOAIENG-93240',
+        fields: { customfield_10855: { name: '3.6 GA RHOAI RELEASE' } }
+      }
+    ]);
+
+    const result = await enrichTargetVersionsFromJira(data, () => {}, fetchFn);
+
+    expect(result.updated).toBe(1);
+    expect(data.components['RHOAIENG-93240'].latest.targetVersion)
+      .toBe('3.6 GA RHOAI RELEASE');
+    expect(needsTargetVersionEnrichment(data.components['RHOAIENG-93240'].latest)).toBe(false);
+  });
+
+  it('skips components that already have a release targetVersion', async () => {
+    const data = {
+      components: {
+        'RHOAIENG-1': {
+          latest: { key: 'RHOAIENG-1', targetVersion: 'rhoai-3.5' },
+          history: []
+        }
+      }
+    };
+
+    const fetchFn = async () => { throw new Error('should not fetch'); };
+    const result = await enrichTargetVersionsFromJira(data, () => {}, fetchFn);
+
+    expect(result.synced).toBe(0);
+    expect(result.updated).toBe(0);
+  });
+});

--- a/modules/ai-impact/client/utils/version-group.js
+++ b/modules/ai-impact/client/utils/version-group.js
@@ -10,23 +10,17 @@
  *   "3.5" / "3.5.EA1" / "3.5.EA2"  → three options
  */
 
-// ODH build type values that are valid version group keys (not numeric releases).
-// Maps lowercase → canonical display form.
-const ODH_BUILD_TYPES = { ci: 'CI', release: 'Release' }
-
 /**
  * @param {string|null|undefined} name
- * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1", "CI", "Release"
+ * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1"
  */
 export function extractVersionGroup(name) {
   if (name == null) return null
   let s = String(name).toLowerCase().trim()
   if (!s) return null
 
-  // ODH build_type values map to their canonical form.
-  if (s in ODH_BUILD_TYPES) {
-    return ODH_BUILD_TYPES[s]
-  }
+  // ODH YAML build_type values are not release versions.
+  if (s === 'ci' || s === 'release') return null
 
   s = s.replace(/\brhel\s+ai\b/g, 'rhelai')
   s = s.replace(/\.z(?=$|[.\s])/gi, '')
@@ -81,14 +75,11 @@ export function collectVersionGroups(versions) {
 }
 
 /**
- * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 … < CI < Release
- * Non-numeric labels (ODH build types) sort after all numeric versions.
+ * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 …
  */
 function compareVersionGroups(a, b) {
   const pa = parseGroupKey(a)
   const pb = parseGroupKey(b)
-  if (pa.isLabel !== pb.isLabel) return pa.isLabel ? 1 : -1
-  if (pa.isLabel && pb.isLabel) return a.localeCompare(b)
   if (pa.major !== pb.major) return pa.major - pb.major
   if (pa.minor !== pb.minor) return pa.minor - pb.minor
   if (pa.patch !== pb.patch) return pa.patch - pb.patch
@@ -98,15 +89,14 @@ function compareVersionGroups(a, b) {
 
 function parseGroupKey(key) {
   const m = String(key).match(/^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(EA\d+))?$/i)
-  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0, isLabel: true }
+  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0 }
   const phase = m[4] ? m[4].toUpperCase() : null
   return {
     major: Number(m[1]),
     minor: Number(m[2]),
     patch: m[3] ? Number(m[3]) : 0,
     phase,
-    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0,
-    isLabel: false
+    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0
   }
 }
 

--- a/modules/ai-impact/server/component-onboarding/jira-sync.js
+++ b/modules/ai-impact/server/component-onboarding/jira-sync.js
@@ -1,0 +1,105 @@
+const { fetchAllJqlResults } = require('../../../../shared/server/jira');
+const { readComponentOnboarding, writeComponentOnboardingAtomic } = require('./storage');
+const {
+  TARGET_VERSION_FIELD,
+  extractVersionNameFromJiraField,
+  needsTargetVersionEnrichment
+} = require('./target-version');
+
+const BATCH_SIZE = 50;
+const BATCH_DELAY_MS = 1000;
+
+const coLock = { held: false };
+
+function acquireLock() {
+  if (coLock.held) return false;
+  coLock.held = true;
+  return true;
+}
+
+function releaseLock() {
+  coLock.held = false;
+}
+
+/**
+ * Fetch Jira Target Version (customfield_10855) for components missing a numeric release.
+ * Mutates data in place.
+ *
+ * @param {object} data - Full component onboarding store
+ * @param {Function} jiraRequest
+ * @param {Function} [fetchFn] - Override for tests
+ * @returns {Promise<{ synced: number, updated: number, errors: string[] }>}
+ */
+async function enrichTargetVersionsFromJira(data, jiraRequest, fetchFn) {
+  const doFetch = fetchFn || fetchAllJqlResults;
+  const keysToEnrich = [];
+
+  for (const [key, entry] of Object.entries(data.components || {})) {
+    if (needsTargetVersionEnrichment(entry.latest)) keysToEnrich.push(key);
+  }
+
+  if (keysToEnrich.length === 0) {
+    return { synced: 0, updated: 0, errors: [] };
+  }
+
+  const counts = { synced: 0, updated: 0 };
+  const errors = [];
+
+  for (let i = 0; i < keysToEnrich.length; i += BATCH_SIZE) {
+    const batch = keysToEnrich.slice(i, i + BATCH_SIZE);
+
+    if (i > 0) {
+      await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+    }
+
+    const jql = `key in (${batch.join(',')})`;
+    let issues;
+    try {
+      issues = await doFetch(jiraRequest, jql, TARGET_VERSION_FIELD);
+    } catch (err) {
+      errors.push(`Batch at offset ${i}: ${err.message}`);
+      continue;
+    }
+
+    const issueMap = new Map((issues || []).map(iss => [iss.key, iss]));
+
+    for (const key of batch) {
+      counts.synced++;
+      const issue = issueMap.get(key);
+      if (!issue) continue;
+
+      const tvName = extractVersionNameFromJiraField(issue.fields?.[TARGET_VERSION_FIELD]);
+      if (!tvName) continue;
+
+      const entry = data.components[key];
+      if (entry.latest.targetVersion !== tvName) {
+        entry.latest.targetVersion = tvName;
+        counts.updated++;
+      }
+    }
+  }
+
+  return { synced: counts.synced, updated: counts.updated, errors };
+}
+
+/**
+ * Read storage, enrich target versions from Jira, write back when changed.
+ */
+async function syncComponentOnboardingFromJira(readFromStorage, writeToStorage, jiraRequest, fetchFn) {
+  const data = await readComponentOnboarding(readFromStorage);
+  const result = await enrichTargetVersionsFromJira(data, jiraRequest, fetchFn);
+
+  if (result.updated > 0) {
+    await writeComponentOnboardingAtomic(writeToStorage, data);
+  }
+
+  return result;
+}
+
+module.exports = {
+  BATCH_SIZE,
+  acquireLock,
+  releaseLock,
+  enrichTargetVersionsFromJira,
+  syncComponentOnboardingFromJira
+};

--- a/modules/ai-impact/server/component-onboarding/routes.js
+++ b/modules/ai-impact/server/component-onboarding/routes.js
@@ -8,20 +8,102 @@ const {
   projectComponent,
   countHistoryEntries
 } = require('./storage');
+const { syncComponentOnboardingFromJira, enrichTargetVersionsFromJira, acquireLock, releaseLock } = require('./jira-sync');
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 const jsonLimit = express.json({ limit: '10mb' });
 const BULK_CAP = 5000;
+
+const syncState = {
+  running: false,
+  startedAt: null,
+  lastResult: null
+};
+
+/**
+ * Run Jira target-version enrichment in the background.
+ */
+async function runSync(readFromStorage, writeToStorage, jiraRequest) {
+  if (syncState.running) return;
+  if (!jiraRequest) {
+    console.warn('[ai-impact] Component onboarding Jira sync skipped: no Jira client');
+    return;
+  }
+  if (!acquireLock()) {
+    console.warn('[ai-impact] Component onboarding Jira sync skipped: write lock held');
+    return;
+  }
+
+  syncState.running = true;
+  syncState.startedAt = new Date().toISOString();
+
+  try {
+    const result = await syncComponentOnboardingFromJira(readFromStorage, writeToStorage, jiraRequest);
+    syncState.lastResult = {
+      status: result.errors.length > 0 ? 'partial' : 'success',
+      message: `Enriched ${result.updated} of ${result.synced} components from Jira Target Version`,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+      completedAt: new Date().toISOString()
+    };
+  } catch (err) {
+    console.error('[ai-impact] Component onboarding Jira sync failed:', err);
+    syncState.lastResult = {
+      status: 'error',
+      message: err.message,
+      completedAt: new Date().toISOString()
+    };
+  } finally {
+    syncState.running = false;
+    releaseLock();
+  }
+}
 
 /**
  * Register component onboarding routes on the module router.
  * Static routes BEFORE parameterized routes.
  */
 module.exports = function registerComponentOnboardingRoutes(router, context) {
-  const { storage, requireAdmin, requireScope } = context;
+  const { storage, requireAdmin, requireScope, jiraRequest } = context;
   const { readFromStorage, writeToStorage } = storage;
 
   // ─── Static routes first ───
+
+  /**
+   * @openapi
+   * /api/modules/ai-impact/component-onboarding/sync/status:
+   *   get:
+   *     summary: Get component onboarding Jira target-version sync status
+   *     tags: [AI Impact - Component Onboarding]
+   *     security: [{ bearerAuth: [] }]
+   *     responses:
+   *       200:
+   *         description: Sync status
+   */
+  router.get('/component-onboarding/sync/status', requireScope('ai-impact:read'), function(req, res) {
+    res.json(syncState);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/ai-impact/component-onboarding/sync:
+   *   post:
+   *     summary: Enrich component onboarding target versions from Jira
+   *     tags: [AI Impact - Component Onboarding]
+   *     security: [{ bearerAuth: [] }]
+   *     responses:
+   *       200:
+   *         description: Sync started or skipped
+   */
+  router.post('/component-onboarding/sync', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
+    if (DEMO_MODE) {
+      return res.json({ status: 'skipped', message: 'Component onboarding sync disabled in demo mode' });
+    }
+    if (syncState.running || context.isRefreshRunning()) {
+      return res.json({ status: 'already_running' });
+    }
+    res.json({ status: 'started' });
+    runSync(readFromStorage, writeToStorage, jiraRequest);
+  });
 
   /**
    * @openapi
@@ -90,6 +172,14 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
     data.fetchedAt = new Date().toISOString();
     data.totalComponents = Object.keys(data.components).length;
 
+    if (jiraRequest && (counts.created > 0 || counts.updated > 0)) {
+      try {
+        await enrichTargetVersionsFromJira(data, jiraRequest);
+      } catch (err) {
+        console.error('[ai-impact] Inline component onboarding target version enrichment failed:', err.message);
+      }
+    }
+
     await writeComponentOnboardingAtomic(writeToStorage, data);
 
     res.json({
@@ -98,6 +188,13 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
       unchanged: counts.unchanged,
       errors
     });
+
+    if (counts.created > 0 || counts.updated > 0) {
+      setTimeout(() => {
+        console.log('[ai-impact] Triggering post-ingest component onboarding Jira sync');
+        runSync(readFromStorage, writeToStorage, jiraRequest);
+      }, 10000);
+    }
   });
 
   /**
@@ -175,4 +272,16 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
       history: entry.history
     });
   });
+
+  if (context.registerRefresh) {
+    context.registerRefresh('component-onboarding-sync', {
+      order: 65,
+      timeout: 600000,
+      description: 'Enriches component onboarding target versions from Jira customfield_10855.',
+      handler: async function() {
+        if (DEMO_MODE) return;
+        await runSync(readFromStorage, writeToStorage, jiraRequest);
+      }
+    });
+  }
 };

--- a/modules/ai-impact/server/component-onboarding/target-version.js
+++ b/modules/ai-impact/server/component-onboarding/target-version.js
@@ -1,0 +1,64 @@
+/**
+ * Target version resolution for component onboarding.
+ *
+ * targetVersion must reflect Jira customfield_10855 (e.g. "3.6 GA RHOAI RELEASE").
+ * ODH YAML build_type values ("CI", "Release") are not release versions — they are
+ * ignored here and back-filled from Jira during sync when credentials are available.
+ */
+
+const ODH_BUILD_TYPE_VALUES = new Set(['ci', 'release']);
+
+const TARGET_VERSION_FIELD = 'customfield_10855';
+
+function isOdhBuildType(value) {
+  if (value == null) return false;
+  return ODH_BUILD_TYPE_VALUES.has(String(value).toLowerCase().trim());
+}
+
+/**
+ * Pick the Jira Target Version string from a bulk-ingest body.
+ * @param {object} body
+ * @returns {string|null}
+ */
+function resolveTargetVersion(body) {
+  const jiraTv = typeof body.jiraTargetVersion === 'string' ? body.jiraTargetVersion.trim() : '';
+  if (jiraTv && !isOdhBuildType(jiraTv)) return jiraTv;
+
+  const raw = typeof body.targetVersion === 'string' ? body.targetVersion.trim() : '';
+  if (!raw) return null;
+  if (isOdhBuildType(raw)) return null;
+
+  return raw;
+}
+
+/**
+ * @param {*} field - Raw Jira customfield_10855 value
+ * @returns {string|null}
+ */
+function extractVersionNameFromJiraField(field) {
+  if (field == null) return null;
+  if (Array.isArray(field)) {
+    for (const v of field) {
+      if (v && v.name) return v.name;
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+    return null;
+  }
+  if (typeof field === 'object' && field.name) return field.name;
+  if (typeof field === 'string' && field.trim()) return field.trim();
+  return null;
+}
+
+function needsTargetVersionEnrichment(component) {
+  const tv = component?.targetVersion;
+  return !tv || isOdhBuildType(tv);
+}
+
+module.exports = {
+  ODH_BUILD_TYPE_VALUES,
+  TARGET_VERSION_FIELD,
+  isOdhBuildType,
+  resolveTargetVersion,
+  extractVersionNameFromJiraField,
+  needsTargetVersionEnrichment
+};

--- a/modules/ai-impact/server/component-onboarding/validation.js
+++ b/modules/ai-impact/server/component-onboarding/validation.js
@@ -1,3 +1,5 @@
+const { resolveTargetVersion } = require('./target-version');
+
 const VALID_COMPLETION_STATUSES = ['completed', 'in-progress', 'in_queue'];
 const VALID_PRODUCT_CONTEXTS = ['RHOAI', 'ODH'];
 const VALID_ONBOARDING_METHODS = ['automated', 'manual'];
@@ -217,9 +219,19 @@ function validateComponentOnboarding(body) {
     errors.push('statusCategory must be a string or null');
   }
 
-  // targetVersion: optional string (Jira customfield_10855, e.g. "rhoai-3.6")
+  // targetVersion: optional string (Jira customfield_10855, e.g. "3.6 GA RHOAI RELEASE")
   if (body.targetVersion !== undefined && body.targetVersion !== null && typeof body.targetVersion !== 'string') {
     errors.push('targetVersion must be a string or null');
+  }
+
+  // jiraTargetVersion: optional alias when pipeline sends build_type as targetVersion
+  if (body.jiraTargetVersion !== undefined && body.jiraTargetVersion !== null && typeof body.jiraTargetVersion !== 'string') {
+    errors.push('jiraTargetVersion must be a string or null');
+  }
+
+  // buildType: optional ODH YAML build_type ("CI" / "Release") — not used as targetVersion
+  if (body.buildType !== undefined && body.buildType !== null && typeof body.buildType !== 'string') {
+    errors.push('buildType must be a string or null');
   }
 
   if (errors.length > 0) {
@@ -238,7 +250,8 @@ function validateComponentOnboarding(body) {
         statusCategory: body.statusCategory || null
       }),
       productContext: body.productContext,
-      targetVersion: body.targetVersion?.trim() || null,
+      targetVersion: resolveTargetVersion(body),
+      buildType: body.buildType?.trim() || null,
       statusCategory: body.statusCategory || null,
       syncedAt: body.syncedAt,
       componentName: body.componentName || '',

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -51,7 +51,7 @@ module.exports = function registerRoutes(router, context) {
 
   // Component onboarding routes (Build & Release)
   const registerComponentOnboardingRoutes = require('./component-onboarding/routes');
-  registerComponentOnboardingRoutes(router, context);
+  registerComponentOnboardingRoutes(router, { ...context, jiraRequest });
 
   // Feature Decomposer routes (epic-decomposer pipeline snapshot push)
   const registerDecomposerRoutes = require('./decomposer/routes');


### PR DESCRIPTION
## Summary
- Stop treating ODH YAML `build_type` values (`CI` / `Release`) as target versions in the Build & Release table and version filter.
- Resolve `targetVersion` from Jira `customfield_10855` on ingest, with support for a `jiraTargetVersion` alias when the pipeline still sends build types in `targetVersion`.
- Add Jira enrichment during bulk ingest, a manual `/component-onboarding/sync` backfill endpoint, and refresh registration to populate missing ODH release labels (e.g. `3.6`, `3.6 EA2`).

## Context
ODH onboarding tickets have Jira Target Version values like `3.6 GA RHOAI RELEASE`, but the dashboard was showing `CI` / `Release` because ingest stored YAML `build_type` in `targetVersion`. This aligns ODH display and filtering with RHOAI release formatting.

## Test plan
- [ ] Run `npm test -- modules/ai-impact/__tests__/client/version-group.test.js modules/ai-impact/__tests__/server/component-onboarding-target-version.test.js`
- [ ] Deploy and trigger `POST /api/modules/ai-impact/component-onboarding/sync` to backfill existing ODH rows stored with `CI`/`Release`
- [ ] Open Build & Release, filter by ODH, and confirm Target Version shows numeric releases matching RHOAI formatting
- [ ] Verify version filter dropdown no longer lists `CI` / `Release` as options
- [ ] Confirm a new bulk ingest enriches target versions inline when Jira credentials are configured


Made with [Cursor](https://cursor.com)