### PR TITLE
feat(releases): add Arjay Hinek as Draft Plans plan admin

### DIFF
--- a/modules/releases/__tests__/client/plan/draft-plans-view.test.js
+++ b/modules/releases/__tests__/client/plan/draft-plans-view.test.js
@@ -70,7 +70,7 @@ var FIXTURE = {
     email: 'emarion@redhat.com',
     canImpersonate: true,
     isPlanAdmin: true,
-    planAdminNames: ['Emarion', 'Tiffany Rozell'],
+    planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek'],
     demoMode: true
   }
 }

--- a/modules/releases/__tests__/client/plan/draft-plans-view.test.js
+++ b/modules/releases/__tests__/client/plan/draft-plans-view.test.js
@@ -64,7 +64,7 @@ var FIXTURE = {
   },
   audit: [],
   session: {
-    // Plan admin is allowlist-only (emarion@redhat.com / trozell@redhat.com);
+    // Plan admin is allowlist-only (see plan-admins.js DEFAULT_PLAN_ADMIN_EMAILS);
     // simulate a real allowlisted actor rather than the legacy "Admin" sentinel.
     actor: 'Emarion',
     email: 'emarion@redhat.com',

--- a/modules/releases/__tests__/client/plan/use-draft-plans.test.js
+++ b/modules/releases/__tests__/client/plan/use-draft-plans.test.js
@@ -62,7 +62,7 @@ var FIXTURE = {
   },
   audit: [],
   session: {
-    // Plan admin is allowlist-only (emarion@redhat.com / trozell@redhat.com);
+    // Plan admin is allowlist-only (see plan-admins.js DEFAULT_PLAN_ADMIN_EMAILS);
     // simulate a real allowlisted actor rather than the legacy "Admin" sentinel.
     actor: 'Emarion',
     canImpersonate: true,

--- a/modules/releases/__tests__/client/plan/use-draft-plans.test.js
+++ b/modules/releases/__tests__/client/plan/use-draft-plans.test.js
@@ -67,7 +67,7 @@ var FIXTURE = {
     actor: 'Emarion',
     canImpersonate: true,
     isPlanAdmin: true,
-    planAdminNames: ['Emarion', 'Tiffany Rozell'],
+    planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek'],
     demoMode: true
   }
 }

--- a/modules/releases/__tests__/server/draft-plans/acl.test.js
+++ b/modules/releases/__tests__/server/draft-plans/acl.test.js
@@ -49,6 +49,12 @@ describe('draft-plans acl', function() {
           jiraDisplayName: 'Emarion'
         },
         {
+          uid: 'ahinek',
+          name: 'Arjay Hinek',
+          email: 'ahinek@redhat.com',
+          jiraDisplayName: 'Arjay Hinek'
+        },
+        {
           uid: 'trozell',
           name: 'Tiffany Rozell',
           email: 'trozell@redhat.com',
@@ -104,6 +110,7 @@ describe('draft-plans acl', function() {
     expect(allowlisted.isPlanAdmin).toBe(true)
     expect(allowlisted.planAdminNames).toContain('Tiffany Rozell')
     expect(allowlisted.planAdminNames).toContain('Emarion')
+    expect(allowlisted.planAdminNames).toContain('Arjay Hinek')
 
     var tiffany = await resolveDraftPlanSession(
       { userEmail: 'trozell@redhat.com' },
@@ -112,7 +119,7 @@ describe('draft-plans acl', function() {
     expect(tiffany.isPlanAdmin).toBe(true)
   })
 
-  it('gates Draft Plans view to viewer allowlist (default: emarion only)', async function() {
+  it('gates Draft Plans view to viewer allowlist (default includes planning stakeholders)', async function() {
     var emarion = await resolveDraftPlanSession(
       { userEmail: 'emarion@redhat.com' },
       makeStorage()
@@ -125,6 +132,13 @@ describe('draft-plans acl', function() {
     )
     expect(tiffany.isPlanAdmin).toBe(true)
     expect(tiffany.canViewDraftPlans).toBe(false)
+
+    var arjay = await resolveDraftPlanSession(
+      { userEmail: 'ahinek@redhat.com' },
+      makeStorage()
+    )
+    expect(arjay.isPlanAdmin).toBe(true)
+    expect(arjay.canViewDraftPlans).toBe(true)
 
     var alice = await resolveDraftPlanSession(
       { userEmail: 'alice@redhat.com' },
@@ -204,7 +218,7 @@ describe('draft-plans acl', function() {
       actor: 'Adam Bellusci',
       isPlanAdmin: false,
       canImpersonate: false,
-      planAdminNames: ['Emarion', 'Tiffany Rozell']
+      planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek']
     }
     var meta = applySessionToMeta(
       { currentUser: 'Admin', isPlanAdmin: true, frozenEvents: {} },
@@ -220,7 +234,7 @@ describe('draft-plans acl', function() {
       actor: 'Adam Bellusci',
       isPlanAdmin: false,
       canImpersonate: true,
-      planAdminNames: ['Emarion', 'Tiffany Rozell']
+      planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek']
     }
     var asTiffany = applySessionToMeta({ frozenEvents: {} }, session, 'Tiffany Rozell')
     expect(asTiffany.currentUser).toBe('Tiffany Rozell')
@@ -239,7 +253,7 @@ describe('draft-plans acl', function() {
       actor: 'Adam Bellusci',
       isPlanAdmin: false,
       canImpersonate: false,
-      planAdminNames: ['Emarion', 'Tiffany Rozell']
+      planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek']
     }
     var draft = {
       candidates: [
@@ -290,7 +304,7 @@ describe('draft-plans acl', function() {
       actor: 'Adam Bellusci',
       isPlanAdmin: false,
       canImpersonate: false,
-      planAdminNames: ['Emarion', 'Tiffany Rozell']
+      planAdminNames: ['Emarion', 'Tiffany Rozell', 'Arjay Hinek']
     }
     var result = authorizeEditorSave(
       session,

--- a/modules/releases/__tests__/server/draft-plans/plan-admins.test.js
+++ b/modules/releases/__tests__/server/draft-plans/plan-admins.test.js
@@ -25,6 +25,7 @@ describe('draft-plans plan-admins email matching', function() {
     expect(isDraftPlansViewerEmail('emarion@redhat.com', DEFAULT_VIEWER_EMAILS)).toBe(true)
     expect(isDraftPlansViewerEmail('emarion@cluster.local', DEFAULT_VIEWER_EMAILS)).toBe(false)
     expect(isPlanAdminEmail('trozell@redhat.com', DEFAULT_PLAN_ADMIN_EMAILS)).toBe(true)
+    expect(isPlanAdminEmail('ahinek@redhat.com', DEFAULT_PLAN_ADMIN_EMAILS)).toBe(true)
   })
 
   it('matches redhat.com allowlist entry against cluster.local session', function() {

--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -611,7 +611,7 @@ describe('draft-plans routes', () => {
           meta: { planVersion: '3.6', currentUser: 'Emarion', frozenEvents: {} },
           audit: [{ action: 'decision', detail: 'test' }]
         },
-        // Plan admin is allowlist-only (emarion@redhat.com / trozell@redhat.com);
+        // Plan admin is allowlist-only (see plan-admins.js DEFAULT_PLAN_ADMIN_EMAILS);
         // platform isAdmin alone must not grant it.
         userEmail: 'emarion@redhat.com'
       })

--- a/modules/releases/server/draft-plans/acl.js
+++ b/modules/releases/server/draft-plans/acl.js
@@ -3,7 +3,7 @@
  * Production: actor is the signed-in user (roster-resolved); no impersonation.
  * DEMO_MODE: keep Acting-as impersonation for local review; UI/API visible to all.
  * Plan admin (freeze / Final GA / reset): allowlisted emails only.
- * Viewer preview gate: draftPlansViewerEmails (default: emarion only) when not DEMO_MODE.
+ * Viewer preview gate: draftPlansViewerEmails (default list in plan-admins.js) when not DEMO_MODE.
  */
 
 const roster = require('../../../../shared/server/roster')

--- a/modules/releases/server/draft-plans/plan-admins.js
+++ b/modules/releases/server/draft-plans/plan-admins.js
@@ -10,7 +10,11 @@
 
 var { normalizeEmail: normalizeEmailForAuth } = require('../../../../shared/server/role-store')
 
-var DEFAULT_PLAN_ADMIN_EMAILS = ['emarion@redhat.com', 'trozell@redhat.com']
+var DEFAULT_PLAN_ADMIN_EMAILS = [
+  'emarion@redhat.com',
+  'trozell@redhat.com',
+  'ahinek@redhat.com'
+]
 
 /** Preview gate: who can see the Draft Plans tab and call draft-plans APIs. */
 var DEFAULT_VIEWER_EMAILS = [
@@ -22,7 +26,8 @@ var DEFAULT_VIEWER_EMAILS = [
 
 var DEFAULT_PLAN_ADMIN_NAMES_BY_EMAIL = {
   'emarion@redhat.com': 'Emarion',
-  'trozell@redhat.com': 'Tiffany Rozell'
+  'trozell@redhat.com': 'Tiffany Rozell',
+  'ahinek@redhat.com': 'Arjay Hinek'
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `ahinek@redhat.com` to Draft Plans plan-admin defaults so Arjay Hinek can edit any row and run freeze / reset / Final GA actions.
- Viewer access for Arjay was already merged in #1479; this PR adds plan-admin only.

## Test plan
- [ ] After deploy, Arjay opens `/api/modules/releases/draft-plans/access` and sees `isPlanAdmin: true`.
- [ ] Arjay can Move/Descope rows he does not own as assignee/PM.
- [ ] Unit tests: `modules/releases/__tests__/server/draft-plans/plan-admins.test.js`, `acl.test.js`.


Made with [Cursor](https://cursor.com)