### PR TITLE
feat(releases): manage Draft Plans access lists in Settings

### DIFF
--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -275,6 +275,22 @@ describe('draft-plans routes', () => {
       expect(res._json.projectId).toBe('81798612')
       expect(res._json.tokenConfigured).toBe(true)
       expect(res._json.tokenSource).toBe('GITLAB_TOKEN')
+      expect(res._json.planAdminEmails).toContain('emarion@redhat.com')
+      expect(res._json.defaultPlanAdminEmails).toContain('emarion@redhat.com')
+      expect(res._json.planAdminEmailsOverridden).toBe(false)
+    })
+
+    it('allows platform admins without Draft Plans viewer access', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router } = await setupRouter()
+      const res = await callRoute(router, 'get', '/config', {
+        isAdmin: true,
+        userEmail: 'ops@cluster.local',
+        userUid: 'ops'
+      })
+
+      expect(res._status).toBe(200)
+      expect(res._json.planAdminEmails.length).toBeGreaterThan(0)
     })
 
     it('reports DRAFT_PLANS_GITLAB_TOKEN as preferred source', async () => {
@@ -305,6 +321,53 @@ describe('draft-plans routes', () => {
       const saved = storage._store[`${DATA_PREFIX}/config.json`]
       expect(saved.projectId).toBe('12345')
       expect(saved.refreshIntervalHours).toBe(12)
+    })
+
+    it('saves planAdminEmails for platform admins', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router, storage } = await setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        isAdmin: true,
+        userEmail: 'emarion@cluster.local',
+        userUid: 'emarion',
+        body: {
+          planAdminEmails: ['emarion@redhat.com', 'ahinek@redhat.com']
+        }
+      })
+
+      expect(res._status).toBe(200)
+      expect(res._json.status).toBe('saved')
+      const saved = storage._store[`${DATA_PREFIX}/config.json`]
+      expect(saved.planAdminEmails).toEqual(['emarion@redhat.com', 'ahinek@redhat.com'])
+    })
+
+    it('rejects invalid planAdminEmails', async () => {
+      const { router } = await setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        isAdmin: true,
+        body: { planAdminEmails: ['not-an-email'] }
+      })
+
+      expect(res._status).toBe(400)
+      expect(res._json.message).toMatch(/valid email/i)
+    })
+
+    it('rejects access-list edits from non-admin viewers', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router } = await setupRouter({
+        [`${DATA_PREFIX}/config.json`]: {
+          draftPlansViewerEmails: ['viewer@redhat.com']
+        }
+      })
+      const res = await callRoute(router, 'post', '/config', {
+        isAdmin: false,
+        userEmail: 'viewer@redhat.com',
+        userUid: 'viewer',
+        body: { planAdminEmails: ['viewer@redhat.com'] }
+      })
+
+      expect(res._status).toBe(403)
+      expect(res._json.error).toMatch(/plan admins/i)
     })
 
     it('auto-fetches when enabling for the first time', async () => {

--- a/modules/releases/client/components/ReleasesSettings.vue
+++ b/modules/releases/client/components/ReleasesSettings.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 import ExecutionSettings from '../execute/components/ExecutionSettings.vue'
 import DeliverySettings from '../deliver/components/DeliverySettings.vue'
+import DraftPlansAccessSettings from '../plan/components/DraftPlansAccessSettings.vue'
 
 const domains = [
   { id: 'execution', label: 'Execution', description: 'Feature traffic from GitLab CI pipeline', refreshUrl: '/modules/releases/execution/refresh', statusUrl: '/modules/releases/execution/status', async: false },
@@ -203,6 +204,12 @@ onUnmounted(() => {
     <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
       <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Delivery</h3>
       <DeliverySettings />
+    </div>
+
+    <!-- Draft Plans access -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Draft Plans access</h3>
+      <DraftPlansAccessSettings />
     </div>
   </div>
 </template>

--- a/modules/releases/client/plan/components/DraftPlansAccessSettings.vue
+++ b/modules/releases/client/plan/components/DraftPlansAccessSettings.vue
@@ -1,0 +1,266 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const API_BASE = '/modules/releases/draft-plans/config'
+
+const config = ref(null)
+const loading = ref(true)
+const loadError = ref(null)
+const saving = ref(false)
+const saveError = ref(null)
+const saveSuccess = ref(false)
+
+const newPlanAdminEmail = ref('')
+const newViewerEmail = ref('')
+
+const planAdminOverridden = computed(function() {
+  return !!(config.value && config.value.planAdminEmailsOverridden)
+})
+
+const viewerOverridden = computed(function() {
+  return !!(config.value && config.value.draftPlansViewerEmailsOverridden)
+})
+
+async function loadConfig() {
+  loading.value = true
+  loadError.value = null
+  try {
+    config.value = await apiRequest(API_BASE)
+  } catch (err) {
+    config.value = null
+    loadError.value = err.message || 'Failed to load Draft Plans access settings'
+  } finally {
+    loading.value = false
+  }
+}
+
+function addEmail(listKey, inputRef) {
+  if (!config.value) return
+  var value = String(inputRef.value || '')
+    .trim()
+    .toLowerCase()
+  if (!value || value.indexOf('@') === -1) return
+  if (!Array.isArray(config.value[listKey])) {
+    config.value[listKey] = []
+  }
+  if (config.value[listKey].indexOf(value) !== -1) {
+    inputRef.value = ''
+    return
+  }
+  config.value[listKey] = config.value[listKey].concat([value])
+  inputRef.value = ''
+}
+
+function removeEmail(listKey, email) {
+  if (!config.value || !Array.isArray(config.value[listKey])) return
+  config.value[listKey] = config.value[listKey].filter(function(item) {
+    return item !== email
+  })
+}
+
+function resetPlanAdminsToDefaults() {
+  if (!config.value) return
+  config.value.planAdminEmails = (config.value.defaultPlanAdminEmails || []).slice()
+}
+
+function resetViewersToDefaults() {
+  if (!config.value) return
+  config.value.draftPlansViewerEmails = (config.value.defaultDraftPlansViewerEmails || []).slice()
+}
+
+function listsEqual(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+    return false
+  }
+  for (var i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false
+  }
+  return true
+}
+
+async function saveAccess() {
+  if (!config.value) return
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+  try {
+    var planAdminEmails = config.value.planAdminEmails || []
+    var draftPlansViewerEmails = config.value.draftPlansViewerEmails || []
+    var defaultAdmins = config.value.defaultPlanAdminEmails || []
+    var defaultViewers = config.value.defaultDraftPlansViewerEmails || []
+    await apiRequest(API_BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        planAdminEmails: listsEqual(planAdminEmails, defaultAdmins) ? [] : planAdminEmails,
+        draftPlansViewerEmails: listsEqual(draftPlansViewerEmails, defaultViewers)
+          ? []
+          : draftPlansViewerEmails
+      })
+    })
+    saveSuccess.value = true
+    setTimeout(function() {
+      saveSuccess.value = false
+    }, 3000)
+    await loadConfig()
+  } catch (err) {
+    saveError.value = err.message || 'Failed to save access settings'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(function() {
+  loadConfig()
+})
+</script>
+
+<template>
+  <div class="space-y-5">
+    <p class="text-xs text-gray-500 dark:text-gray-400">
+      Control who can open Draft Plans and who can freeze events, reset the plan, or edit any row.
+      Stored on the server data volume; empty saved lists fall back to code defaults after deploy.
+    </p>
+
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading access settings…</div>
+    <div v-else-if="loadError" class="text-sm text-red-600 dark:text-red-400">{{ loadError }}</div>
+
+    <template v-else-if="config">
+      <div class="space-y-3">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Plan admins</h4>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Freeze / unfreeze, Final GA, reset, and edit all rows.
+            </p>
+          </div>
+          <span
+            class="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full"
+            :class="planAdminOverridden
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+          >
+            {{ planAdminOverridden ? 'Custom list saved' : 'Using code defaults' }}
+          </span>
+        </div>
+
+        <ul v-if="config.planAdminEmails && config.planAdminEmails.length" class="space-y-1">
+          <li
+            v-for="email in config.planAdminEmails"
+            :key="'admin-' + email"
+            class="flex items-center justify-between gap-2 rounded-md border border-gray-200 dark:border-gray-600 px-3 py-1.5 text-sm"
+          >
+            <span class="font-mono text-xs text-gray-800 dark:text-gray-200">{{ email }}</span>
+            <button
+              type="button"
+              class="text-xs text-red-600 dark:text-red-400 hover:underline"
+              @click="removeEmail('planAdminEmails', email)"
+            >
+              Remove
+            </button>
+          </li>
+        </ul>
+        <p v-else class="text-xs text-gray-400 dark:text-gray-500">No plan admins configured.</p>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            v-model="newPlanAdminEmail"
+            type="email"
+            placeholder="name@redhat.com"
+            class="flex-1 min-w-[12rem] border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"
+            @keydown.enter.prevent="addEmail('planAdminEmails', newPlanAdminEmail)"
+          />
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            @click="addEmail('planAdminEmails', newPlanAdminEmail)"
+          >
+            Add plan admin
+          </button>
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            @click="resetPlanAdminsToDefaults"
+          >
+            Reset to code defaults
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-3 pt-2 border-t border-gray-200 dark:border-gray-700">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Draft Plans viewers</h4>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Who can open the Draft Plans tab and use draft-plans APIs.
+            </p>
+          </div>
+          <span
+            class="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full"
+            :class="viewerOverridden
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+          >
+            {{ viewerOverridden ? 'Custom list saved' : 'Using code defaults' }}
+          </span>
+        </div>
+
+        <ul v-if="config.draftPlansViewerEmails && config.draftPlansViewerEmails.length" class="space-y-1">
+          <li
+            v-for="email in config.draftPlansViewerEmails"
+            :key="'viewer-' + email"
+            class="flex items-center justify-between gap-2 rounded-md border border-gray-200 dark:border-gray-600 px-3 py-1.5 text-sm"
+          >
+            <span class="font-mono text-xs text-gray-800 dark:text-gray-200">{{ email }}</span>
+            <button
+              type="button"
+              class="text-xs text-red-600 dark:text-red-400 hover:underline"
+              @click="removeEmail('draftPlansViewerEmails', email)"
+            >
+              Remove
+            </button>
+          </li>
+        </ul>
+        <p v-else class="text-xs text-gray-400 dark:text-gray-500">No viewers configured.</p>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            v-model="newViewerEmail"
+            type="email"
+            placeholder="name@redhat.com"
+            class="flex-1 min-w-[12rem] border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"
+            @keydown.enter.prevent="addEmail('draftPlansViewerEmails', newViewerEmail)"
+          />
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            @click="addEmail('draftPlansViewerEmails', newViewerEmail)"
+          >
+            Add viewer
+          </button>
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            @click="resetViewersToDefaults"
+          >
+            Reset to code defaults
+          </button>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3 pt-2">
+        <button
+          type="button"
+          class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700 disabled:opacity-50"
+          :disabled="saving"
+          @click="saveAccess"
+        >
+          {{ saving ? 'Saving…' : 'Save access settings' }}
+        </button>
+        <span v-if="saveSuccess" class="text-sm text-green-600 dark:text-green-400">Saved</span>
+        <span v-if="saveError" class="text-sm text-red-600 dark:text-red-400">{{ saveError }}</span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -7,6 +7,12 @@ const {
   authorizeEditorSave,
   assertCanViewDraftPlans
 } = require('./acl');
+const {
+  loadAdminEmails,
+  loadViewerEmails,
+  DEFAULT_PLAN_ADMIN_EMAILS,
+  DEFAULT_VIEWER_EMAILS
+} = require('./plan-admins');
 const rateLimit = require('express-rate-limit');
 const fs = require('fs');
 const path = require('path');
@@ -146,13 +152,38 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
     return null;
   }
 
+  async function loadRawConfig() {
+    try {
+      return await storage.readFromStorage(DATA_PREFIX + '/config.json');
+    } catch {
+      return null;
+    }
+  }
+
   async function loadConfig() {
-    var stored = await storage.readFromStorage(DATA_PREFIX + '/config.json');
+    var stored = await loadRawConfig();
     return Object.assign({}, DEFAULT_CONFIG, stored || {});
   }
 
   async function saveConfig(config) {
     await storage.writeToStorage(DATA_PREFIX + '/config.json', config);
+  }
+
+  async function buildConfigResponse() {
+    var config = await loadConfig();
+    var raw = (await loadRawConfig()) || {};
+    return Object.assign({}, config, {
+      planAdminEmails: loadAdminEmails(raw),
+      draftPlansViewerEmails: loadViewerEmails(raw),
+      planAdminEmailsOverridden: !!(raw.planAdminEmails && raw.planAdminEmails.length > 0),
+      draftPlansViewerEmailsOverridden: !!(
+        raw.draftPlansViewerEmails && raw.draftPlansViewerEmails.length > 0
+      ),
+      defaultPlanAdminEmails: DEFAULT_PLAN_ADMIN_EMAILS.slice(),
+      defaultDraftPlansViewerEmails: DEFAULT_VIEWER_EMAILS.slice(),
+      tokenConfigured: !!getToken(),
+      tokenSource: getTokenSource()
+    });
   }
 
   async function requireDraftPlansViewer(req, res, next) {
@@ -167,6 +198,62 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
     } catch (err) {
       console.warn('[releases/draft-plans] viewer gate failed:', err.message);
       return res.status(500).json({ error: 'Failed to resolve Draft Plans access' });
+    }
+  }
+
+  /** Settings + fetch config: platform admins, or Draft Plans viewers. */
+  async function requireDraftPlansConfigAccess(req, res, next) {
+    try {
+      var session = await resolveDraftPlanSession(req, storage);
+      req.draftPlanSession = session;
+      if (req.isAdmin) return next();
+      var gate = assertCanViewDraftPlans(session);
+      if (!gate.ok) {
+        return res.status(gate.status).json({ error: gate.error });
+      }
+      next();
+    } catch (err) {
+      console.warn('[releases/draft-plans] config access failed:', err.message);
+      return res.status(500).json({ error: 'Failed to resolve Draft Plans access' });
+    }
+  }
+
+  function requireConfigAclEditor(req, res, next) {
+    var body = req.body || {};
+    var touchesAcl =
+      body.planAdminEmails !== undefined || body.draftPlansViewerEmails !== undefined;
+    if (!touchesAcl) return next();
+    var session = req.draftPlanSession;
+    if (req.isAdmin || (session && session.isPlanAdmin)) return next();
+    return res.status(403).json({
+      error: 'Only platform admins or Draft Plans plan admins can change access lists'
+    });
+  }
+
+  function normalizeEmailList(list) {
+    if (!Array.isArray(list)) return list;
+    return list
+      .map(function(email) {
+        return String(email || '')
+          .trim()
+          .toLowerCase();
+      })
+      .filter(Boolean);
+  }
+
+  function validateEmailListField(fieldName, value) {
+    if (value === undefined) return;
+    if (!Array.isArray(value)) {
+      throw new Error(fieldName + ' must be an array of emails');
+    }
+    for (var i = 0; i < value.length; i++) {
+      if (typeof value[i] !== 'string') {
+        throw new Error(fieldName + ' must be an array of emails');
+      }
+      var trimmed = value[i].trim();
+      if (!trimmed || trimmed.indexOf('@') === -1) {
+        throw new Error(fieldName + ' entries must be valid email addresses');
+      }
     }
   }
 
@@ -223,16 +310,8 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
     if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
       throw new Error('enabled must be a boolean');
     }
-    if (input.draftPlansViewerEmails !== undefined) {
-      if (!Array.isArray(input.draftPlansViewerEmails)) {
-        throw new Error('draftPlansViewerEmails must be an array of emails');
-      }
-      for (var vi = 0; vi < input.draftPlansViewerEmails.length; vi++) {
-        if (typeof input.draftPlansViewerEmails[vi] !== 'string') {
-          throw new Error('draftPlansViewerEmails must be an array of emails');
-        }
-      }
-    }
+    validateEmailListField('draftPlansViewerEmails', input.draftPlansViewerEmails);
+    validateEmailListField('planAdminEmails', input.planAdminEmails);
   }
 
   async function doFetch() {
@@ -475,17 +554,13 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    * /api/modules/releases/draft-plans/config:
    *   get:
    *     tags: [Releases]
-   *     summary: Get draft plans fetch configuration
+   *     summary: Get draft plans fetch configuration and access lists
    *     responses:
    *       200:
-   *         description: Current configuration with token status
+   *         description: Current configuration with effective planAdminEmails and draftPlansViewerEmails
    */
-  router.get('/config', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, async function(req, res) {
-    var config = await loadConfig();
-    res.json(Object.assign({}, config, {
-      tokenConfigured: !!getToken(),
-      tokenSource: getTokenSource()
-    }));
+  router.get('/config', requireAuth, requireScope('releases:write'), requireDraftPlansConfigAccess, async function(req, res) {
+    res.json(await buildConfigResponse());
   });
 
   /**
@@ -499,12 +574,27 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *         description: Configuration saved (optionally triggers fetch if newly enabled)
    *       400:
    *         description: Invalid configuration values
+   *       403:
+   *         description: Forbidden when changing planAdminEmails or draftPlansViewerEmails without admin rights
    */
-  router.post('/config', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, async function(req, res) {
+  router.post(
+    '/config',
+    requireAuth,
+    requireScope('releases:write'),
+    requireDraftPlansConfigAccess,
+    requireConfigAclEditor,
+    async function(req, res) {
     try {
       validateConfig(req.body);
       var oldConfig = await loadConfig();
-      var config = Object.assign({}, oldConfig, req.body);
+      var patch = Object.assign({}, req.body);
+      if (patch.planAdminEmails !== undefined) {
+        patch.planAdminEmails = normalizeEmailList(patch.planAdminEmails);
+      }
+      if (patch.draftPlansViewerEmails !== undefined) {
+        patch.draftPlansViewerEmails = normalizeEmailList(patch.draftPlansViewerEmails);
+      }
+      var config = Object.assign({}, oldConfig, patch);
       await saveConfig(config);
 
       await logAudit(storage.readFromStorage, storage.writeToStorage, {
@@ -526,10 +616,17 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
 
       res.json({ status: 'saved' });
     } catch (err) {
-      var status = (err.message && (err.message.includes('must be') || err.message.includes('must start'))) ? 400 : 500;
+      var status =
+        err.message &&
+        (err.message.includes('must be') ||
+          err.message.includes('must start') ||
+          err.message.includes('valid email'))
+          ? 400
+          : 500;
       res.status(status).json({ status: 'error', message: err.message });
     }
-  });
+  }
+  );
 
   /**
    * @openapi

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -138,6 +138,7 @@ export const viewOwners = {
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
 
   // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
   'team-tracker/reports/team-comparison':          'Alex Corvin',
   'team-tracker/reports/trends':                   'Alex Corvin',
 }


### PR DESCRIPTION
## Summary
- Adds a **Draft Plans access** section on Settings → Releases for managing plan admin and viewer email allowlists without `oc` or browser console hacks.
- Extends `GET/POST /api/modules/releases/draft-plans/config` to return effective lists (with override flags and code defaults), validate `planAdminEmails`, and restrict ACL edits to platform admins or existing plan admins.

## Test plan
- [ ] Open Settings → Releases → **Draft Plans access** as platform admin
- [ ] Confirm plan admin and viewer lists load (shows code defaults or custom saved list)
- [ ] Add `ahinek@redhat.com` as plan admin, save, reload `/api/modules/releases/draft-plans/access` — expect `isPlanAdmin: true` for Arjay
- [ ] Confirm non-admin viewers cannot POST access-list changes (403)
- [ ] `npm test -- modules/releases/__tests__/server/draft-plans/routes.test.js`


Made with [Cursor](https://cursor.com)