### PR TITLE
fix(releases): default commitment release options

### DIFF
--- a/modules/releases/__tests__/server/delivery/commitment.test.js
+++ b/modules/releases/__tests__/server/delivery/commitment.test.js
@@ -5,7 +5,8 @@ import {
   resolvePlanningFreezeDate,
   getConfiguredVersions,
   findPhaseConfig,
-  buildFeatureFromIssue
+  buildFeatureFromIssue,
+  loadCommitmentConfig
 } from '../../../server/delivery/commitment.js'
 
 describe('analyzeFixVersionHistory', () => {
@@ -372,6 +373,29 @@ describe('getConfiguredVersions', () => {
       releases: [{ version: '3.4', phases: {} }]
     }
     expect(getConfiguredVersions(config)).toEqual([])
+  })
+})
+
+describe('loadCommitmentConfig', () => {
+  it('uses the persisted config when one exists', async () => {
+    const storedConfig = {
+      releases: [
+        { version: '9.9', phases: { GA: { fixVersions: ['rhoai-9.9'] } } }
+      ]
+    }
+
+    await expect(loadCommitmentConfig(async () => storedConfig)).resolves.toEqual(storedConfig)
+  })
+
+  it('falls back to the bundled release config when storage is empty', async () => {
+    const config = await loadCommitmentConfig(async () => null)
+
+    expect(getConfiguredVersions(config).map(function (entry) { return entry.version })).toEqual([
+      '3.4',
+      '3.5',
+      '3.6',
+      '3.7'
+    ])
   })
 })
 

--- a/modules/releases/server/delivery/commitment.js
+++ b/modules/releases/server/delivery/commitment.js
@@ -12,6 +12,7 @@
 const sharedJira = require('../../../../shared/server/jira')
 const { readRegistry } = require('../registry')
 const { getConfig } = require('./config')
+const DEFAULT_COMMITMENT_CONFIG = require('../../../../fixtures/releases/delivery/commitment-config.json')
 
 const COMMITMENT_CONFIG_FILE = 'releases/delivery/commitment-config.json'
 const COMMITMENT_CACHE_PREFIX = 'releases/delivery/commitment-cache-'
@@ -23,7 +24,10 @@ const DELIVERED_STATUSES = ['Release Pending', 'Closed', 'Done']
 async function loadCommitmentConfig(readFromStorage) {
   var data = await readFromStorage(COMMITMENT_CONFIG_FILE)
   if (data && Array.isArray(data.releases)) return data
-  return { releases: [] }
+  // Keep the release selector usable on installations whose PVC predates this
+  // config file. A persisted config still takes precedence over the bundled
+  // defaults, so administrators can continue to customize the mappings.
+  return DEFAULT_COMMITMENT_CONFIG
 }
 
 function findPhaseConfig(commitmentConfig, version, phase) {
@@ -548,3 +552,4 @@ module.exports.resolvePlanningFreezeDate = resolvePlanningFreezeDate
 module.exports.getConfiguredVersions = getConfiguredVersions
 module.exports.findPhaseConfig = findPhaseConfig
 module.exports.buildFeatureFromIssue = buildFeatureFromIssue
+module.exports.loadCommitmentConfig = loadCommitmentConfig

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -55,6 +55,16 @@ test.describe('Releases Module @releases', () => {
 
 });
 
+test.describe('Releases Commitment Tracking @releases', () => {
+  test('exposes the configured release versions', async ({ request }) => {
+    const response = await request.get('/api/modules/releases/delivery/commitment/versions');
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+    expect(body.versions.map(version => version.version)).toEqual(['3.4', '3.5', '3.6', '3.7']);
+  });
+});
+
 /**
  * RICE Config API
  *


### PR DESCRIPTION
## Summary
- fall back to the bundled commitment config when a production PVC has no persisted config
- preserve persisted administrator configuration as the higher-priority source
- verify release options 3.4 through 3.7 with unit and integration coverage

## Testing
- npm test -- modules/releases/__tests__/server/delivery/commitment.test.js
- npx eslint modules/releases/server/delivery/commitment.js modules/releases/__tests__/server/delivery/commitment.test.js tests/integration/releases.spec.js
- npm run test:integration -- tests/integration/releases.spec.js --grep "exposes the configured release versions"