### PR TITLE
fix(releases): preserve commitment aliases

### DIFF
--- a/fixtures/releases/delivery/commitment-config.json
+++ b/fixtures/releases/delivery/commitment-config.json
@@ -11,9 +11,9 @@
     {
       "version": "3.5",
       "phases": {
-        "EA1": { "fixVersions": ["3.5 EA1 RHOAI RELEASE", "3.5 EA1 RHAII RELEASE", "3.5 EA1 RHELAI RELEASE"], "planningFreezeOverride": "2026-04-17" },
-        "EA2": { "fixVersions": ["3.5 EA2 RHOAI RELEASE", "3.5 EA2 RHAII RELEASE", "3.5 EA2 RHELAI RELEASE"], "planningFreezeOverride": "2026-05-15" },
-        "GA":  { "fixVersions": ["3.5 GA RHOAI RELEASE", "3.5 GA RHAII RELEASE", "3.5 GA RHELAI RELEASE"], "planningFreezeOverride": "2026-06-24" }
+        "EA1": { "fixVersions": ["3.5 EA1 RHOAI RELEASE", "3.5 EA1 RHAII RELEASE", "3.5 EA1 RHELAI RELEASE", "rhoai-3.5.EA1", "RHAII-3.5.EA1", "RHAII-3.5 EA1", "rhelai-3.5EA1", "rhelai-3.5 EA1 release"], "planningFreezeOverride": "2026-04-17" },
+        "EA2": { "fixVersions": ["3.5 EA2 RHOAI RELEASE", "3.5 EA2 RHAII RELEASE", "3.5 EA2 RHELAI RELEASE", "rhoai-3.5.EA2", "RHAII-3.5.EA2", "RHAII-3.5 EA2", "rhelai-3.5EA2", "rhelai-3.5 EA2 release"], "planningFreezeOverride": "2026-05-15" },
+        "GA":  { "fixVersions": ["3.5 GA RHOAI RELEASE", "3.5 GA RHAII RELEASE", "3.5 GA RHELAI RELEASE", "rhoai-3.5", "RHAII-3.5", "RHAIIS-3.5", "rhelai-3.5", "rhelai-3.5 release"], "planningFreezeOverride": "2026-06-24" }
       }
     },
     {

--- a/modules/releases/__tests__/server/delivery/commitment.test.js
+++ b/modules/releases/__tests__/server/delivery/commitment.test.js
@@ -6,7 +6,8 @@ import {
   getConfiguredVersions,
   findPhaseConfig,
   buildFeatureFromIssue,
-  loadCommitmentConfig
+  loadCommitmentConfig,
+  isCommitmentCacheCurrent
 } from '../../../server/delivery/commitment.js'
 
 describe('analyzeFixVersionHistory', () => {
@@ -396,6 +397,77 @@ describe('loadCommitmentConfig', () => {
       '3.6',
       '3.7'
     ])
+    expect(findPhaseConfig(config, '3.5', 'EA2').fixVersions).toContain('rhoai-3.5.EA2')
+  })
+
+  it('adds bundled aliases to a matching persisted phase', async () => {
+    const storedConfig = {
+      releases: [{
+        version: '3.5',
+        phases: {
+          EA2: {
+            fixVersions: [
+              '3.5 EA2 RHOAI RELEASE',
+              '3.5 EA2 RHAII RELEASE',
+              '3.5 EA2 RHELAI RELEASE'
+            ],
+            planningFreezeOverride: '2026-05-15'
+          }
+        }
+      }]
+    }
+
+    const config = await loadCommitmentConfig(async () => storedConfig)
+    const ea2 = findPhaseConfig(config, '3.5', 'EA2')
+
+    expect(ea2.fixVersions).toEqual([
+      '3.5 EA2 RHOAI RELEASE',
+      '3.5 EA2 RHAII RELEASE',
+      '3.5 EA2 RHELAI RELEASE',
+      'rhoai-3.5.EA2',
+      'RHAII-3.5.EA2',
+      'RHAII-3.5 EA2',
+      'rhelai-3.5EA2',
+      'rhelai-3.5 EA2 release'
+    ])
+    expect(ea2.planningFreezeOverride).toBe('2026-05-15')
+  })
+
+  it('leaves unrelated persisted phase mappings unchanged', async () => {
+    const storedConfig = {
+      releases: [{
+        version: '3.5',
+        phases: { EA2: { fixVersions: ['custom-3.5-ea2'] } }
+      }]
+    }
+
+    await expect(loadCommitmentConfig(async () => storedConfig)).resolves.toEqual(storedConfig)
+  })
+})
+
+describe('isCommitmentCacheCurrent', () => {
+  it('accepts a cache containing the configured fix version set', () => {
+    const cached = {
+      metrics: { committed: 1 },
+      fixVersions: ['RHOAI-3.5.EA2', '3.5 EA2 RHOAI RELEASE']
+    }
+
+    expect(isCommitmentCacheCurrent(cached, [
+      '3.5 EA2 RHOAI RELEASE',
+      'rhoai-3.5.ea2'
+    ])).toBe(true)
+  })
+
+  it('rejects a cache created before an alias was added', () => {
+    const cached = {
+      metrics: { committed: 0 },
+      fixVersions: ['3.5 EA2 RHOAI RELEASE']
+    }
+
+    expect(isCommitmentCacheCurrent(cached, [
+      '3.5 EA2 RHOAI RELEASE',
+      'rhoai-3.5.EA2'
+    ])).toBe(false)
   })
 })
 

--- a/modules/releases/server/delivery/commitment.js
+++ b/modules/releases/server/delivery/commitment.js
@@ -23,11 +23,85 @@ const DELIVERED_STATUSES = ['Release Pending', 'Closed', 'Done']
 
 async function loadCommitmentConfig(readFromStorage) {
   var data = await readFromStorage(COMMITMENT_CONFIG_FILE)
-  if (data && Array.isArray(data.releases)) return data
+  if (data && Array.isArray(data.releases)) return mergeBundledFixVersionAliases(data)
   // Keep the release selector usable on installations whose PVC predates this
-  // config file. A persisted config still takes precedence over the bundled
-  // defaults, so administrators can continue to customize the mappings.
+  // config file.
   return DEFAULT_COMMITMENT_CONFIG
+}
+
+/**
+ * Add bundled compatibility aliases to matching phases in persisted configs.
+ *
+ * Production config lives on a PVC and can predate newly discovered Jira
+ * aliases. A phase is augmented only when it already contains at least one of
+ * the bundled names, preserving unrelated administrator-defined mappings.
+ */
+function mergeBundledFixVersionAliases(config) {
+  var bundledByVersion = {}
+  for (var d = 0; d < DEFAULT_COMMITMENT_CONFIG.releases.length; d++) {
+    var bundledRelease = DEFAULT_COMMITMENT_CONFIG.releases[d]
+    bundledByVersion[bundledRelease.version] = bundledRelease
+  }
+
+  var releases = config.releases.map(function(release) {
+    var bundled = bundledByVersion[release.version]
+    if (!bundled || !release.phases) return release
+
+    var phases = Object.assign({}, release.phases)
+    var phaseNames = Object.keys(phases)
+    var changed = false
+
+    for (var p = 0; p < phaseNames.length; p++) {
+      var phaseName = phaseNames[p]
+      var phase = phases[phaseName]
+      var bundledPhase = bundled.phases && bundled.phases[phaseName]
+      if (!phase || !Array.isArray(phase.fixVersions) || !bundledPhase) continue
+
+      var bundledNames = bundledPhase.fixVersions || []
+      var bundledSet = {}
+      for (var b = 0; b < bundledNames.length; b++) {
+        bundledSet[bundledNames[b].toLowerCase()] = true
+      }
+
+      var matchesBundledPhase = phase.fixVersions.some(function(name) {
+        return bundledSet[String(name).toLowerCase()] === true
+      })
+      if (!matchesBundledPhase) continue
+
+      var mergedNames = phase.fixVersions.slice()
+      var mergedSet = {}
+      for (var m = 0; m < mergedNames.length; m++) {
+        mergedSet[String(mergedNames[m]).toLowerCase()] = true
+      }
+      for (var a = 0; a < bundledNames.length; a++) {
+        var alias = bundledNames[a]
+        if (!mergedSet[alias.toLowerCase()]) {
+          mergedNames.push(alias)
+          mergedSet[alias.toLowerCase()] = true
+          changed = true
+        }
+      }
+      phases[phaseName] = Object.assign({}, phase, { fixVersions: mergedNames })
+    }
+
+    return changed ? Object.assign({}, release, { phases: phases }) : release
+  })
+
+  return Object.assign({}, config, { releases: releases })
+}
+
+function isCommitmentCacheCurrent(cached, fixVersions) {
+  if (!cached || !cached.metrics || !Array.isArray(cached.fixVersions)) return false
+  if (!Array.isArray(fixVersions) || cached.fixVersions.length !== fixVersions.length) return false
+
+  var cachedSet = {}
+  for (var c = 0; c < cached.fixVersions.length; c++) {
+    cachedSet[String(cached.fixVersions[c]).toLowerCase()] = true
+  }
+  for (var f = 0; f < fixVersions.length; f++) {
+    if (!cachedSet[String(fixVersions[f]).toLowerCase()]) return false
+  }
+  return true
 }
 
 function findPhaseConfig(commitmentConfig, version, phase) {
@@ -505,9 +579,12 @@ module.exports = async function registerCommitmentRoutes(router, context) {
 
       if (freezePassed && !forceRefresh) {
         var cached = await readFromStorage(cacheKey)
-        if (cached && cached.metrics) {
+        if (isCommitmentCacheCurrent(cached, phaseConfig.fixVersions)) {
           console.log('[commitment] Serving cached data for ' + version + ' ' + phase)
           return res.json(cached)
+        }
+        if (cached && cached.metrics) {
+          console.log('[commitment] Ignoring stale cache for ' + version + ' ' + phase + ' because fix version mappings changed')
         }
       }
 
@@ -553,3 +630,5 @@ module.exports.getConfiguredVersions = getConfiguredVersions
 module.exports.findPhaseConfig = findPhaseConfig
 module.exports.buildFeatureFromIssue = buildFeatureFromIssue
 module.exports.loadCommitmentConfig = loadCommitmentConfig
+module.exports.mergeBundledFixVersionAliases = mergeBundledFixVersionAliases
+module.exports.isCommitmentCacheCurrent = isCommitmentCacheCurrent

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -63,6 +63,20 @@ test.describe('Releases Commitment Tracking @releases', () => {
     const body = await response.json();
     expect(body.versions.map(version => version.version)).toEqual(['3.4', '3.5', '3.6', '3.7']);
   });
+
+  test('exposes compatibility aliases for the 3.5 EA2 commitment report', async ({ request }) => {
+    const response = await request.get('/api/modules/releases/delivery/commitment/config');
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+    const release = body.releases.find(entry => entry.version === '3.5');
+    expect(release.phases.EA2.fixVersions).toEqual(expect.arrayContaining([
+      '3.5 EA2 RHOAI RELEASE',
+      'rhoai-3.5.EA2',
+      'RHAII-3.5 EA2',
+      'rhelai-3.5 EA2 release'
+    ]));
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
- include legacy 3.5 Fix Version aliases in the bundled commitment configuration
- augment matching persisted PVC configurations with newly bundled aliases
- invalidate cached commitment results when the effective Fix Version set changes
- cover alias migration and the commitment config API

## Verification
- npx vitest run modules/releases/__tests__/server/delivery/commitment.test.js
- npm test (289 files, 5,692 passed)
- tracked-code ESLint
- npm run build
- npm run validate:modules
- npm run validate:openapi
- npx playwright test tests/integration/releases.spec.js --grep "Releases Commitment Tracking"